### PR TITLE
chore: fix lint warnings (unused vars, duplicate imports)

### DIFF
--- a/apps/desktop/.eslintrc.json
+++ b/apps/desktop/.eslintrc.json
@@ -14,5 +14,12 @@
     "plugin:storybook/recommended"
   ],
   "parser": "@typescript-eslint/parser",
-  "ignorePatterns": ["vitest.config.ts", "electron.vite.config.ts"]
+  "ignorePatterns": ["vitest.config.ts", "electron.vite.config.ts"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["warn", {
+      "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_",
+      "caughtErrorsIgnorePattern": "^_"
+    }]
+  }
 }

--- a/apps/desktop/src/main/emulator/CoreDownloader.ts
+++ b/apps/desktop/src/main/emulator/CoreDownloader.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as os from 'os';
+
 import { app } from 'electron';
 import { execFile } from 'child_process';
 import { promisify } from 'util';

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -33,7 +33,7 @@ vi.mock('../logger', () => ({
   ipcLog: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
-import { ipcMain, BrowserWindow, dialog } from 'electron';
+import { ipcMain, BrowserWindow, dialog, app } from 'electron';
 import { EmulatorManager } from '../emulator/EmulatorManager';
 import { EmulationWorkerClient } from '../emulator/EmulationWorkerClient';
 import { resolveAddonPath } from '../emulator/resolveAddonPath';
@@ -175,9 +175,6 @@ beforeEach(() => {
   // Instantiate IPCHandlers — triggers all handler registrations
   new IPCHandlers('/fake/preload.js');
 });
-
-// We need to re-import `app` since the electron mock is module-level
-import { app } from 'electron';
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -1516,7 +1516,7 @@ describe('LibraryService', () => {
         progressEvents.push(event)
       })
 
-      const secondScan = await service.scanDirectory(zipScanDir)
+      await service.scanDirectory(zipScanDir)
 
       // Total game count unchanged — no duplicates
       expect(service.getGames().length).toBe(totalAfterFirst)
@@ -1765,7 +1765,7 @@ describe('LibraryService', () => {
       const hashSpy = vi.spyOn(service, 'computeRomHashes')
 
       // Second scan — zip unchanged, should skip extraction + hashing entirely
-      const secondScan = await service.scanDirectory(zipMtimeDir)
+      await service.scanDirectory(zipMtimeDir)
       expect(hashSpy).not.toHaveBeenCalled()
 
       // Game count unchanged

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -7,7 +7,6 @@ import { DevBranchBadge } from './components/DevBranchBadge'
 import { LibraryView } from './components/LibraryView'
 import { ResumeGameDialog } from './components/ResumeGameDialog'
 import { CoreSelectDialog } from './components/CoreSelectDialog'
-import { Game } from '../types/library'
 import type { GamelordAPI, CoreInfo } from './types/global'
 
 interface ResumeDialogState {
@@ -50,8 +49,7 @@ function App() {
   const api = (window as unknown as { gamelord: GamelordAPI }).gamelord
   const [viewState, setViewState] = useState<ViewState>('library')
   const viewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [currentGame, setCurrentGame] = useState<Game | null>(null)
-  const { isReady, currentShader, handleRendererReady, changeShader } =
+  const { currentShader, handleRendererReady, changeShader } =
     useWebGLRenderer()
   type ThemeMode = 'system' | 'dark' | 'light'
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
@@ -311,16 +309,6 @@ function App() {
     })
 
     return items
-  }, [])
-
-  /** Transition to the game view with a crossfade. */
-  const transitionToGame = useCallback(() => {
-    if (viewTimerRef.current) clearTimeout(viewTimerRef.current)
-    setViewState('to-game')
-    viewTimerRef.current = setTimeout(() => {
-      setViewState('game')
-      viewTimerRef.current = null
-    }, VIEW_TRANSITION_MS)
   }, [])
 
   const handleStop = async () => {

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
-import { Button } from '@gamelord/ui'
+import { Button, WebGLRenderer, SHADER_PRESETS, SHADER_LABELS } from '@gamelord/ui'
 import {
   Play,
   Pause,
@@ -18,7 +18,6 @@ import {
 } from 'lucide-react'
 import type { Game } from '../../types/library'
 import type { GamelordAPI } from '../types/global'
-import { WebGLRenderer, SHADER_PRESETS, SHADER_LABELS } from '@gamelord/ui'
 import {
   CTRL_ACTIVE_BUFFER,
   CTRL_FRAME_SEQUENCE,

--- a/apps/desktop/src/renderer/hooks/useGamepad.ts
+++ b/apps/desktop/src/renderer/hooks/useGamepad.ts
@@ -163,7 +163,7 @@ export function useGamepad({ gameInput, enabled }: UseGamepadOptions): {
   }, [])
 
   useEffect(() => {
-    const handleConnect = (event: GamepadEvent) => {
+    const handleConnect = (_event: GamepadEvent) => {
       setConnectedCount((count) => count + 1)
     }
 

--- a/apps/desktop/src/renderer/lib/webgl/WebGLRenderer.ts
+++ b/apps/desktop/src/renderer/lib/webgl/WebGLRenderer.ts
@@ -32,7 +32,7 @@ export class WebGLRenderer {
     // TODO: Switch shader programs
   }
 
-  render(videoFrame: ImageData): void {
+  render(_videoFrame: ImageData): void {
     if (!this.isReady) return;
     
     // TODO: Render the video frame using WebGL


### PR DESCRIPTION
## Summary
- Remove all 13 `no-unused-vars` and 4 `import/no-duplicates` lint warnings (211 → 194 total)
- Remove dead code in `App.tsx`: unused `currentGame` state, `isReady` destructure, `transitionToGame` callback, stale `Game` import
- Prefix intentionally-unused callback params with `_` (`useGamepad.ts`, `WebGLRenderer.ts`)
- Merge duplicate `@gamelord/ui` imports in `GameWindow.tsx` and duplicate `electron` imports in `handlers.test.ts`
- Remove unused `os` import from `CoreDownloader.ts`
- Drop unused `secondScan` bindings in `LibraryService.test.ts` (keep the side-effecting `await`)
- Configure ESLint `argsIgnorePattern: "^_"` so `_`-prefixed params in abstract stubs and catch blocks are properly ignored
- Fix flaky unreadable-ROM test to use mock instead of `chmod 000` (fails when run as root)

## Test plan
- [x] `pnpm lint` — 0 errors, 194 warnings (down from 211), zero `no-unused-vars` or `import/no-duplicates` remaining
- [x] `pnpm vitest run` (desktop) — 366 tests pass
- [x] `pnpm vitest run` (ui) — 137 tests pass
