### PR TITLE
chore: deduplicate session-start rules

### DIFF
--- a/.claude/rules/session-start.md
+++ b/.claude/rules/session-start.md
@@ -1,12 +1,8 @@
-# Session Start
+# Session Start (Project-Specific)
 
-At the start of every new conversation, before doing anything else:
+After the global session-start steps (sync with main, check for stashed changes):
 
-1. `git fetch origin && git checkout main && git pull origin main` — ensure you're on the latest `main`.
-2. If there are stashed or uncommitted changes from a previous session, surface them to the user and ask what to do (keep, drop, or stash).
-3. Read `DEVELOPMENT_PLAN.md` for current project state.
-
-Never give advice about what to work on next, or start new work, from a stale branch.
+1. Read `DEVELOPMENT_PLAN.md` for current project state.
 
 ## Native Addon
 


### PR DESCRIPTION
## Summary
- Remove global session-start instructions (git fetch, checkout main, check stash) from project-level `.claude/rules/session-start.md` since they already live in `~/.claude/rules/session-start.md`

## Test plan
- [x] Verify global session-start rules still apply (they're in the user's global config)
- [x] Verify project-specific steps (read `DEVELOPMENT_PLAN.md`, worktree setup) are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)