### PR TITLE
feat: dev branch badge for worktree identification

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "desktop",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["--filter", "@gamelord/desktop", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "storybook",

--- a/.claude/rules/session-start.md
+++ b/.claude/rules/session-start.md
@@ -14,3 +14,16 @@ When working in a git worktree (`.claude/worktrees/`), dependencies and build ar
 
 1. **Build the native addon** — `cd apps/desktop/native && npx node-gyp rebuild`. Without this, the emulator cores won't load.
 2. **Symlink `.env`** — `ln -s /Users/ryanmagoon/code/gamelord/apps/desktop/.env apps/desktop/.env`. The worktree only has `.env.example`; the real credentials (ScreenScraper, etc.) live in the main repo.
+
+### Rename auto-generated worktree branches
+
+Claude Code creates worktrees with random branch names like `claude/xenodochial-bassi`. These are useless for identifying what's being worked on. **Before starting any work**, rename the branch to follow the project's `<type>/<short-descriptive-name>` convention:
+
+```bash
+git branch -m claude/random-name feat/descriptive-feature-name
+```
+
+This matters because:
+- The dev branch badge in the title bar displays the branch name — a descriptive name immediately tells you which feature each app window belongs to.
+- PRs, commit history, and `git branch` output are all more readable with meaningful names.
+- The worktree directory name stays the same (it's just a checkout path), so nothing else breaks.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,33 @@
 import { resolve } from 'path'
+import { execSync } from 'child_process'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
+
+function getGitBranch(): string | null {
+  try {
+    return execSync('git branch --show-current', { encoding: 'utf-8' }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+function getWorktreeName(): string | null {
+  const match = process.cwd().match(/\.claude\/worktrees\/([^/]+)/)
+  return match?.[1] ?? null
+}
+
+function getLatestCommitSubject(): string | null {
+  try {
+    return execSync('git log -1 --format=%s', { encoding: 'utf-8' }).trim() || null
+  } catch {
+    return null
+  }
+}
+
+const isDev = process.env.NODE_ENV !== 'production'
+const gitBranch = isDev ? getGitBranch() : null
+const worktreeName = isDev ? getWorktreeName() : null
+const commitSubject = isDev ? getLatestCommitSubject() : null
 
 export default defineConfig({
   main: {
@@ -42,6 +69,11 @@ export default defineConfig({
       },
     },
     plugins: [react()],
+    define: {
+      __DEV_GIT_BRANCH__: JSON.stringify(gitBranch),
+      __DEV_WORKTREE_NAME__: JSON.stringify(worktreeName),
+      __DEV_COMMIT_SUBJECT__: JSON.stringify(commitSubject),
+    },
     resolve: {
       // Ensure pnpm workspace symlinks (e.g. @gamelord/ui → packages/ui)
       // resolve to their real paths, so Node module resolution walks up from

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -2,6 +2,7 @@ import { resolve } from 'path'
 import { execSync } from 'child_process'
 import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
 import react from '@vitejs/plugin-react'
+import type { Plugin } from 'vite'
 
 function getGitBranch(): string | null {
   try {
@@ -11,23 +12,36 @@ function getGitBranch(): string | null {
   }
 }
 
-function getWorktreeName(): string | null {
-  const match = process.cwd().match(/\.claude\/worktrees\/([^/]+)/)
-  return match?.[1] ?? null
-}
-
-function getLatestCommitSubject(): string | null {
-  try {
-    return execSync('git log -1 --format=%s', { encoding: 'utf-8' }).trim() || null
-  } catch {
-    return null
-  }
+function getWorktreeInfo(): { name: string; path: string } | null {
+  const match = process.cwd().match(/^(.*\/\.claude\/worktrees\/([^/]+))/)
+  if (!match) return null
+  return { name: match[2], path: match[1] }
 }
 
 const isDev = process.env.NODE_ENV !== 'production'
 const gitBranch = isDev ? getGitBranch() : null
-const worktreeName = isDev ? getWorktreeName() : null
-const commitSubject = isDev ? getLatestCommitSubject() : null
+const worktreeInfo = isDev ? getWorktreeInfo() : null
+
+/** Vite plugin that injects dev-time git info as compile-time constants. */
+function devGitInfoPlugin(): Plugin {
+  const replacements: Record<string, string> = {
+    __DEV_GIT_BRANCH__: JSON.stringify(gitBranch),
+    __DEV_WORKTREE_NAME__: JSON.stringify(worktreeInfo?.name ?? null),
+    __DEV_WORKTREE_PATH__: JSON.stringify(worktreeInfo?.path ?? null),
+  }
+
+  return {
+    name: 'dev-git-info',
+    transform(code, id) {
+      if (!id.endsWith('.tsx') && !id.endsWith('.ts')) return
+      let result = code
+      for (const [key, value] of Object.entries(replacements)) {
+        result = result.replaceAll(key, value)
+      }
+      if (result !== code) return { code: result, map: null }
+    },
+  }
+}
 
 export default defineConfig({
   main: {
@@ -68,12 +82,7 @@ export default defineConfig({
         },
       },
     },
-    plugins: [react()],
-    define: {
-      __DEV_GIT_BRANCH__: JSON.stringify(gitBranch),
-      __DEV_WORKTREE_NAME__: JSON.stringify(worktreeName),
-      __DEV_COMMIT_SUBJECT__: JSON.stringify(commitSubject),
-    },
+    plugins: [react(), devGitInfoPlugin()],
     resolve: {
       // Ensure pnpm workspace symlinks (e.g. @gamelord/ui → packages/ui)
       // resolve to their real paths, so Node module resolution walks up from

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -3,6 +3,7 @@ import { Button, WebGLRendererComponent, Game as UiGame, cn, type GameCardMenuIt
 import { useWebGLRenderer } from './hooks/useWebGLRenderer'
 import { Monitor, Tv, Sun, Moon, Cpu, Heart } from 'lucide-react'
 import { DevAgentation } from './components/DevAgentation'
+import { DevBranchBadge } from './components/DevBranchBadge'
 import { LibraryView } from './components/LibraryView'
 import { ResumeGameDialog } from './components/ResumeGameDialog'
 import { CoreSelectDialog } from './components/CoreSelectDialog'
@@ -333,7 +334,8 @@ function App() {
             pointerEvents: viewState === 'library' ? 'auto' : 'none',
           }}
         >
-          <div className="drag-region titlebar-inset h-10 border-b flex items-center justify-end px-4">
+          <div className="drag-region titlebar-inset h-10 border-b flex items-center justify-end gap-2 px-4">
+            <DevBranchBadge />
             <Button variant="ghost" size="icon" className="no-drag h-7 w-7" onClick={toggleTheme}>
               {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>

--- a/apps/desktop/src/renderer/components/DevBranchBadge.tsx
+++ b/apps/desktop/src/renderer/components/DevBranchBadge.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useState } from 'react'
+import { GitBranch, Check } from 'lucide-react'
+
+/**
+ * Dev-only badge showing the latest commit subject and git branch.
+ * Helps distinguish between multiple running worktree instances.
+ * The commit subject is the primary label (describes the feature);
+ * the branch name appears as secondary context.
+ * Clicking copies the branch name to clipboard.
+ */
+export function DevBranchBadge() {
+  const branch = __DEV_GIT_BRANCH__
+  const commitSubject = __DEV_COMMIT_SUBJECT__
+  const [copied, setCopied] = useState(false)
+
+  const handleClick = useCallback(() => {
+    if (!branch) return
+    navigator.clipboard.writeText(branch)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }, [branch])
+
+  if (!branch) return null
+
+  const primaryLabel = commitSubject ?? branch
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={copied ? 'Copied!' : `${branch}\nClick to copy branch name`}
+      className="no-drag inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-muted/50 px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground/70 transition-colors hover:bg-muted hover:text-muted-foreground"
+    >
+      {copied ? (
+        <Check className="h-3 w-3 text-green-500" />
+      ) : (
+        <GitBranch className="h-3 w-3" />
+      )}
+      <span className="max-w-[300px] truncate font-mono">{primaryLabel}</span>
+    </button>
+  )
+}

--- a/apps/desktop/src/renderer/components/DevBranchBadge.tsx
+++ b/apps/desktop/src/renderer/components/DevBranchBadge.tsx
@@ -1,42 +1,83 @@
 import { useCallback, useState } from 'react'
-import { GitBranch, Check } from 'lucide-react'
+import { GitBranch, FolderGit2, Check } from 'lucide-react'
+
+type CopiedField = 'branch' | 'worktree' | null
+
+interface DevBranchBadgeProps {
+  /** Visual variant. `titlebar` for the library header, `overlay` for the game window HUD. */
+  variant?: 'titlebar' | 'overlay'
+}
+
+const STYLES = {
+  titlebar: {
+    container: 'no-drag inline-flex items-center rounded-full border border-border/50 bg-muted/50 text-[10px] font-medium text-muted-foreground/70',
+    branchButton: 'inline-flex items-center gap-1.5 rounded-l-full py-0.5 pl-2.5 pr-2 transition-colors hover:bg-muted hover:text-muted-foreground',
+    worktreeButton: 'inline-flex items-center gap-1 border-l border-border/50 rounded-r-full py-0.5 pl-1.5 pr-2.5 transition-colors hover:bg-muted hover:text-muted-foreground',
+    divider: 'border-border/50',
+  },
+  overlay: {
+    container: 'inline-flex items-center rounded-full bg-black/60 text-[10px] font-medium text-white/70 pointer-events-auto',
+    branchButton: 'inline-flex items-center gap-1.5 rounded-l-full py-0.5 pl-2.5 pr-2 transition-colors hover:bg-white/20 hover:text-white',
+    worktreeButton: 'inline-flex items-center gap-1 border-l border-white/20 rounded-r-full py-0.5 pl-1.5 pr-2.5 transition-colors hover:bg-white/20 hover:text-white',
+    divider: 'border-white/20',
+  },
+} as const
 
 /**
- * Dev-only badge showing the latest commit subject and git branch.
+ * Dev-only badge showing the git branch and worktree name.
  * Helps distinguish between multiple running worktree instances.
- * The commit subject is the primary label (describes the feature);
- * the branch name appears as secondary context.
- * Clicking copies the branch name to clipboard.
+ * Each segment is independently clickable to copy its value.
  */
-export function DevBranchBadge() {
+export function DevBranchBadge({ variant = 'titlebar' }: DevBranchBadgeProps) {
   const branch = __DEV_GIT_BRANCH__
-  const commitSubject = __DEV_COMMIT_SUBJECT__
-  const [copied, setCopied] = useState(false)
+  const worktree = __DEV_WORKTREE_NAME__
+  const worktreePath = __DEV_WORKTREE_PATH__
+  const [copied, setCopied] = useState<CopiedField>(null)
 
-  const handleClick = useCallback(() => {
-    if (!branch) return
-    navigator.clipboard.writeText(branch)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
-  }, [branch])
+  const copyValue = useCallback((value: string, field: CopiedField) => {
+    navigator.clipboard.writeText(value)
+    setCopied(field)
+    setTimeout(() => setCopied(null), 1500)
+  }, [])
 
   if (!branch) return null
 
-  const primaryLabel = commitSubject ?? branch
+  const s = STYLES[variant]
+  const soloRounding = worktree ? 'rounded-l-full' : 'rounded-full'
 
   return (
-    <button
-      type="button"
-      onClick={handleClick}
-      title={copied ? 'Copied!' : `${branch}\nClick to copy branch name`}
-      className="no-drag inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-muted/50 px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground/70 transition-colors hover:bg-muted hover:text-muted-foreground"
-    >
-      {copied ? (
-        <Check className="h-3 w-3 text-green-500" />
-      ) : (
-        <GitBranch className="h-3 w-3" />
+    <div className={s.container}>
+      {/* Branch segment */}
+      <button
+        type="button"
+        onClick={() => copyValue(branch, 'branch')}
+        title={copied === 'branch' ? 'Copied!' : 'Click to copy branch name'}
+        className={`${s.branchButton.replace('rounded-l-full', soloRounding)}`}
+      >
+        {copied === 'branch' ? (
+          <Check className="h-3 w-3 text-green-500" />
+        ) : (
+          <GitBranch className="h-3 w-3" />
+        )}
+        <span className="max-w-[200px] truncate font-mono">{branch}</span>
+      </button>
+
+      {/* Worktree segment */}
+      {worktree && (
+        <button
+          type="button"
+          onClick={() => copyValue(worktreePath ?? worktree, 'worktree')}
+          title={copied === 'worktree' ? 'Copied!' : 'Click to copy worktree path'}
+          className={s.worktreeButton}
+        >
+          {copied === 'worktree' ? (
+            <Check className="h-3 w-3 text-green-500" />
+          ) : (
+            <FolderGit2 className="h-3 w-3" />
+          )}
+          <span className="max-w-[150px] truncate font-mono">{worktree}</span>
+        </button>
       )}
-      <span className="max-w-[300px] truncate font-mono">{primaryLabel}</span>
-    </button>
+    </div>
   )
 }

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -754,12 +754,6 @@ export const GameWindow: React.FC = () => {
         </div>
       )}
 
-      {/* Dev branch badge — top-right, always visible in dev mode */}
-      {isNative && (
-        <div className="absolute top-2 right-2 z-40">
-          <DevBranchBadge variant="overlay" />
-        </div>
-      )}
 
       {/* Persistent drag region — always allows window dragging from the top
           edge, even when the visible controls overlay is hidden. Sits below the
@@ -786,6 +780,7 @@ export const GameWindow: React.FC = () => {
           <div className="flex items-center gap-3">
             <h1 className="text-white font-semibold">{game.title}</h1>
             <span className="text-gray-400 text-sm">{game.system}</span>
+            <DevBranchBadge variant="overlay" />
           </div>
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -28,6 +28,7 @@ import {
   CTRL_AUDIO_READ_POS,
   CTRL_AUDIO_SAMPLE_RATE,
 } from '../../main/workers/shared-frame-protocol'
+import { DevBranchBadge } from './DevBranchBadge'
 import { PowerAnimation } from './animations'
 import { getDisplayType } from '../../types/displayType'
 import { useGamepad } from '../hooks/useGamepad'
@@ -750,6 +751,13 @@ export const GameWindow: React.FC = () => {
       {isNative && showFps && (
         <div className="absolute top-2 left-2 z-40 px-2 py-1 bg-black/60 rounded text-xs font-mono text-green-400 pointer-events-none select-none">
           {fps} FPS
+        </div>
+      )}
+
+      {/* Dev branch badge — top-right, always visible in dev mode */}
+      {isNative && (
+        <div className="absolute top-2 right-2 z-40">
+          <DevBranchBadge variant="overlay" />
         </div>
       )}
 

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -114,6 +114,10 @@ export interface AudioSamples {
 }
 
 declare global {
+  const __DEV_GIT_BRANCH__: string | null
+  const __DEV_WORKTREE_NAME__: string | null
+  const __DEV_COMMIT_SUBJECT__: string | null
+
   interface Window {
     gamelord: GamelordAPI
   }

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -116,7 +116,7 @@ export interface AudioSamples {
 declare global {
   const __DEV_GIT_BRANCH__: string | null
   const __DEV_WORKTREE_NAME__: string | null
-  const __DEV_COMMIT_SUBJECT__: string | null
+  const __DEV_WORKTREE_PATH__: string | null
 
   interface Window {
     gamelord: GamelordAPI


### PR DESCRIPTION
## Summary
- Adds a dev-only badge in the library title bar and game window overlay showing the current git branch and worktree name, making it easy to identify which Electron instance corresponds to which worktree
- Branch and worktree segments are independently clickable — branch copies the branch name, worktree copies the absolute filesystem path for direct terminal use
- Uses a custom Vite transform plugin to inject build-time constants (`__DEV_GIT_BRANCH__`, `__DEV_WORKTREE_NAME__`, `__DEV_WORKTREE_PATH__`) since electron-vite's `define` doesn't work in dev mode

## Test plan
- [x] Run `pnpm dev` from a worktree — confirm badge appears in library title bar with branch name and worktree name
- [x] Click branch segment — confirm branch name is copied to clipboard
- [x] Click worktree segment — confirm absolute worktree path is copied to clipboard
- [x] Launch a game — confirm badge appears in the top overlay bar alongside the game title
- [x] Run `pnpm build` — confirm badge does not appear (constants resolve to `null`)
- [x] Run `pnpm typecheck && pnpm lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)