### PR TITLE
chore: add no-op vercel.json to stabilize builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "echo 'No web app yet — see P10 in DEVELOPMENT_PLAN.md'"
+  "buildCommand": "mkdir -p dist && echo '<html><body><h1>Coming Soon</h1><p>No web app yet — see P10 in DEVELOPMENT_PLAN.md</p></body></html>' > dist/index.html && echo 'No web app yet — see P10 in DEVELOPMENT_PLAN.md'"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "echo 'No web app yet — see P10 in DEVELOPMENT_PLAN.md'"
+}


### PR DESCRIPTION
The Vercel build fails because turbo build tries to compile the
Electron desktop app's native C++ addon (node-gyp), which will never
work on Vercel's build environment. There's no web app to deploy yet.

This makes builds pass with a no-op until P10 work begins (landing
page, cloud saves API, etc.), preserving any existing Vercel project
configuration.

https://claude.ai/code/session_01RDZhgxSjcsQQ9TAgi5rv52