### PR TITLE
chore: gitignore Claude Code artifacts and .entire/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,10 @@ dist/
 *storybook.log
 storybook-static
 test-roms/
+
+# Claude Code
+.claude/settings.json
+.claude/worktrees/
+
+# Entire
+.entire/


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json`, `.claude/worktrees/`, and `.entire/` to `.gitignore`
- These are local tool artifacts that shouldn't be tracked

## Test plan
- [x] Verify `git status` no longer shows these as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)