### PR TITLE
feat: ROM checksum validation (CRC32/SHA-1/MD5)

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -87,7 +87,7 @@ Items are grouped by priority. Work top-down within each tier.
 - [x] **Test suite — WebGL renderer** — Shader compilation, preset switching, fallback behavior
 - [x] **Fix test environment** — Switch vitest config from jsdom to happy-dom (per project conventions)
 - [x] **Fix game ID hashing** — Replace `MD5(romPath)` in `LibraryService.ts` with `SHA-256(fileContent)` so IDs survive file moves
-- [ ] **ROM checksum validation** — Compute CRC32/SHA-1 checksums on ROM files for integrity verification and database lookups (e.g. No-Intro DAT matching) — [#61](https://github.com/ryanmagoon/gamelord/issues/61)
+- [x] **ROM checksum validation** — Compute CRC32/SHA-1/MD5 checksums on ROM files at scan time via single-pass streaming. Stored in required `romHashes` field on `Game`. Backfill on startup for existing libraries. ArtworkService simplified to use pre-computed MD5. — [#61](https://github.com/ryanmagoon/gamelord/issues/61)
 
 ### P2 — Performance
 

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -286,6 +286,7 @@ describe('IPCHandlers', () => {
       system: 'NES',
       systemId: 'nes',
       romPath: '/roms/smb.nes',
+      romHashes: { crc32: 'deadbeef', sha1: 'a'.repeat(40), md5: 'b'.repeat(32) },
     };
 
     it('launches in native mode successfully', async () => {

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -19,8 +19,10 @@ export interface Game {
   coverArt?: string;
   /** Width / height ratio of the downloaded cover art (e.g. 0.714 for a 3:4.2 box). */
   coverArtAspectRatio?: number;
-  romHashes?: {
-    md5?: string;
+  romHashes: {
+    crc32: string;
+    sha1: string;
+    md5: string;
   };
   lastPlayed?: Date;
   playTime?: number;


### PR DESCRIPTION
## Summary
- Compute CRC32, SHA-1, and MD5 checksums on ROM files at scan time in a single streaming pass, storing them as required fields on every `Game` record
- Remove the standalone MD5 computation from ArtworkService — it now reads the pre-computed hash from `game.romHashes.md5`
- Add startup backfill migration so existing libraries get hashes filled in automatically; unreadable ROMs are pruned

Closes #61

## Test plan
- [x] `pnpm typecheck` — no errors (required `romHashes` enforced everywhere)
- [x] `pnpm test` — 462 tests pass, including 15+ new tests for `computeRomHashes`, backfill, and integration
- [x] `pnpm lint` — clean (0 errors)
- [ ] Manual: scan ROMs, inspect `library.json` — every game has `romHashes: { crc32, sha1, md5 }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)