### PR TITLE
fix: stabilize CRT Geom Deluxe image and restore vertical borders

### DIFF
--- a/packages/ui/webgl/crt-geom-deluxe-shaders.ts
+++ b/packages/ui/webgl/crt-geom-deluxe-shaders.ts
@@ -24,7 +24,7 @@ const float R              = 3.5;
 const float cornersize     = 0.01;
 const float cornersmooth   = 1000.0;
 const float overscan_x     = 1.0;
-const float overscan_y     = 1.0;
+const float overscan_y     = 0.98;
 const float aspect_x       = 1.0;
 const float aspect_y       = 0.75;
 
@@ -32,7 +32,7 @@ const float aspect_y       = 0.75;
 const float scanline_weight = 0.3;
 const float geom_lum        = 0.0;
 const float halation         = 0.1;
-const float rasterbloom_raw  = 0.1;
+const float rasterbloom_raw  = 0.0;
 const float rasterbloom      = rasterbloom_raw / 10.0;
 const float width            = 2.0;
 


### PR DESCRIPTION
## Summary
- Disable raster bloom (`rasterbloom_raw` 0.1 → 0.0) which was causing content-driven image breathing — bright scenes shrink, dark scenes expand
- Restore `overscan_y` from 1.0 to 0.98 (regression from a bad merge) to balance vertical black bars with horizontal ones

## Test plan
- [x] Full test suite passes (324 tests)
- [x] Lint and typecheck clean
- [ ] Visual verification: CRT image holds stable geometry across bright/dark scene transitions
- [ ] Visual verification: top/bottom black borders match side borders

🤖 Generated with [Claude Code](https://claude.com/claude-code)