### PR TITLE
fix: hide Agentation toolbar behind Settings toggle in game window

### DIFF
--- a/apps/desktop/src/game-window.css
+++ b/apps/desktop/src/game-window.css
@@ -39,3 +39,16 @@ html, body, #root {
   background: transparent !important;
   background-color: transparent !important;
 }
+
+/* Agentation dev toolbar: hidden by default, toggled via Settings > Annotate.
+   When visible, repositioned from bottom-right to top-right so it doesn't
+   overlap the game canvas or bottom control bar. */
+[data-feedback-toolbar] {
+  display: none !important;
+}
+body.show-agentation [data-feedback-toolbar] {
+  display: block !important;
+  bottom: auto !important;
+  top: 1rem !important;
+  right: 1rem !important;
+}

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -73,6 +73,9 @@ export const GameWindow: React.FC = () => {
   const [showFps, setShowFps] = useState(() => {
     return localStorage.getItem('gamelord:showFps') === 'true'
   })
+  const [showAgentation, setShowAgentation] = useState(() => {
+    return localStorage.getItem('gamelord:showAgentation') === 'true'
+  })
   const [fps, setFps] = useState(0)
   const [isPoweringOn, setIsPoweringOn] = useState(false)
   const [isPoweringOff, setIsPoweringOff] = useState(false)
@@ -510,6 +513,12 @@ export const GameWindow: React.FC = () => {
   useEffect(() => {
     localStorage.setItem('gamelord:showFps', String(showFps))
   }, [showFps])
+
+  // Toggle Agentation toolbar visibility via body class (portal renders to body)
+  useEffect(() => {
+    localStorage.setItem('gamelord:showAgentation', String(showAgentation))
+    document.body.classList.toggle('show-agentation', showAgentation)
+  }, [showAgentation])
 
   // Sync traffic light visibility with controls overlay (hide during shutdown)
   useEffect(() => {
@@ -994,6 +1003,17 @@ export const GameWindow: React.FC = () => {
                       {showFps ? 'ON' : 'OFF'}
                     </span>
                   </button>
+                  {process.env.NODE_ENV === 'development' && (
+                    <button
+                      onClick={() => setShowAgentation((v) => !v)}
+                      className="w-full flex items-center justify-between px-4 py-2 text-sm text-white/80 hover:bg-white/10 transition-colors"
+                    >
+                      <span>Annotate</span>
+                      <span className={`ml-3 text-xs font-medium ${showAgentation ? 'text-green-400' : 'text-white/40'}`}>
+                        {showAgentation ? 'ON' : 'OFF'}
+                      </span>
+                    </button>
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Agentation dev overlay was permanently visible over the game canvas, blocking the emulator control UI
- Hide it by default via CSS (`display: none` on `[data-feedback-toolbar]`)
- Add a **Settings > Annotate** toggle (dev-only, matches the FPS toggle pattern) that adds a `show-agentation` body class to reveal and reposition the toolbar to the top-right corner
- Toggle state persisted in localStorage

## Test plan
- [x] Launch a game — Agentation toolbar should NOT be visible
- [x] Open controls overlay → Settings → toggle "Annotate" ON — toolbar appears in top-right
- [x] Toggle OFF — toolbar disappears
- [x] Relaunch game — toggle state persists from previous session
- [x] Verify Annotate toggle does not appear in production builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)