### PR TITLE
fix: handle worker client error event in EmulatorManager

### DIFF
--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -337,6 +337,7 @@ export class EmulatorManager extends EventEmitter {
       client.on('paused', () => this.emit('emulator:paused'));
       client.on('resumed', () => this.emit('emulator:resumed'));
       client.on('reset', () => this.emit('emulator:reset'));
+      client.on('error', (error) => this.emit('emulator:error', error));
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds missing `error` event listener on the worker client in `EmulatorManager.setWorkerClient()`, forwarding it as `emulator:error` to match the existing event chain
- Fixes `ERR_UNHANDLED_ERROR` crash on app quit caused by the emulation worker's exit event having no handler

## Test plan
- [x] All 324 existing tests pass
- [ ] Launch a game, then quit the app — verify no uncaught exception in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)