### PR TITLE
Game window state persistence, hero transition, and per-system preferences

### DIFF
--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -138,8 +138,10 @@ export class GameWindowManager {
       gameWindow.webContents.send('game:av-info', avInfo)
 
       // If no hero transition, tell renderer to start boot animation immediately
+      // and focus the window so keyboard input works right away.
       if (!hasHeroTransition) {
         gameWindow.webContents.send('game:ready-for-boot')
+        gameWindow.focus()
       }
 
       if (shouldResume) {

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -68,9 +68,10 @@ export class GameWindowManager {
     // Width is calculated from height using the correct aspect ratio
     const defaultWidth = Math.round(defaultHeight * aspectRatio)
 
-    // Build state config for this game window
+    // Build state config for this game window (per-system so different aspect
+    // ratios don't clash — e.g. a wide GBA size won't be restored for 4:3 NES).
     const gameWindowConfig: WindowStateConfig = {
-      stateFile: 'game-window-state.json',
+      stateFile: `game-window-state-${game.systemId}.json`,
       defaults: {
         x: -1,
         y: -1,

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -6,6 +6,8 @@ import type { Game } from '../types/library'
 import type { EmulationWorkerClient } from './emulator/EmulationWorkerClient'
 import type { AVInfo } from './workers/core-worker-protocol'
 import { animateWindowClose } from './windowCloseAnimation'
+import { animateWindowOpen } from './windowOpenAnimation'
+import { manageWindowState, saveWindowStateNow, type WindowStateConfig } from './utils/windowState'
 import { gameWindowLog } from './logger'
 
 const execFileAsync = promisify(execFile)
@@ -47,6 +49,7 @@ export class GameWindowManager {
     workerClient: EmulationWorkerClient,
     avInfo: AVInfo,
     shouldResume = false,
+    cardScreenBounds?: { x: number; y: number; width: number; height: number },
   ): BrowserWindow {
     const existingWindow = this.gameWindows.get(game.id)
     if (existingWindow && !existingWindow.isDestroyed()) {
@@ -61,13 +64,30 @@ export class GameWindowManager {
       : baseWidth / baseHeight
     // Scale up to a reasonable window size (targeting ~720p height)
     const scale = Math.max(2, Math.floor(720 / baseHeight))
-    const windowHeight = baseHeight * scale
+    const defaultHeight = baseHeight * scale
     // Width is calculated from height using the correct aspect ratio
-    const windowWidth = Math.round(windowHeight * aspectRatio)
+    const defaultWidth = Math.round(defaultHeight * aspectRatio)
+
+    // Build state config for this game window
+    const gameWindowConfig: WindowStateConfig = {
+      stateFile: 'game-window-state.json',
+      defaults: {
+        x: -1,
+        y: -1,
+        width: defaultWidth,
+        height: defaultHeight,
+        isMaximized: false,
+        isFullScreen: false,
+      },
+      trackFullScreen: true,
+      manualCloseSave: true,
+    }
+
+    const hasHeroTransition = !!cardScreenBounds
 
     const gameWindow = new BrowserWindow({
-      width: windowWidth,
-      height: windowHeight,
+      width: defaultWidth,
+      height: defaultHeight,
       minWidth: Math.round(baseHeight * 2 * aspectRatio),
       minHeight: baseHeight * 2,
       useContentSize: true, // Ensure width/height refer to content area, not window frame
@@ -75,6 +95,7 @@ export class GameWindowManager {
       titleBarStyle: 'hidden',
       trafficLightPosition: { x: 10, y: 10 },
       backgroundColor: '#000000',
+      show: !hasHeroTransition, // Hide initially if hero transition will animate it
       webPreferences: {
         preload: this.preloadPath,
         contextIsolation: true,
@@ -85,6 +106,10 @@ export class GameWindowManager {
     // Lock window to the core's aspect ratio
     gameWindow.setAspectRatio(aspectRatio)
 
+    // Restore saved position/size and attach resize/move state tracking.
+    // Must come after setAspectRatio so subsequent user resizes stay correct.
+    manageWindowState(gameWindow, gameWindowConfig)
+
     if (process.env.ELECTRON_RENDERER_URL) {
       gameWindow.loadURL(`${process.env.ELECTRON_RENDERER_URL}/game-window.html`)
     } else {
@@ -93,10 +118,29 @@ export class GameWindowManager {
       )
     }
 
+    // Run the hero transition if card bounds were provided.
+    // The window starts at the card's screen position and morphs to its
+    // final bounds, then signals the renderer to start the boot animation.
+    if (hasHeroTransition) {
+      const finalBounds = gameWindow.getBounds()
+      gameWindow.once('ready-to-show', () => {
+        animateWindowOpen(gameWindow, cardScreenBounds, finalBounds).then(() => {
+          if (!gameWindow.isDestroyed()) {
+            gameWindow.webContents.send('game:ready-for-boot')
+          }
+        })
+      })
+    }
+
     gameWindow.webContents.on('did-finish-load', () => {
       gameWindow.webContents.send('game:loaded', game)
       gameWindow.webContents.send('game:mode', 'native')
       gameWindow.webContents.send('game:av-info', avInfo)
+
+      // If no hero transition, tell renderer to start boot animation immediately
+      if (!hasHeroTransition) {
+        gameWindow.webContents.send('game:ready-for-boot')
+      }
 
       if (shouldResume) {
         workerClient.loadState(99).catch((error) => {
@@ -136,6 +180,10 @@ export class GameWindowManager {
         this.readyToCloseWindows.delete(windowId)
         return
       }
+
+      // Save window state before the shutdown animation (which shrinks the
+      // window and would corrupt the saved bounds if we saved after).
+      saveWindowStateNow(gameWindow, gameWindowConfig)
 
       // Prevent the default close so we can play the shutdown animation
       event.preventDefault()

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -325,7 +325,7 @@ describe('IPCHandlers', () => {
       });
       expect(emulatorManagerInstance.setWorkerClient).toHaveBeenCalledWith(workerClientInstance);
       expect(gameWindowManagerInstance.createNativeGameWindow).toHaveBeenCalledWith(
-        fakeGame, workerClientInstance, fakeAvInfo, false,
+        fakeGame, workerClientInstance, fakeAvInfo, false, undefined,
       );
       expect(result).toEqual({ success: true });
     });

--- a/apps/desktop/src/main/utils/windowState.test.ts
+++ b/apps/desktop/src/main/utils/windowState.test.ts
@@ -14,7 +14,9 @@ const mockSetBounds = vi.fn()
 const mockSetSize = vi.fn()
 const mockCenter = vi.fn()
 const mockMaximize = vi.fn()
+const mockSetFullScreen = vi.fn()
 const mockIsMaximized = vi.fn().mockReturnValue(false)
+const mockIsFullScreen = vi.fn().mockReturnValue(false)
 const mockIsDestroyed = vi.fn().mockReturnValue(false)
 const mockOn = vi.fn()
 
@@ -45,7 +47,7 @@ vi.mock('node:fs', () => ({
 }))
 
 // Import after mocks are set up
-import { getSavedWindowBounds, manageWindowState } from './windowState'
+import { getSavedWindowBounds, manageWindowState, saveWindowStateNow, type WindowStateConfig } from './windowState'
 import type { BrowserWindow } from 'electron'
 
 function createMockWindow(): BrowserWindow {
@@ -55,10 +57,26 @@ function createMockWindow(): BrowserWindow {
     setSize: mockSetSize,
     center: mockCenter,
     maximize: mockMaximize,
+    setFullScreen: mockSetFullScreen,
     isMaximized: mockIsMaximized,
+    isFullScreen: mockIsFullScreen,
     isDestroyed: mockIsDestroyed,
     on: mockOn,
   } as unknown as BrowserWindow
+}
+
+const GAME_WINDOW_CONFIG: WindowStateConfig = {
+  stateFile: 'game-window-state.json',
+  defaults: {
+    x: -1,
+    y: -1,
+    width: 960,
+    height: 720,
+    isMaximized: false,
+    isFullScreen: false,
+  },
+  trackFullScreen: true,
+  manualCloseSave: true,
 }
 
 beforeEach(() => {
@@ -66,6 +84,7 @@ beforeEach(() => {
   mockReadFileSync.mockReset()
   mockWriteFileSync.mockReset()
   mockIsMaximized.mockReturnValue(false)
+  mockIsFullScreen.mockReturnValue(false)
   mockIsDestroyed.mockReturnValue(false)
   mockGetBounds.mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 })
 })
@@ -128,6 +147,30 @@ describe('getSavedWindowBounds', () => {
     expect(bounds).toEqual({ width: 1024, height: 768 })
     expect(bounds).not.toHaveProperty('x')
     expect(bounds).not.toHaveProperty('y')
+  })
+
+  it('uses custom config defaults and file path', () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
+    expect(bounds).toEqual({ width: 960, height: 720 })
+
+    // Verify it reads from the custom state file
+    expect(mockReadFileSync).toHaveBeenCalledWith(
+      `${MOCK_USER_DATA}/game-window-state.json`,
+      'utf-8'
+    )
+  })
+
+  it('reads saved state from custom config file', () => {
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ x: 300, y: 400, width: 800, height: 600, isMaximized: false, isFullScreen: true })
+    )
+
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
+    expect(bounds).toEqual({ x: 300, y: 400, width: 800, height: 600 })
   })
 })
 
@@ -238,6 +281,103 @@ describe('manageWindowState', () => {
     const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
     const closeHandler = closeCall![1] as () => void
     closeHandler()
+
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+
+  describe('with trackFullScreen config', () => {
+    it('restores fullscreen state when saved', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false, isFullScreen: true })
+      )
+
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
+
+      expect(mockSetFullScreen).toHaveBeenCalledWith(true)
+      expect(mockMaximize).not.toHaveBeenCalled()
+    })
+
+    it('registers fullscreen events instead of maximize events', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
+
+      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
+      expect(registeredEvents).toContain('resize')
+      expect(registeredEvents).toContain('move')
+      expect(registeredEvents).toContain('enter-full-screen')
+      expect(registeredEvents).toContain('leave-full-screen')
+      expect(registeredEvents).not.toContain('maximize')
+      expect(registeredEvents).not.toContain('unmaximize')
+    })
+
+    it('defaults isFullScreen to false when missing from saved state', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false })
+      )
+
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
+
+      expect(mockSetFullScreen).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('with manualCloseSave config', () => {
+    it('does not attach a close handler', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
+
+      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
+      expect(registeredEvents).not.toContain('close')
+    })
+  })
+})
+
+describe('saveWindowStateNow', () => {
+  it('saves current bounds when not fullscreen or maximized', () => {
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      `${MOCK_USER_DATA}/game-window-state.json`,
+      expect.stringContaining('"width": 1024'),
+      'utf-8'
+    )
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
+    expect(savedState.isFullScreen).toBe(false)
+    expect(savedState.isMaximized).toBe(false)
+  })
+
+  it('preserves pre-fullscreen bounds when fullscreen', () => {
+    mockIsFullScreen.mockReturnValue(true)
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({ x: 300, y: 400, width: 960, height: 720, isMaximized: false, isFullScreen: false })
+    )
+
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
+
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
+    expect(savedState.isFullScreen).toBe(true)
+    // Should preserve the pre-fullscreen bounds, not the current fullscreen bounds
+    expect(savedState.width).toBe(960)
+    expect(savedState.height).toBe(720)
+  })
+
+  it('does nothing when window is destroyed', () => {
+    mockIsDestroyed.mockReturnValue(true)
+
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
 
     expect(mockWriteFileSync).not.toHaveBeenCalled()
   })

--- a/apps/desktop/src/main/utils/windowState.ts
+++ b/apps/desktop/src/main/utils/windowState.ts
@@ -9,31 +9,50 @@ interface WindowState {
   width: number
   height: number
   isMaximized: boolean
+  isFullScreen: boolean
 }
 
-const STATE_FILE = 'window-state.json'
-
-const defaultState: WindowState = {
-  x: -1,
-  y: -1,
-  width: 1280,
-  height: 800,
-  isMaximized: false,
+export interface WindowStateConfig {
+  /** File name stored in the userData directory. */
+  stateFile: string
+  /** Default state when no saved file exists. */
+  defaults: WindowState
+  /** Track fullscreen instead of maximized state. */
+  trackFullScreen?: boolean
+  /**
+   * If true, the caller is responsible for saving state on close via
+   * `saveWindowStateNow`. `manageWindowState` will not attach a `close`
+   * listener. Useful when the window has a custom close flow (e.g.
+   * shutdown animation) that could corrupt saved bounds.
+   */
+  manualCloseSave?: boolean
 }
 
-/** Load the saved window bounds from disk, or return defaults. */
-function loadWindowState(): WindowState {
-  const filePath = path.join(app.getPath('userData'), STATE_FILE)
+export const MAIN_WINDOW_CONFIG: WindowStateConfig = {
+  stateFile: 'window-state.json',
+  defaults: {
+    x: -1,
+    y: -1,
+    width: 1280,
+    height: 800,
+    isMaximized: false,
+    isFullScreen: false,
+  },
+}
+
+function loadWindowState(config: WindowStateConfig = MAIN_WINDOW_CONFIG): WindowState {
+  const filePath = path.join(app.getPath('userData'), config.stateFile)
   try {
     const raw = fs.readFileSync(filePath, 'utf-8')
     const parsed = JSON.parse(raw) as Partial<WindowState>
 
     const state: WindowState = {
-      x: typeof parsed.x === 'number' ? parsed.x : defaultState.x,
-      y: typeof parsed.y === 'number' ? parsed.y : defaultState.y,
-      width: typeof parsed.width === 'number' ? parsed.width : defaultState.width,
-      height: typeof parsed.height === 'number' ? parsed.height : defaultState.height,
-      isMaximized: typeof parsed.isMaximized === 'boolean' ? parsed.isMaximized : defaultState.isMaximized,
+      x: typeof parsed.x === 'number' ? parsed.x : config.defaults.x,
+      y: typeof parsed.y === 'number' ? parsed.y : config.defaults.y,
+      width: typeof parsed.width === 'number' ? parsed.width : config.defaults.width,
+      height: typeof parsed.height === 'number' ? parsed.height : config.defaults.height,
+      isMaximized: typeof parsed.isMaximized === 'boolean' ? parsed.isMaximized : config.defaults.isMaximized,
+      isFullScreen: typeof parsed.isFullScreen === 'boolean' ? parsed.isFullScreen : config.defaults.isFullScreen,
     }
 
     // Validate that the saved position is still visible on any connected display
@@ -58,13 +77,12 @@ function loadWindowState(): WindowState {
 
     return state
   } catch {
-    return { ...defaultState }
+    return { ...config.defaults }
   }
 }
 
-/** Save the current window bounds to disk. */
-function saveWindowState(state: WindowState): void {
-  const filePath = path.join(app.getPath('userData'), STATE_FILE)
+function saveWindowState(state: WindowState, config: WindowStateConfig = MAIN_WINDOW_CONFIG): void {
+  const filePath = path.join(app.getPath('userData'), config.stateFile)
   try {
     fs.writeFileSync(filePath, JSON.stringify(state, null, 2), 'utf-8')
   } catch (error) {
@@ -73,15 +91,43 @@ function saveWindowState(state: WindowState): void {
 }
 
 /**
+ * Save current window state to disk immediately. Use this when the caller
+ * manages its own close lifecycle (e.g. `manualCloseSave: true`).
+ */
+export function saveWindowStateNow(window: BrowserWindow, config: WindowStateConfig): void {
+  if (window.isDestroyed()) return
+
+  const isFullScreen = config.trackFullScreen ? window.isFullScreen() : false
+  const isMaximized = !config.trackFullScreen ? window.isMaximized() : false
+
+  if (!isFullScreen && !isMaximized) {
+    const bounds = window.getBounds()
+    saveWindowState({
+      x: bounds.x,
+      y: bounds.y,
+      width: bounds.width,
+      height: bounds.height,
+      isMaximized: false,
+      isFullScreen: false,
+    }, config)
+  } else {
+    const existing = loadWindowState(config)
+    saveWindowState({
+      ...existing,
+      isMaximized,
+      isFullScreen,
+    }, config)
+  }
+}
+
+/**
  * Attach window state tracking to a BrowserWindow.
  *
  * Listens for resize/move/maximize/close events and persists the window
  * bounds so they can be restored on the next launch.
- *
- * Returns the loaded state so the caller can apply it to BrowserWindow options.
  */
-export function manageWindowState(window: BrowserWindow): void {
-  const state = loadWindowState()
+export function manageWindowState(window: BrowserWindow, config: WindowStateConfig = MAIN_WINDOW_CONFIG): void {
+  const state = loadWindowState(config)
 
   // Restore saved bounds
   if (state.x !== -1 && state.y !== -1) {
@@ -91,7 +137,9 @@ export function manageWindowState(window: BrowserWindow): void {
     window.center()
   }
 
-  if (state.isMaximized) {
+  if (config.trackFullScreen && state.isFullScreen) {
+    window.setFullScreen(true)
+  } else if (!config.trackFullScreen && state.isMaximized) {
     window.maximize()
   }
 
@@ -102,60 +150,68 @@ export function manageWindowState(window: BrowserWindow): void {
     saveTimeout = setTimeout(() => {
       if (window.isDestroyed()) return
 
-      const isMaximized = window.isMaximized()
-      // Only save normal bounds (not maximized bounds) so we restore
-      // to the last non-maximized size when un-maximized.
-      if (!isMaximized) {
-        const bounds = window.getBounds()
-        saveWindowState({
-          x: bounds.x,
-          y: bounds.y,
-          width: bounds.width,
-          height: bounds.height,
-          isMaximized: false,
-        })
+      if (config.trackFullScreen) {
+        const isFullScreen = window.isFullScreen()
+        if (!isFullScreen) {
+          const bounds = window.getBounds()
+          saveWindowState({
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width,
+            height: bounds.height,
+            isMaximized: false,
+            isFullScreen: false,
+          }, config)
+        } else {
+          const existing = loadWindowState(config)
+          saveWindowState({ ...existing, isFullScreen: true }, config)
+        }
       } else {
-        // Save the maximized flag but keep the last known normal bounds
-        const existing = loadWindowState()
-        saveWindowState({ ...existing, isMaximized: true })
+        const isMaximized = window.isMaximized()
+        if (!isMaximized) {
+          const bounds = window.getBounds()
+          saveWindowState({
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width,
+            height: bounds.height,
+            isMaximized: false,
+            isFullScreen: false,
+          }, config)
+        } else {
+          const existing = loadWindowState(config)
+          saveWindowState({ ...existing, isMaximized: true }, config)
+        }
       }
     }, 500)
   }
 
   window.on('resize', scheduleSave)
   window.on('move', scheduleSave)
-  window.on('maximize', scheduleSave)
-  window.on('unmaximize', scheduleSave)
 
-  // Final save on close to ensure latest state is persisted
-  window.on('close', () => {
-    if (saveTimeout) clearTimeout(saveTimeout)
+  if (config.trackFullScreen) {
+    window.on('enter-full-screen', scheduleSave)
+    window.on('leave-full-screen', scheduleSave)
+  } else {
+    window.on('maximize', scheduleSave)
+    window.on('unmaximize', scheduleSave)
+  }
 
-    if (!window.isDestroyed()) {
-      const isMaximized = window.isMaximized()
-      if (!isMaximized) {
-        const bounds = window.getBounds()
-        saveWindowState({
-          x: bounds.x,
-          y: bounds.y,
-          width: bounds.width,
-          height: bounds.height,
-          isMaximized: false,
-        })
-      } else {
-        const existing = loadWindowState()
-        saveWindowState({ ...existing, isMaximized: true })
-      }
-    }
-  })
+  if (!config.manualCloseSave) {
+    // Final save on close to ensure latest state is persisted
+    window.on('close', () => {
+      if (saveTimeout) clearTimeout(saveTimeout)
+      saveWindowStateNow(window, config)
+    })
+  }
 }
 
 /**
  * Get saved window state for use in BrowserWindow constructor options.
  * Returns width/height (and optionally x/y) from the last saved state.
  */
-export function getSavedWindowBounds(): { width: number; height: number; x?: number; y?: number } {
-  const state = loadWindowState()
+export function getSavedWindowBounds(config: WindowStateConfig = MAIN_WINDOW_CONFIG): { width: number; height: number; x?: number; y?: number } {
+  const state = loadWindowState(config)
   if (state.x !== -1 && state.y !== -1) {
     return { width: state.width, height: state.height, x: state.x, y: state.y }
   }

--- a/apps/desktop/src/main/windowOpenAnimation.ts
+++ b/apps/desktop/src/main/windowOpenAnimation.ts
@@ -74,6 +74,7 @@ export function animateWindowOpen(
         // Ensure final state is exact
         window.setOpacity(1)
         window.setBounds(endBounds)
+        window.focus()
         resolve()
       }
     }, stepDuration)

--- a/apps/desktop/src/main/windowOpenAnimation.ts
+++ b/apps/desktop/src/main/windowOpenAnimation.ts
@@ -1,0 +1,81 @@
+import type { BrowserWindow } from 'electron'
+
+/** Duration of the OS-level window open/morph animation in ms. */
+export const WINDOW_OPEN_ANIMATION_DURATION = 300
+
+/** Number of discrete animation steps (~60fps at 300ms). */
+export const WINDOW_OPEN_ANIMATION_STEPS = 18
+
+interface Bounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Animate a BrowserWindow from one set of bounds to another.
+ * Used for the "hero transition" — the game window spawns at the clicked
+ * card's position and morphs to its final emulator size.
+ *
+ * Fades opacity from 0 → 1 with a cubic ease-out, and interpolates bounds
+ * from `startBounds` to `endBounds`.
+ *
+ * Returns a Promise that resolves when the animation finishes or the window
+ * is destroyed mid-animation.
+ */
+export function animateWindowOpen(
+  window: BrowserWindow,
+  startBounds: Bounds,
+  endBounds: Bounds,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (window.isDestroyed()) {
+      resolve()
+      return
+    }
+
+    const totalSteps = WINDOW_OPEN_ANIMATION_STEPS
+    const stepDuration = WINDOW_OPEN_ANIMATION_DURATION / totalSteps
+    let currentStep = 0
+
+    // Start at the card's position with 0 opacity
+    window.setBounds(startBounds)
+    window.setOpacity(0)
+    window.showInactive()
+
+    const interval = setInterval(() => {
+      currentStep++
+
+      if (window.isDestroyed()) {
+        clearInterval(interval)
+        resolve()
+        return
+      }
+
+      // Progress from 0 → 1
+      const progress = currentStep / totalSteps
+
+      // Cubic ease-out: starts fast, decelerates smoothly
+      const easedProgress = 1 - Math.pow(1 - progress, 3)
+
+      // Fade opacity from 0 to 1
+      window.setOpacity(easedProgress)
+
+      // Interpolate bounds from start to end
+      const newX = Math.round(startBounds.x + (endBounds.x - startBounds.x) * easedProgress)
+      const newY = Math.round(startBounds.y + (endBounds.y - startBounds.y) * easedProgress)
+      const newWidth = Math.round(startBounds.width + (endBounds.width - startBounds.width) * easedProgress)
+      const newHeight = Math.round(startBounds.height + (endBounds.height - startBounds.height) * easedProgress)
+      window.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight })
+
+      if (currentStep >= totalSteps) {
+        clearInterval(interval)
+        // Ensure final state is exact
+        window.setOpacity(1)
+        window.setBounds(endBounds)
+        resolve()
+      }
+    }, stepDuration)
+  })
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -4,8 +4,8 @@ import { contextBridge, ipcRenderer } from 'electron';
 contextBridge.exposeInMainWorld('gamelord', {
   // Emulator management
   emulator: {
-    launch: (romPath: string, systemId: string, emulatorId?: string, coreName?: string) =>
-      ipcRenderer.invoke('emulator:launch', romPath, systemId, emulatorId, coreName),
+    launch: (romPath: string, systemId: string, emulatorId?: string, coreName?: string, cardBounds?: { x: number; y: number; width: number; height: number }) =>
+      ipcRenderer.invoke('emulator:launch', romPath, systemId, emulatorId, coreName, cardBounds),
     stop: () => ipcRenderer.invoke('emulator:stop'),
     getAvailable: () => ipcRenderer.invoke('emulator:getAvailable'),
     isRunning: () => ipcRenderer.invoke('emulator:isRunning'),
@@ -61,7 +61,8 @@ contextBridge.exposeInMainWorld('gamelord', {
       'artwork:syncError',
       'dialog:showResumeGame',
       'game:prepare-close',
-      'game:emulation-error'
+      'game:emulation-error',
+      'game:ready-for-boot'
     ];
 
     if (validChannels.includes(channel)) {

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -62,7 +62,7 @@ export const GameWindow: React.FC = () => {
     return localStorage.getItem('gamelord:showFps') === 'true'
   })
   const [fps, setFps] = useState(0)
-  const [isPoweringOn, setIsPoweringOn] = useState(true)
+  const [isPoweringOn, setIsPoweringOn] = useState(false)
   const [isPoweringOff, setIsPoweringOff] = useState(false)
 
   // Memoize power animation callbacks so they have stable references.
@@ -163,9 +163,16 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners('game:video-frame')
     api.removeAllListeners('game:audio-samples')
     api.removeAllListeners('game:prepare-close')
+    api.removeAllListeners('game:ready-for-boot')
 
     api.on('game:loaded', (gameData: Game) => {
       setGame(gameData)
+    })
+
+    // Sent by the main process after the hero transition animation completes
+    // (or immediately if there is no hero transition).
+    api.on('game:ready-for-boot', () => {
+      setIsPoweringOn(true)
     })
 
     api.on('game:mode', (m: string) => {
@@ -342,6 +349,7 @@ export const GameWindow: React.FC = () => {
       api.removeAllListeners('game:video-frame')
       api.removeAllListeners('game:audio-samples')
       api.removeAllListeners('game:prepare-close')
+      api.removeAllListeners('game:ready-for-boot')
 
       cancelAnimationFrame(rafIdRef.current)
       pendingFrameRef.current = null

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -167,6 +167,12 @@ export const GameWindow: React.FC = () => {
 
     api.on('game:loaded', (gameData: Game) => {
       setGame(gameData)
+
+      // Load per-system shader preference (e.g. CRT for NES, LCD for GBA)
+      const systemShader = localStorage.getItem(`gamelord:shader:${gameData.systemId}`)
+      if (systemShader) {
+        setShader(systemShader)
+      }
     })
 
     // Sent by the main process after the hero transition animation completes
@@ -379,11 +385,14 @@ export const GameWindow: React.FC = () => {
     }
   }, [updateCanvasSize])
 
-  // Sync shader preference
+  // Sync shader preference (saved per-system when a game is loaded)
   useEffect(() => {
     rendererRef.current?.setShader(shader)
     localStorage.setItem('gamelord:shader', shader)
-  }, [shader])
+    if (game) {
+      localStorage.setItem(`gamelord:shader:${game.systemId}`, shader)
+    }
+  }, [shader, game])
 
   // Sync gain node with volume/mute state and persist
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -33,7 +33,7 @@ interface CoreDownloadProgress {
 }
 
 export const LibraryView: React.FC<{
-  onPlayGame: (game: Game) => void
+  onPlayGame: (game: Game, cardRect?: DOMRect) => void
   getMenuItems?: (game: Game) => GameCardMenuItem[]
 }> = ({ onPlayGame, getMenuItems }) => {
   const api = (window as unknown as { gamelord: GamelordAPI }).gamelord
@@ -418,8 +418,8 @@ export const LibraryView: React.FC<{
   const idToGame = useMemo(() => new Map(games.map((g) => [g.id, g])), [games])
 
   /** Delegate to the parent's onPlayGame so App.tsx can handle core selection. */
-  const handlePlayUiGame = (uiGame: UiGame) => {
-    onPlayGame(uiGame)
+  const handlePlayUiGame = (uiGame: UiGame, cardRect?: DOMRect) => {
+    onPlayGame(uiGame, cardRect)
   }
 
   const handleGameOptions = (game: AppGame) => {
@@ -615,8 +615,8 @@ export const LibraryView: React.FC<{
         {filteredGames.length > 0 ? (
           <GameLibrary
             games={uiGames}
-            onPlayGame={(g) => {
-              void handlePlayUiGame(g)
+            onPlayGame={(g, cardRect) => {
+              void handlePlayUiGame(g, cardRect)
             }}
             onGameOptions={handleUiGameOptions}
             getMenuItems={getMenuItems}

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -15,6 +15,7 @@ export interface GamelordAPI {
       systemId: string,
       emulatorId?: string,
       coreName?: string,
+      cardBounds?: { x: number; y: number; width: number; height: number },
     ) => Promise<{ success: boolean; error?: string }>
     stop: () => Promise<{ success: boolean; error?: string }>
     getAvailable: () => Promise<any>

--- a/packages/ui/components/GameCard.test.tsx
+++ b/packages/ui/components/GameCard.test.tsx
@@ -88,7 +88,7 @@ describe('GameCard', () => {
       render(<GameCard game={mockGame} onPlay={onPlay} />)
 
       await user.click(screen.getByRole('button', { name: /play super mario bros/i }))
-      expect(onPlay).toHaveBeenCalledWith(mockGame)
+      expect(onPlay).toHaveBeenCalledWith(mockGame, expect.any(DOMRect))
     })
 
     it('calls onPlay when Enter is pressed on focused card', async () => {
@@ -98,7 +98,7 @@ describe('GameCard', () => {
 
       await user.tab()
       await user.keyboard('{Enter}')
-      expect(onPlay).toHaveBeenCalledWith(mockGame)
+      expect(onPlay).toHaveBeenCalledWith(mockGame, expect.any(DOMRect))
     })
 
     it('calls onPlay when Space is pressed on focused card', async () => {
@@ -108,7 +108,7 @@ describe('GameCard', () => {
 
       await user.tab()
       await user.keyboard(' ')
-      expect(onPlay).toHaveBeenCalledWith(mockGame)
+      expect(onPlay).toHaveBeenCalledWith(mockGame, expect.any(DOMRect))
     })
 
     it('calls onOptions when Options button is clicked without triggering onPlay', async () => {

--- a/packages/ui/components/GameCard.tsx
+++ b/packages/ui/components/GameCard.tsx
@@ -35,7 +35,7 @@ export interface GameCardMenuItem {
 
 export interface GameCardProps {
   game: Game
-  onPlay: (game: Game) => void
+  onPlay: (game: Game, cardRect?: DOMRect) => void
   /** @deprecated Use menuItems instead for dropdown menu support. */
   onOptions?: (game: Game) => void
   /** Menu items shown in the options dropdown on hover. */
@@ -68,13 +68,15 @@ export const GameCard: React.FC<GameCardProps> = React.memo(function GameCard({
   const menuItems = menuItemsProp ?? (getMenuItems ? getMenuItems(game) : undefined)
   const handlePlay = (e: React.MouseEvent) => {
     e.preventDefault()
-    onPlay(game)
+    const rect = e.currentTarget.getBoundingClientRect()
+    onPlay(game, rect)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      onPlay(game)
+      const rect = e.currentTarget.getBoundingClientRect()
+      onPlay(game, rect)
     }
   }
 

--- a/packages/ui/components/GameLibrary.tsx
+++ b/packages/ui/components/GameLibrary.tsx
@@ -24,7 +24,7 @@ const VIRTUALIZATION_THRESHOLD = 100;
 
 export interface GameLibraryProps {
   games: Game[];
-  onPlayGame: (game: Game) => void;
+  onPlayGame: (game: Game, cardRect?: DOMRect) => void;
   onGameOptions?: (game: Game) => void;
   /** Returns menu items for a specific game's dropdown. */
   getMenuItems?: (game: Game) => GameCardMenuItem[];


### PR DESCRIPTION
## Summary

- **Window state persistence for game windows**: Parameterized the existing `windowState.ts` module with `WindowStateConfig` so both the main window and game/emulator windows remember their size, position, maximized, and fullscreen state across sessions. Game window state is saved per-system (e.g., `game-window-state-nes.json`) to avoid aspect ratio conflicts between platforms.
- **Hero transition animation**: When launching a game, the game window spawns at the clicked card's screen position and animates (morphs bounds + fades in) to its final size over 300ms with cubic ease-out. The boot animation (CRT/LCD power-on) plays only after the hero transition completes.
- **Window focus on open**: Game window receives keyboard focus immediately on open so users can start playing with keyboard input right away.
- **Per-system shader preferences**: Each system remembers its own shader preference (e.g., CRT for NES, LCD for GBA) via per-system localStorage keys.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no errors)
- [x] `pnpm test` passes (433 tests)
- [ ] Manual: launch a game → verify window spawns from card position and morphs to final size
- [ ] Manual: close game window, reopen → verify saved position/size restored
- [ ] Manual: switch between systems → verify each system remembers its own window size and shader
- [ ] Manual: verify keyboard input works immediately after game window opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)