### PR TITLE
feat: custom game window overlay with RetroArch tracking

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -52,6 +52,10 @@ const config: ForgeConfig = {
           name: 'main_window',
           config: 'vite.renderer.config.ts',
         },
+        {
+          name: 'game_window',
+          config: 'vite.game-window.config.ts',
+        },
       ],
     }),
     // Fuses are used to enable/disable various Electron functionality

--- a/apps/desktop/game-window.html
+++ b/apps/desktop/game-window.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GameLord</title>
+  </head>
+  <body>
+    <style>html, body, #root { background: transparent !important; }</style>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/game-window.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop/src/game-window.css
+++ b/apps/desktop/src/game-window.css
@@ -1,0 +1,21 @@
+@import "tailwindcss";
+
+/* Window drag region utilities */
+@utility drag-region {
+  -webkit-app-region: drag;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+@utility no-drag {
+  -webkit-app-region: no-drag;
+}
+
+* {
+  border-color: transparent;
+}
+
+html, body, #root {
+  background: transparent !important;
+  background-color: transparent !important;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,7 +43,8 @@ const createWindow = () => {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   // Initialize IPC handlers before creating window
-  ipcHandlers = new IPCHandlers();
+  const preloadPath = path.join(__dirname, 'preload.js');
+  ipcHandlers = new IPCHandlers(preloadPath);
   createWindow();
 });
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -52,9 +52,7 @@ app.on('ready', () => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+  app.quit();
 });
 
 app.on('activate', () => {

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -1,0 +1,231 @@
+import { BrowserWindow, ipcMain } from 'electron'
+import path from 'path'
+import { execSync } from 'child_process'
+import type { Game } from '../types/library'
+
+/**
+ * Manages custom game windows that overlay controls on top of native emulator windows.
+ * Provides OpenEmu-style cohesive UI experience while maintaining native emulation performance.
+ */
+export class GameWindowManager {
+  private gameWindows = new Map<string, BrowserWindow>()
+  private trackingIntervals = new Map<string, ReturnType<typeof setInterval>>()
+  private readonly preloadPath: string
+
+  constructor(preloadPath: string) {
+    this.preloadPath = preloadPath
+    this.setupIpcHandlers()
+  }
+
+  /**
+   * Create a custom game window for the given game
+   */
+  createGameWindow(game: Game): BrowserWindow {
+    // Close existing window for this game if any
+    const existingWindow = this.gameWindows.get(game.id)
+    if (existingWindow && !existingWindow.isDestroyed()) {
+      existingWindow.close()
+    }
+
+    // Create transparent frameless overlay window
+    const gameWindow = new BrowserWindow({
+      width: 1024,
+      height: 768,
+      minWidth: 640,
+      minHeight: 480,
+      frame: false,
+      titleBarStyle: 'hidden',
+      title: `GameLord - ${game.title}`,
+      transparent: true,
+      hasShadow: false,
+      backgroundColor: '#00000000',
+      skipTaskbar: true,
+      webPreferences: {
+        preload: this.preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    })
+
+    // Load the game window renderer
+    if (GAME_WINDOW_VITE_DEV_SERVER_URL) {
+      gameWindow.loadURL(`${GAME_WINDOW_VITE_DEV_SERVER_URL}/game-window.html`)
+      gameWindow.webContents.openDevTools()
+    } else {
+      gameWindow.loadFile(path.join(__dirname, `../renderer/${GAME_WINDOW_VITE_NAME}/index.html`))
+    }
+
+    // Send game data once window is ready
+    gameWindow.webContents.on('did-finish-load', () => {
+      gameWindow.webContents.send('game:loaded', game)
+    })
+
+    // Cleanup on close
+    gameWindow.on('closed', () => {
+      this.stopTracking(game.id)
+      this.gameWindows.delete(game.id)
+    })
+
+    // Store window reference
+    this.gameWindows.set(game.id, gameWindow)
+
+    return gameWindow
+  }
+
+  /**
+   * Get window bounds of a process by PID using macOS JXA/System Events
+   */
+  private getWindowBoundsByPid(pid: number): { x: number; y: number; width: number; height: number } | null {
+    try {
+      const script = `
+        const se = Application("System Events");
+        const procs = se.processes.whose({unixId: ${pid}});
+        if (procs.length === 0) throw "no process";
+        const w = procs[0].windows[0];
+        const pos = w.position();
+        const sz = w.size();
+        JSON.stringify({x: pos[0], y: pos[1], width: sz[0], height: sz[1]});
+      `
+      const result = execSync(`osascript -l JavaScript -e '${script}'`, {
+        timeout: 5000,
+        encoding: 'utf-8',
+      }).trim()
+      return JSON.parse(result)
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * Start tracking the RetroArch window position/size and overlay our window on top
+   */
+  startTrackingRetroArchWindow(gameId: string, pid: number): void {
+    const gameWindow = this.gameWindows.get(gameId)
+    if (!gameWindow || gameWindow.isDestroyed()) {
+      console.warn(`Game window for ${gameId} not found or destroyed`)
+      return
+    }
+
+    gameWindow.setAlwaysOnTop(true, 'floating')
+    gameWindow.setIgnoreMouseEvents(true, { forward: true })
+    gameWindow.show()
+
+    // Poll RetroArch window position
+    const interval = setInterval(() => {
+      if (gameWindow.isDestroyed()) {
+        this.stopTracking(gameId)
+        return
+      }
+
+      const bounds = this.getWindowBoundsByPid(pid)
+      if (!bounds) {
+        // RetroArch window disappeared — close overlay
+        console.log(`RetroArch window (PID ${pid}) disappeared, closing overlay`)
+        this.stopTracking(gameId)
+        if (!gameWindow.isDestroyed()) {
+          gameWindow.close()
+        }
+        return
+      }
+
+      gameWindow.setBounds(bounds)
+    }, 150)
+
+    this.trackingIntervals.set(gameId, interval)
+    console.log(`Tracking RetroArch window (PID ${pid}) for game ${gameId}`)
+  }
+
+  /**
+   * Stop tracking for a given game
+   */
+  stopTracking(gameId: string): void {
+    const interval = this.trackingIntervals.get(gameId)
+    if (interval) {
+      clearInterval(interval)
+      this.trackingIntervals.delete(gameId)
+    }
+  }
+
+  /**
+   * Close game window for the given game ID
+   */
+  closeGameWindow(gameId: string): void {
+    this.stopTracking(gameId)
+    const window = this.gameWindows.get(gameId)
+    if (window && !window.isDestroyed()) {
+      window.close()
+    }
+  }
+
+  /**
+   * Close all game windows
+   */
+  closeAllGameWindows(): void {
+    for (const [gameId] of this.trackingIntervals) {
+      this.stopTracking(gameId)
+    }
+    for (const window of this.gameWindows.values()) {
+      if (!window.isDestroyed()) {
+        window.close()
+      }
+    }
+    this.gameWindows.clear()
+  }
+
+  /**
+   * Get the window for a specific game
+   */
+  getGameWindow(gameId: string): BrowserWindow | undefined {
+    return this.gameWindows.get(gameId)
+  }
+
+  /**
+   * Setup IPC handlers for game window actions
+   */
+  private setupIpcHandlers(): void {
+    ipcMain.on('game-window:minimize', (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender)
+      window?.minimize()
+    })
+
+    ipcMain.on('game-window:maximize', (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender)
+      if (window?.isMaximized()) {
+        window.unmaximize()
+      } else {
+        window?.maximize()
+      }
+    })
+
+    ipcMain.on('game-window:close', (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender)
+      window?.close()
+    })
+
+    ipcMain.on('game-window:toggle-fullscreen', (event) => {
+      const window = BrowserWindow.fromWebContents(event.sender)
+      if (window) {
+        window.setFullScreen(!window.isFullScreen())
+      }
+    })
+
+    ipcMain.on('game-window:set-click-through', (event, clickThrough: boolean) => {
+      const window = BrowserWindow.fromWebContents(event.sender)
+      if (window) {
+        window.setIgnoreMouseEvents(clickThrough, { forward: true })
+      }
+    })
+  }
+
+  /**
+   * Cleanup resources
+   */
+  destroy(): void {
+    this.closeAllGameWindows()
+    ipcMain.removeAllListeners('game-window:minimize')
+    ipcMain.removeAllListeners('game-window:maximize')
+    ipcMain.removeAllListeners('game-window:close')
+    ipcMain.removeAllListeners('game-window:toggle-fullscreen')
+    ipcMain.removeAllListeners('game-window:set-click-through')
+  }
+}

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -98,7 +98,7 @@ export class EmulatorManager extends EventEmitter {
   /**
    * Launch a game with the specified emulator and system
    */
-  async launchGame(romPath: string, systemId: string, emulatorId?: string): Promise<void> {
+  async launchGame(romPath: string, systemId: string, emulatorId?: string, extraArgs?: string[]): Promise<void> {
     // Close current emulator if running
     if (this.currentEmulator?.isActive()) {
       await this.currentEmulator.terminate();
@@ -126,6 +126,10 @@ export class EmulatorManager extends EventEmitter {
       if (!options.corePath) {
         throw new Error(`No core found for system: ${systemId}`);
       }
+    }
+
+    if (extraArgs) {
+      options.extraArgs = extraArgs;
     }
 
     // Launch the game

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -44,6 +44,7 @@ export class IPCHandlers {
         fs.writeFileSync(tmpCfgPath, [
           'video_window_show_decorations = "false"',
           'ui_menubar_enable = "false"',
+          'pause_nonactive = "false"',
         ].join('\n') + '\n');
 
         // Launch the emulator with decoration-hiding config

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -37,7 +37,8 @@ contextBridge.exposeInMainWorld('gamelord', {
       'emulator:paused',
       'emulator:resumed',
       'emulator:reset',
-      'emulator:terminated'
+      'emulator:terminated',
+      'game:loaded'
     ];
 
     if (validChannels.includes(channel)) {
@@ -47,6 +48,15 @@ contextBridge.exposeInMainWorld('gamelord', {
 
   removeAllListeners: (channel: string) => {
     ipcRenderer.removeAllListeners(channel);
+  },
+
+  // Game window controls
+  gameWindow: {
+    minimize: () => ipcRenderer.send('game-window:minimize'),
+    maximize: () => ipcRenderer.send('game-window:maximize'),
+    close: () => ipcRenderer.send('game-window:close'),
+    toggleFullscreen: () => ipcRenderer.send('game-window:toggle-fullscreen'),
+    setClickThrough: (value: boolean) => ipcRenderer.send('game-window:set-click-through', value)
   },
 
   // Library management

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -38,7 +38,8 @@ contextBridge.exposeInMainWorld('gamelord', {
       'emulator:resumed',
       'emulator:reset',
       'emulator:terminated',
-      'game:loaded'
+      'game:loaded',
+      'overlay:show-controls'
     ];
 
     if (validChannels.includes(channel)) {

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -25,24 +25,32 @@ export const GameWindow: React.FC = () => {
       setGame(gameData)
     })
 
-    // Main process tells us when to show/hide controls based on cursor position
     api.on('overlay:show-controls', (visible: boolean) => {
       setShowControls(visible)
     })
 
+    // Drive pause state from emulator events, not optimistic toggling
+    api.on('emulator:paused', () => setIsPaused(true))
+    api.on('emulator:resumed', () => setIsPaused(false))
+
     return () => {
       api.removeAllListeners('game:loaded')
       api.removeAllListeners('overlay:show-controls')
+      api.removeAllListeners('emulator:paused')
+      api.removeAllListeners('emulator:resumed')
     }
   }, [api])
 
   const handlePauseResume = async () => {
-    if (isPaused) {
-      await api.emulation.resume()
-    } else {
-      await api.emulation.pause()
+    try {
+      if (isPaused) {
+        await api.emulation.resume()
+      } else {
+        await api.emulation.pause()
+      }
+    } catch (err) {
+      console.error('Pause/resume failed:', err)
     }
-    setIsPaused(!isPaused)
   }
 
   const handleSaveState = async () => {

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -1,0 +1,290 @@
+import React, { useState, useEffect } from 'react'
+import { Button } from '@gamelord/ui'
+import {
+  Play,
+  Pause,
+  X,
+  Minimize2,
+  Maximize2,
+  Save,
+  FolderOpen,
+  Camera,
+  Volume2,
+  Settings,
+  Maximize,
+} from 'lucide-react'
+import type { Game } from '../../types/library'
+import type { GamelordAPI } from '../types/global'
+
+export const GameWindow: React.FC = () => {
+  const api = (window as unknown as { gamelord: GamelordAPI }).gamelord
+  const [game, setGame] = useState<Game | null>(null)
+  const [isPaused, setIsPaused] = useState(false)
+  const [showControls, setShowControls] = useState(true)
+  const [selectedSlot, setSelectedSlot] = useState(0)
+
+  useEffect(() => {
+    // Listen for game data from main process
+    const handleGameLoaded = (gameData: Game) => {
+      setGame(gameData)
+    }
+
+    api.on('game:loaded', handleGameLoaded)
+
+    // Auto-hide controls after 3 seconds of no movement
+    let hideTimeout: NodeJS.Timeout
+    const handleMouseMove = () => {
+      setShowControls(true)
+      clearTimeout(hideTimeout)
+      hideTimeout = setTimeout(() => setShowControls(false), 3000)
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      clearTimeout(hideTimeout)
+      api.removeAllListeners('game:loaded')
+    }
+  }, [api])
+
+  const handlePauseResume = async () => {
+    if (isPaused) {
+      await api.emulation.resume()
+    } else {
+      await api.emulation.pause()
+    }
+    setIsPaused(!isPaused)
+  }
+
+  const handleSaveState = async () => {
+    await api.saveState.save(selectedSlot)
+  }
+
+  const handleLoadState = async () => {
+    await api.saveState.load(selectedSlot)
+  }
+
+  const handleScreenshot = async () => {
+    await api.emulation.screenshot()
+  }
+
+  const handleClose = () => {
+    api.gameWindow.close()
+  }
+
+  const handleMinimize = () => {
+    api.gameWindow.minimize()
+  }
+
+  const handleMaximize = () => {
+    api.gameWindow.maximize()
+  }
+
+  const handleToggleFullscreen = () => {
+    api.gameWindow.toggleFullscreen()
+  }
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // F5 - Quick save
+      if (e.key === 'F5') {
+        e.preventDefault()
+        void handleSaveState()
+      }
+      // F9 - Quick load
+      if (e.key === 'F9') {
+        e.preventDefault()
+        void handleLoadState()
+      }
+      // F11 - Toggle fullscreen
+      if (e.key === 'F11') {
+        e.preventDefault()
+        handleToggleFullscreen()
+      }
+      // Escape - Show controls
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setShowControls(true)
+      }
+      // Space - Pause/Resume
+      if (e.key === ' ' && e.target === document.body) {
+        e.preventDefault()
+        void handlePauseResume()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isPaused, selectedSlot])
+
+  if (!game) {
+    return (
+      <div className="flex items-center justify-center h-screen bg-gray-900 text-white">
+        <p>Loading game...</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-screen bg-transparent overflow-hidden">
+      {/* Custom title bar */}
+      <div
+        className={`absolute top-0 left-0 right-0 z-50 transition-opacity duration-300 ${
+          showControls ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onMouseEnter={() => api.gameWindow.setClickThrough(false)}
+        onMouseLeave={() => api.gameWindow.setClickThrough(true)}
+      >
+        <div className="flex items-center justify-between px-4 py-2 bg-gradient-to-b from-black/80 to-transparent backdrop-blur-sm">
+          <div className="flex items-center gap-3">
+            <h1 className="text-white font-semibold">{game.title}</h1>
+            <span className="text-gray-400 text-sm">{game.system}</span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleMinimize}
+              className="text-white hover:bg-white/10"
+            >
+              <Minimize2 className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleMaximize}
+              className="text-white hover:bg-white/10"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleClose}
+              className="text-white hover:bg-red-500/20"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Bottom control bar */}
+      <div
+        className={`absolute bottom-0 left-0 right-0 z-50 transition-opacity duration-300 ${
+          showControls ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onMouseEnter={() => api.gameWindow.setClickThrough(false)}
+        onMouseLeave={() => api.gameWindow.setClickThrough(true)}
+      >
+        <div className="flex items-center justify-between px-6 py-4 bg-gradient-to-t from-black/90 to-transparent backdrop-blur-sm">
+          {/* Playback controls */}
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handlePauseResume}
+              className="text-white hover:bg-white/10"
+            >
+              {isPaused ? (
+                <Play className="h-5 w-5" />
+              ) : (
+                <Pause className="h-5 w-5" />
+              )}
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleScreenshot}
+              className="text-white hover:bg-white/10"
+            >
+              <Camera className="h-5 w-5" />
+            </Button>
+          </div>
+
+          {/* Save state controls */}
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-white text-sm">Slot:</span>
+              <div className="flex gap-1">
+                {[0, 1, 2, 3, 4].map((slot) => (
+                  <button
+                    key={slot}
+                    onClick={() => setSelectedSlot(slot)}
+                    className={`w-8 h-8 rounded flex items-center justify-center text-sm font-medium transition-colors ${
+                      selectedSlot === slot
+                        ? 'bg-blue-500 text-white'
+                        : 'bg-white/10 text-white/60 hover:bg-white/20'
+                    }`}
+                  >
+                    {slot}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSaveState}
+              className="text-white hover:bg-white/10"
+            >
+              <Save className="h-4 w-4 mr-2" />
+              Save (F5)
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleLoadState}
+              className="text-white hover:bg-white/10"
+            >
+              <FolderOpen className="h-4 w-4 mr-2" />
+              Load (F9)
+            </Button>
+          </div>
+
+          {/* Additional controls */}
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-white hover:bg-white/10"
+            >
+              <Volume2 className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleToggleFullscreen}
+              className="text-white hover:bg-white/10"
+            >
+              <Maximize className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-white hover:bg-white/10"
+            >
+              <Settings className="h-5 w-5" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Pause overlay */}
+      {isPaused && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-40">
+          <div className="text-center">
+            <Pause className="h-16 w-16 text-white mx-auto mb-4" />
+            <p className="text-white text-xl font-semibold">Paused</p>
+            <p className="text-gray-400 text-sm mt-2">
+              Press Space or click Play to resume
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/game-window.tsx
+++ b/apps/desktop/src/renderer/game-window.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { GameWindow } from './components/GameWindow'
-import '../app.css'
+import '../game-window.css'
 
 const rootElement = document.getElementById('root')
 if (rootElement) {

--- a/apps/desktop/src/renderer/game-window.tsx
+++ b/apps/desktop/src/renderer/game-window.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { GameWindow } from './components/GameWindow'
+import '../app.css'
+
+const rootElement = document.getElementById('root')
+if (rootElement) {
+  createRoot(rootElement).render(
+    <React.StrictMode>
+      <GameWindow />
+    </React.StrictMode>
+  )
+}

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -48,6 +48,16 @@ export interface GamelordAPI {
     selectDirectory: () => Promise<string | null>
     selectRomFile: (systemId: string) => Promise<string | null>
   }
+
+  // Game window controls
+  gameWindow: {
+    minimize: () => void
+    maximize: () => void
+    close: () => void
+    toggleFullscreen: () => void
+    setClickThrough: (value: boolean) => void
+  }
+
   on: (channel: string, callback: (...args: any[]) => void) => void
   removeAllListeners: (channel: string) => void
 }

--- a/apps/desktop/src/types/vite-env.d.ts
+++ b/apps/desktop/src/types/vite-env.d.ts
@@ -2,3 +2,5 @@
 
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
 declare const MAIN_WINDOW_VITE_NAME: string;
+declare const GAME_WINDOW_VITE_DEV_SERVER_URL: string | undefined;
+declare const GAME_WINDOW_VITE_NAME: string;

--- a/apps/desktop/vite.game-window.config.ts
+++ b/apps/desktop/vite.game-window.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: 'game-window.html',
+    },
+  },
+});

--- a/packages/ui/components/GameCard.tsx
+++ b/packages/ui/components/GameCard.tsx
@@ -61,8 +61,8 @@ export const GameCard: React.FC<GameCardProps> = ({
             </div>
           )}
 
-          {/* Hover overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+          {/* Always visible overlay */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent">
             <div className="absolute bottom-0 left-0 right-0 p-4">
               <h3 className="text-white font-semibold text-sm mb-2 line-clamp-2">
                 {game.title}

--- a/packages/ui/types/global.d.ts
+++ b/packages/ui/types/global.d.ts
@@ -5,9 +5,23 @@ export interface GamelordAPI {
     ) => Promise<{ success: boolean; error?: string }>
     unload: () => Promise<{ success: boolean; error?: string }>
   }
+  emulator: {
+    launch: (
+      romPath: string,
+      systemId: string,
+      emulatorId?: string,
+    ) => Promise<{ success: boolean; error?: string }>
+    stop: () => Promise<{ success: boolean; error?: string }>
+    getAvailable: () => Promise<any>
+    isRunning: () => Promise<boolean>
+  }
   emulation: {
     pause: () => Promise<{ success: boolean }>
     resume: () => Promise<{ success: boolean }>
+    reset: () => Promise<{ success: boolean; error?: string }>
+    screenshot: (
+      outputPath?: string,
+    ) => Promise<{ success: boolean; path?: string; error?: string }>
   }
   saveState: {
     save: (slot: number) => Promise<{ success: boolean }>
@@ -36,6 +50,13 @@ export interface GamelordAPI {
   dialog?: {
     selectDirectory: () => Promise<string | null>
     selectRomFile: (systemId: string) => Promise<string | null>
+  }
+  gameWindow?: {
+    minimize: () => void
+    maximize: () => void
+    close: () => void
+    toggleFullscreen: () => void
+    setClickThrough: (value: boolean) => void
   }
   on: (channel: string, callback: (...args: any[]) => void) => void
   removeAllListeners: (channel: string) => void

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4002,10 +4002,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}


### PR DESCRIPTION
## Summary
- Transparent overlay window that tracks RetroArch's position/size via async JXA polling
- Control bars (pause, save/load state, screenshot, fullscreen) fade in when cursor enters the overlay
- Click-through on transparent areas so the user interacts with RetroArch underneath
- RetroArch launched with `--appendconfig` to disable pause-on-focus-loss and window decorations
- Native emulator management with UDP network commands
- Library service with game scanning and system management

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Electron window/process coordination (PID polling via `osascript`, click-through overlay, temp config writes) and changes emulator launch flow, which can be brittle across OS/windowing scenarios.
> 
> **Overview**
> Adds a new `game_window` renderer (Vite/Forge entry, `game-window.html`, CSS, and `GameWindow` React UI) to render a transparent always-on-top overlay with in-game controls (pause/resume, save/load state, screenshot, fullscreen shortcuts).
> 
> Updates desktop IPC/emulator launch to create this overlay per game, launch RetroArch with a temporary `--appendconfig` to hide decorations/disable pause-on-focus-loss, and then track the RetroArch PID by polling window bounds via JXA (`osascript`) to reposition the overlay and toggle click-through + control visibility based on cursor position.
> 
> Extends `EmulatorManager.launchGame` to accept `extraArgs`, wires new `game-window:*` IPC commands through preload/types, adjusts app quit behavior on window close, and makes `GameCard`’s gradient overlay always visible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0462818766ab457824ad6014905c42d66fb4cce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->