### PR TITLE
fix: smarter scroll letter indicator trigger

### DIFF
--- a/packages/ui/hooks/useScrollLetterIndicator.ts
+++ b/packages/ui/hooks/useScrollLetterIndicator.ts
@@ -12,6 +12,13 @@ export interface UseScrollLetterIndicatorOptions {
   scrollTop: number
   /** Delay in ms before hiding the letter after scrolling stops. @default 400 */
   hideDelay?: number
+  /**
+   * Minimum scroll speed in px/ms required to show the indicator.
+   * Below this threshold the indicator stays hidden even when crossing
+   * letter boundaries.
+   * @default 2.5
+   */
+  minSpeedPxPerMs?: number
 }
 
 export interface ScrollLetterIndicatorState {
@@ -34,15 +41,28 @@ export function getLetterFromTitle(title: string): string {
  * Tracks which alphabetical section is visible during scrolling and controls
  * the visibility of a letter overlay indicator (Steam-style).
  *
+ * The indicator only appears when scrolling fast enough AND crossing a letter
+ * boundary. Slow browsing within a single letter section won't trigger it.
+ *
  * Only activates when `sortBy === 'title'`. Returns `letter: null` otherwise.
  */
 export function useScrollLetterIndicator(
   options: UseScrollLetterIndicatorOptions,
 ): ScrollLetterIndicatorState {
-  const { firstVisibleIndex, games, sortBy, scrollTop, hideDelay = 400 } = options
+  const {
+    firstVisibleIndex,
+    games,
+    sortBy,
+    scrollTop,
+    hideDelay = 400,
+    minSpeedPxPerMs = 2.5,
+  } = options
   const [isVisible, setIsVisible] = useState(false)
+  const isVisibleRef = useRef(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const prevScrollTopRef = useRef(scrollTop)
+  const prevLetterRef = useRef<string | null>(null)
+  const prevScrollTimeRef = useRef(Date.now())
   const hasScrolledRef = useRef(false)
 
   const letter = useMemo(() => {
@@ -52,23 +72,50 @@ export function useScrollLetterIndicator(
     return getLetterFromTitle(games[firstVisibleIndex].title)
   }, [sortBy, firstVisibleIndex, games])
 
-  // Scroll activity detection
+  // Scroll activity detection — only show when fast-scrolling across letter boundaries
   useEffect(() => {
     if (scrollTop === prevScrollTopRef.current) return
+
+    const now = Date.now()
+    const deltaTime = now - prevScrollTimeRef.current
+    const deltaScroll = Math.abs(scrollTop - prevScrollTopRef.current)
     prevScrollTopRef.current = scrollTop
+    prevScrollTimeRef.current = now
 
     // Skip the first scroll change (e.g. programmatic scroll-to-top on filter change)
     if (!hasScrolledRef.current) {
       hasScrolledRef.current = true
+      prevLetterRef.current = letter
       return
     }
 
     if (sortBy !== 'title' || letter === null) return
 
-    setIsVisible(true)
-    clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => setIsVisible(false), hideDelay)
-  }, [scrollTop, sortBy, letter, hideDelay])
+    // Compute scroll speed (px/ms). Guard against deltaTime === 0.
+    const speed = deltaTime > 0 ? deltaScroll / deltaTime : 0
+    const isFast = speed >= minSpeedPxPerMs
+
+    const crossedLetterBoundary = letter !== prevLetterRef.current
+    prevLetterRef.current = letter
+
+    // Trigger: fast scroll across a letter boundary
+    if (crossedLetterBoundary && isFast) {
+      isVisibleRef.current = true
+      setIsVisible(true)
+    }
+
+    // Reset the hide timer whenever scrolling fast while indicator is up.
+    // This keeps the indicator alive during continuous fast scrolling, even
+    // within a single letter section. The countdown only begins once scrolling
+    // slows down or stops.
+    if (isVisibleRef.current && isFast) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => {
+        isVisibleRef.current = false
+        setIsVisible(false)
+      }, hideDelay)
+    }
+  }, [scrollTop, sortBy, letter, hideDelay, minSpeedPxPerMs])
 
   // Cleanup timeout on unmount
   useEffect(() => {
@@ -77,8 +124,10 @@ export function useScrollLetterIndicator(
 
   // Reset when sort mode or games change
   useEffect(() => {
+    isVisibleRef.current = false
     setIsVisible(false)
     hasScrolledRef.current = false
+    prevLetterRef.current = null
   }, [sortBy, games])
 
   return { letter, isVisible }


### PR DESCRIPTION
## Summary
- Scroll letter indicator now only appears when **fast-scrolling across a letter boundary** — no more flashing on casual browsing
- Added `minSpeedPxPerMs` option (default 2.5 px/ms) as a speed threshold below which the indicator stays hidden
- Hide timer resets on continued fast scrolling so the indicator stays visible during sustained drags instead of flickering away mid-scroll

## Test plan
- [x] Existing tests updated for new two-condition trigger (boundary + speed)
- [x] New test: indicator stays hidden when scrolling within same letter
- [x] New test: indicator stays hidden on slow letter-boundary crossings
- [x] New test: indicator appears on fast letter-boundary crossings
- [x] New test: indicator stays visible during sustained fast scrolling within a letter section
- [x] Full test suite passes (19 hook tests + all project tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)