### PR TITLE
docs: add worktree setup steps to session-start rules

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "desktop",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@gamelord/desktop", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@gamelord/ui", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/.claude/rules/session-start.md
+++ b/.claude/rules/session-start.md
@@ -7,3 +7,10 @@ At the start of every new conversation, before doing anything else:
 3. Read `DEVELOPMENT_PLAN.md` for current project state.
 
 Never give advice about what to work on next, or start new work, from a stale branch.
+
+## Worktree Setup
+
+When working in a git worktree (`.claude/worktrees/`), dependencies and build artifacts are not shared with the main repo. After `pnpm install`, also run:
+
+1. **Build the native addon** — `cd apps/desktop/native && npx node-gyp rebuild`. Without this, the emulator cores won't load.
+2. **Symlink `.env`** — `ln -s /Users/ryanmagoon/code/gamelord/apps/desktop/.env apps/desktop/.env`. The worktree only has `.env.example`; the real credentials (ScreenScraper, etc.) live in the main repo.


### PR DESCRIPTION
## Summary
- Adds worktree setup section to `.claude/rules/session-start.md` documenting the native addon build and `.env` symlink steps needed in new worktrees
- Adds `.claude/launch.json` with desktop and storybook dev server configurations

## Test plan
- [x] Verified native addon builds successfully in worktree
- [x] Verified `.env` symlink works for ScreenScraper credentials
- [x] Docs-only change — no code behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)