### PR TITLE
fix: clear edge translate when launch lock releases

### DIFF
--- a/packages/ui/hooks/useEdgeAwareHover.ts
+++ b/packages/ui/hooks/useEdgeAwareHover.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 
 export interface UseEdgeAwareHoverOptions {
   /** Scale factor applied on hover. @default 1.25 */
@@ -109,6 +109,15 @@ export function useEdgeAwareHover({
   const onPointerLeave = useCallback(() => {
     if (locked) return
     setEdgeTranslate(null)
+  }, [locked])
+
+  // Clear translate when lock releases (launch ended, pointer already left)
+  const prevLockedRef = useRef(locked)
+  useEffect(() => {
+    if (prevLockedRef.current && !locked) {
+      setEdgeTranslate(null)
+    }
+    prevLockedRef.current = locked
   }, [locked])
 
   return { onPointerEnter, onPointerLeave, edgeTranslate }


### PR DESCRIPTION
## Summary

- When a card on the edge of the screen is launched (modal opens), the edge translate is locked so the card stays in its shifted position
- When `isLaunching` goes back to `false`, the translate was stuck because `onPointerLeave` had already fired while locked
- Added a `useEffect` that detects the `locked` true→false transition and clears the translate, so the card smoothly returns to its resting position

Follow-up to #148 — this commit was pushed after the squash merge.

## Test plan

- [x] All 174 UI tests pass
- [ ] Launch edge card → modal opens → card stays shifted → dismiss modal → card returns to resting position

🤖 Generated with [Claude Code](https://claude.com/claude-code)