### PR TITLE
chore: add modular .claude/rules/ for project instructions

### DIFF
--- a/.claude/rules/design-philosophy.md
+++ b/.claude/rules/design-philosophy.md
@@ -1,0 +1,5 @@
+# Design Philosophy
+
+- **Extremely polished UI.** Every interaction should feel intentional and delightful. Prioritize craft and attention to detail — this is a desktop app, not a throwaway prototype.
+- **Microinteractions and animations.** Use tasteful transitions, hover effects, loading states, and motion to make the app feel alive. Think about easing curves, staggered animations, and subtle feedback on every click, toggle, and navigation.
+- **Ideate novel flourishes.** When implementing a feature, proactively suggest creative UI touches — e.g. a CRT power-on animation when launching a game, particle effects on achievements, satisfying haptic-style feedback on button presses, ambient glow effects. Propose these ideas to the user before implementing.

--- a/.claude/rules/development-plan.md
+++ b/.claude/rules/development-plan.md
@@ -1,0 +1,8 @@
+# Keeping the Development Plan Current
+
+`DEVELOPMENT_PLAN.md` is the single source of truth for project state. It must stay accurate across sessions so any new chat can pick up where the last one left off.
+
+- **Mark items done as you complete them.** When you finish a TODO item, immediately update it from `[ ]` to `[x]` with a brief description of what was done. Don't batch these — update the plan in the same commit as the implementation.
+- **Add new items when they're discovered.** If work reveals a new task, bug, or follow-up, add it to the appropriate priority section in `DEVELOPMENT_PLAN.md`. This includes ideas discussed in conversation that we decide to pursue — if it's agreed upon, it goes in the plan.
+- **Record new known issues.** If you encounter a bug, limitation, or quirk during development, add it to the "Known Issues" section at the bottom of the plan.
+- **Reference GitHub issues.** When a GitHub issue is created for deferred work, include the issue URL next to the corresponding item in the plan (e.g., `— see #42`). When closing an issue via PR, update the plan item to `[x]` in the same change.

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -1,0 +1,13 @@
+# Performance — Frame Rate is Sacred
+
+Emulation frame pacing is a top-tier concern. Every code change — especially in the renderer, game window, and emulation loop — must be evaluated for its impact on consistent frame delivery. The app must look and feel smooth on 120Hz+ displays.
+
+## Rules
+
+- **No `backdrop-filter` or `backdrop-blur` in the game window.** These force expensive GPU compositing every frame and compete with the WebGL shader pipeline. Use solid or semi-transparent backgrounds instead. Backdrop effects are fine in the library UI where frame pacing doesn't matter.
+- **No expensive CSS effects layered over the game canvas.** Avoid `box-shadow` animations, large `filter: blur()`, or CSS `transform` animations on elements that overlap the canvas during gameplay. Static transforms and opacity transitions are acceptable.
+- **Renderer draws must be synced to `requestAnimationFrame`.** Never draw to WebGL directly from an IPC event handler. Buffer the latest frame and draw it in the next rAF callback to align with the display's vsync.
+- **Emulation timing must not rely on `setTimeout`/`setInterval` precision.** These have ~4ms minimum granularity and jitter under load. The target architecture is a dedicated Worker thread with high-resolution timing (see P2 in `DEVELOPMENT_PLAN.md`).
+- **Profile before adding multi-pass shaders.** Any shader preset with 3+ passes must be tested on integrated GPUs (e.g. Apple M-series) to confirm it maintains 60fps. Include lighter alternatives users can fall back to.
+- **Measure, don't guess.** When in doubt about a change's performance impact, add a temporary FPS/frame-time counter and test with a real game running. Don't ship code that "should be fine" without verification.
+- **Pause-state effects are exempt.** When the emulation loop is stopped (paused, menu open, etc.), the GPU is idle and expensive cosmetic effects (VHS distortion, scanline drift, static overlays) are fair game. The performance rules above apply to effects running *during active gameplay*.

--- a/.claude/rules/session-start.md
+++ b/.claude/rules/session-start.md
@@ -1,0 +1,9 @@
+# Session Start
+
+At the start of every new conversation, before doing anything else:
+
+1. `git fetch origin && git checkout main && git pull origin main` — ensure you're on the latest `main`.
+2. If there are stashed or uncommitted changes from a previous session, surface them to the user and ask what to do (keep, drop, or stash).
+3. Read `DEVELOPMENT_PLAN.md` for current project state.
+
+Never give advice about what to work on next, or start new work, from a stale branch.

--- a/.claude/rules/storybook.md
+++ b/.claude/rules/storybook.md
@@ -1,0 +1,3 @@
+# Storybook Coverage
+
+All UI components with loading, error, or transitional states **must** have Storybook stories representing each state. This makes states easy to polish, iterate on, and visually verify without needing to reproduce them in the running app. Examples: artwork sync phases (hashing, querying, downloading, done, error, not-found), empty/loading library, form validation errors.


### PR DESCRIPTION
## Summary

- Adds `.claude/rules/` directory with focused, topic-specific rule files for Claude Code
- Rules are automatically loaded alongside `CLAUDE.md`, providing better organization without changing behavior
- Also reorganized global `~/.claude/rules/` (not in this PR — those are local to the machine)

## Files

| File | Topic |
|------|-------|
| `session-start.md` | Sync to main, check stashes, read dev plan |
| `development-plan.md` | Keeping `DEVELOPMENT_PLAN.md` current |
| `design-philosophy.md` | Polished UI, microinteractions, novel flourishes |
| `storybook.md` | Coverage requirements for stateful components |
| `performance.md` | Frame rate rules, no backdrop-blur, rAF sync |