### PR TITLE
feat: error resilience — crash modals, error boundary, BIOS validation

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -19,10 +19,14 @@ If the user provides media, embed it in the PR body using GitHub markdown (`![de
 
 ## Review Comments
 
-After creating or merging a PR, check for review comments before moving on:
+**All review comments must be resolved before merging.** This is enforced by GitHub branch protection (`required_conversation_resolution`). Before merging any PR:
 
-```bash
-gh api repos/{owner}/{repo}/pulls/{number}/comments
-```
+1. Check for review comments:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/comments
+   gh api repos/{owner}/{repo}/pulls/{number}/reviews
+   ```
+2. Address every comment — push fixes to the same branch for code changes, reply to acknowledge non-actionable feedback.
+3. Verify no unresolved conversations remain before running `gh pr merge`.
 
-Address any actionable feedback (bugs, code review suggestions, bot reports). If the PR is still open, push fixes to the same branch. If already merged, open a follow-up PR for the fix. Don't wait for the user to relay comments — check proactively.
+After creating a PR, also check proactively for comments before moving on to other work. If the PR is already merged, open a follow-up PR for any unaddressed feedback.

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -227,11 +227,15 @@ Items are grouped by priority. Work top-down within each tier.
 
 Tracking issue for the first alpha release. All items below must be completed before shipping.
 
+- [x] **Error resilience** — Emulation crash modal in GameWindow, React ErrorBoundary for both windows, BIOS pre-launch validation (Saturn/PS1), IPC launch errors shown as AlertDialogs instead of alert(). — PR [#163](https://github.com/ryanmagoon/gamelord/pull/163), closes [#161](https://github.com/ryanmagoon/gamelord/issues/161)
+- [ ] **Core download retry** — Add retry button when core download fails (currently shows error banner that auto-dismisses after 2s)
 - [ ] **Graceful app startup** — [#125](https://github.com/ryanmagoon/gamelord/issues/125)
-- [ ] **Library UI redesign — shelf-based home view** — Replace the dashboard layout with a shelf-based layout: hero section, horizontal scroll rows grouped by category (Recently Played, Favorites, per-platform), Cmd+K command palette, no persistent chrome. Existing mosaic grid becomes the "browse all" sub-view. — [#141](https://github.com/ryanmagoon/gamelord/issues/141)
+- [ ] **Custom app menu** — About, Preferences (Cmd+,), Scan Library, Help links — [#162](https://github.com/ryanmagoon/gamelord/issues/162)
+- [ ] **Library UI redesign — shelf-based home view** — Replace the dashboard layout with a shelf-based layout: hero section, horizontal scroll rows grouped by category (Recently Played, Favorites, per-platform), Cmd+K command palette, no persistent chrome. Existing mosaic grid becomes the "browse all" sub-view. — [#141](https://github.com/ryanmagoon/gamelord/issues/141) (deferred to alpha.2)
 - [ ] **Cmd+K command palette** — Fuzzy search overlay for games, platforms, and actions. Replaces inline search toolbar. — [#142](https://github.com/ryanmagoon/gamelord/issues/142)
 - [ ] **Settings panel** — [#96](https://github.com/ryanmagoon/gamelord/issues/96)
-- [ ] **DMG packaging + code signing** — [#59](https://github.com/ryanmagoon/gamelord/issues/59)
+- [ ] **Bundled homebrew ROMs** — Ship 2-3 public domain NES ROMs for instant playability on first launch — [#139](https://github.com/ryanmagoon/gamelord/issues/139)
+- [ ] **DMG packaging** — Unsigned DMG via electron-builder, CI release workflow on tagged pushes — [#59](https://github.com/ryanmagoon/gamelord/issues/59)
 
 ### P8 — UI Polish
 

--- a/apps/desktop/src/main/emulator/EmulatorManager.test.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.test.ts
@@ -50,6 +50,7 @@ vi.mock('./LibretroNativeCore', async () => {
 vi.mock('./EmulationWorkerClient')
 
 import { powerSaveBlocker } from 'electron'
+import * as fs from 'fs'
 import { EmulatorManager } from './EmulatorManager'
 
 // ---------------------------------------------------------------------------
@@ -132,5 +133,45 @@ describe('EmulatorManager — power save blocker', () => {
     // stop() should not be called since isStarted returned false
     expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
     expect(internals(manager).powerSaveBlockerId).toBeNull()
+  })
+})
+
+describe('EmulatorManager — BIOS validation', () => {
+  let manager: EmulatorManager
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    manager = new EmulatorManager()
+  })
+
+  it('returns valid for systems without BIOS requirements', () => {
+    const result = manager.validateBios('nes')
+    expect(result.valid).toBe(true)
+    expect(result.missingFiles).toEqual([])
+  })
+
+  it('returns valid when all BIOS files exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(true)
+    expect(result.missingFiles).toEqual([])
+  })
+
+  it('returns missing files when BIOS files are absent', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(false)
+    expect(result.missingFiles).toEqual(['sega_101.bin', 'mpr-17933.bin'])
+    expect(result.systemName).toBe('Sega Saturn')
+    expect(result.biosDir).toContain('BIOS')
+  })
+
+  it('detects partial BIOS files', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: any) =>
+      String(p).endsWith('sega_101.bin')
+    )
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(false)
+    expect(result.missingFiles).toEqual(['mpr-17933.bin'])
   })
 })

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { powerSaveBlocker } from 'electron';
+import { app, powerSaveBlocker } from 'electron';
 import { EmulatorCore, EmulatorInfo } from './EmulatorCore';
 import { RetroArchCore } from './RetroArchCore';
 import { LibretroNativeCore } from './LibretroNativeCore';
@@ -8,6 +8,28 @@ import { CoreDownloader, CoreInfo } from './CoreDownloader';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+
+/**
+ * Systems that require BIOS files to run. Maps system ID to an array of
+ * required filenames that must be present in the BIOS directory.
+ */
+const BIOS_REQUIREMENTS: Record<string, { files: string[]; systemName: string }> = {
+  saturn: {
+    files: ['sega_101.bin', 'mpr-17933.bin'],
+    systemName: 'Sega Saturn',
+  },
+  psx: {
+    files: ['scph5501.bin'],
+    systemName: 'PlayStation',
+  },
+};
+
+export interface BiosValidationResult {
+  valid: boolean
+  missingFiles: string[]
+  biosDir: string
+  systemName: string
+}
 
 /**
  * Manages emulator instances and provides a unified interface for launching games.
@@ -31,6 +53,30 @@ export class EmulatorManager extends EventEmitter {
 
   getCoreDownloader(): CoreDownloader {
     return this.coreDownloader;
+  }
+
+  /**
+   * Checks whether required BIOS files exist for a given system.
+   * Returns a result with missing file names if validation fails.
+   * Systems without BIOS requirements always pass.
+   */
+  validateBios(systemId: string): BiosValidationResult {
+    const requirement = BIOS_REQUIREMENTS[systemId];
+    if (!requirement) {
+      return { valid: true, missingFiles: [], biosDir: '', systemName: '' };
+    }
+
+    const biosDir = path.join(app.getPath('userData'), 'BIOS');
+    const missingFiles = requirement.files.filter(
+      (file) => !fs.existsSync(path.join(biosDir, file))
+    );
+
+    return {
+      valid: missingFiles.length === 0,
+      missingFiles,
+      biosDir,
+      systemName: requirement.systemName,
+    };
   }
 
   /**

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -115,6 +115,7 @@ beforeEach(() => {
       loadState: vi.fn(),
       screenshot: vi.fn(),
       setWorkerClient: vi.fn(),
+      validateBios: vi.fn(() => ({ valid: true, missingFiles: [], biosDir: '', systemName: '' })),
     });
     return emulatorManagerInstance;
   } as any);

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -55,6 +55,16 @@ export class IPCHandlers {
           throw new Error('Game not found in library');
         }
 
+        // Validate BIOS files before attempting to launch
+        const biosCheck = this.emulatorManager.validateBios(systemId);
+        if (!biosCheck.valid) {
+          const fileList = biosCheck.missingFiles.join(', ');
+          return {
+            success: false,
+            error: `${biosCheck.systemName} requires BIOS files that are missing: ${fileList}. Place them in: ${biosCheck.biosDir}`,
+          };
+        }
+
         // Convert renderer-relative card bounds to screen coordinates
         let cardScreenBounds: { x: number; y: number; width: number; height: number } | undefined;
         if (cardBounds) {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react'
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, WebGLRendererComponent, Game as UiGame, cn, type GameCardMenuItem } from '@gamelord/ui'
+import { AlertDialog, AlertDialogAction, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, WebGLRendererComponent, Game as UiGame, cn, type GameCardMenuItem } from '@gamelord/ui'
 import { useWebGLRenderer } from './hooks/useWebGLRenderer'
 import { useSfx } from './hooks/useSfx'
-import { Check, Monitor, Tv, Sun, Moon, Cpu, Heart, SunMoon } from 'lucide-react'
+import { AlertTriangle, Check, Monitor, Tv, Sun, Moon, Cpu, Heart, SunMoon } from 'lucide-react'
 import { DevAgentation } from './components/DevAgentation'
 import { DevBranchBadge } from './components/DevBranchBadge'
 import { LibraryView } from './components/LibraryView'
@@ -78,6 +78,8 @@ function App() {
   const pendingCardBoundsRef = useRef<CardBounds | null>(null)
   /** Tracks which game is currently being launched (shimmer + disable other cards). */
   const [launchingGameId, setLaunchingGameId] = useState<string | null>(null)
+  /** Error dialog state for launch/IPC failures. */
+  const [launchError, setLaunchError] = useState<string | null>(null)
 
   // Listen for resume game dialog requests from main process
   useEffect(() => {
@@ -159,7 +161,7 @@ function App() {
         if (selectedCore && !selectedCore.installed) {
           const downloadResult = await api.emulator.downloadCore(coreName, systemId)
           if (!downloadResult.success) {
-            alert(`Failed to download core: ${downloadResult.error}`)
+            setLaunchError(downloadResult.error ?? 'Failed to download core')
             setLaunchingGameId(null)
             return
           }
@@ -176,11 +178,11 @@ function App() {
 
       if (!result.success) {
         console.error('Failed to launch emulator:', result.error)
-        alert(`Failed to launch game: ${result.error}`)
+        setLaunchError(result.error ?? 'Failed to launch game')
       }
     } catch (error) {
       console.error('Error launching game:', error)
-      alert(`Error: ${error}`)
+      setLaunchError(error instanceof Error ? error.message : String(error))
     } finally {
       setLaunchingGameId(null)
     }
@@ -233,7 +235,7 @@ function App() {
       })
     } catch (error) {
       console.error('Error launching game:', error)
-      alert(`Error: ${error}`)
+      setLaunchError(error instanceof Error ? error.message : String(error))
       setLaunchingGameId(null)
     }
   }
@@ -446,6 +448,26 @@ function App() {
           </div>
         </div>
       )}
+
+      {/* Launch error dialog */}
+      <AlertDialog open={launchError !== null}>
+        <AlertDialogContent className="sm:max-w-md">
+          <AlertDialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+                <AlertTriangle className="h-5 w-5 text-destructive" />
+              </div>
+              <AlertDialogTitle>Launch Failed</AlertDialogTitle>
+            </div>
+            <AlertDialogDescription className="pt-2">
+              {launchError}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setLaunchError(null)}>OK</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <DevAgentation />
     </div>

--- a/apps/desktop/src/renderer/components/EmulationErrorDialog.tsx
+++ b/apps/desktop/src/renderer/components/EmulationErrorDialog.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@gamelord/ui'
+import { AlertTriangle } from 'lucide-react'
+
+export interface EmulationErrorDialogProps {
+  open: boolean
+  message: string
+  onClose: () => void
+}
+
+/**
+ * Modal dialog shown when the emulation worker encounters a fatal error
+ * (e.g. core crash, BIOS not found, ROM load failure). Gives the user
+ * a clear message and a single action to return to the library.
+ */
+export const EmulationErrorDialog: React.FC<EmulationErrorDialogProps> = ({
+  open,
+  message,
+  onClose,
+}) => {
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/10">
+              <AlertTriangle className="h-5 w-5 text-destructive" />
+            </div>
+            <AlertDialogTitle>Emulation Error</AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="pt-2">
+            The game encountered a fatal error and had to stop.
+          </AlertDialogDescription>
+          {message && (
+            <pre className="mt-2 max-h-24 overflow-auto rounded-md bg-muted p-3 text-left text-xs text-muted-foreground">
+              {message}
+            </pre>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={onClose}>Close</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/desktop/src/renderer/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { AlertTriangle, RotateCcw } from 'lucide-react'
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Top-level error boundary that catches unhandled React errors and displays
+ * a fallback UI instead of a blank white screen. The user can restart the
+ * app (reload the window) to recover.
+ */
+export class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  ErrorBoundaryState
+> {
+  constructor(props: { children: React.ReactNode }) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('Uncaught error in React tree:', error, errorInfo)
+  }
+
+  handleRestart = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-background p-8">
+          <div className="max-w-md text-center">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10">
+              <AlertTriangle className="h-8 w-8 text-destructive" />
+            </div>
+            <h1 className="mb-2 text-xl font-semibold text-foreground">
+              Something went wrong
+            </h1>
+            <p className="mb-6 text-sm text-muted-foreground">
+              An unexpected error occurred. Restarting should fix the problem.
+            </p>
+            {this.state.error && (
+              <pre className="mb-6 max-h-32 overflow-auto rounded-md bg-muted p-3 text-left text-xs text-muted-foreground">
+                {this.state.error.message}
+              </pre>
+            )}
+            <button
+              onClick={this.handleRestart}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              <RotateCcw className="h-4 w-4" />
+              Restart
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -276,6 +276,7 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners('game:prepare-close')
     api.removeAllListeners('game:ready-for-boot')
     api.removeAllListeners('emulator:speedChanged')
+    api.removeAllListeners('game:emulation-error')
 
     // Register for SharedArrayBuffer delivery via MessagePort bridge.
     // The main process sends SABs through a MessagePort because contextBridge

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -28,6 +28,7 @@ import {
   CTRL_AUDIO_SAMPLE_RATE,
 } from '../../main/workers/shared-frame-protocol'
 import { DevBranchBadge } from './DevBranchBadge'
+import { EmulationErrorDialog } from './EmulationErrorDialog'
 import { PowerAnimation } from './animations'
 import { getDisplayType } from '../../types/displayType'
 import { useGamepad } from '../hooks/useGamepad'
@@ -79,6 +80,7 @@ export const GameWindow: React.FC = () => {
   const [fps, setFps] = useState(0)
   const [isPoweringOn, setIsPoweringOn] = useState(false)
   const [isPoweringOff, setIsPoweringOff] = useState(false)
+  const [emulationError, setEmulationError] = useState<string | null>(null)
   const [speedMultiplier, setSpeedMultiplier] = useState(1)
   const [showSpeedMenu, setShowSpeedMenu] = useState(false)
   // The last fast-forward speed the user explicitly chose (persisted).
@@ -323,6 +325,10 @@ export const GameWindow: React.FC = () => {
       setSpeedMultiplier(data.multiplier)
     })
 
+    api.on('game:emulation-error', (data: { message: string }) => {
+      setEmulationError(data.message || 'An unknown error occurred')
+    })
+
     api.on('game:prepare-close', () => {
       setIsPoweringOff(true)
       setShowControls(false)
@@ -459,6 +465,7 @@ export const GameWindow: React.FC = () => {
       api.removeAllListeners('game:prepare-close')
       api.removeAllListeners('game:ready-for-boot')
       api.removeAllListeners('emulator:speedChanged')
+      api.removeAllListeners('game:emulation-error')
 
       cancelAnimationFrame(rafIdRef.current)
       pendingFrameRef.current = null
@@ -1122,6 +1129,15 @@ export const GameWindow: React.FC = () => {
         </div>
       </div>
 
+      {/* Fatal emulation error dialog */}
+      <EmulationErrorDialog
+        open={emulationError !== null}
+        message={emulationError ?? ''}
+        onClose={() => {
+          setEmulationError(null)
+          api.gameWindow.readyToClose()
+        }}
+      />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/game-window.tsx
+++ b/apps/desktop/src/renderer/game-window.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { GameWindow } from './components/GameWindow'
 import { DevAgentation } from './components/DevAgentation'
 import '../game-window.css'
@@ -8,8 +9,10 @@ const rootElement = document.getElementById('root')
 if (rootElement) {
   createRoot(rootElement).render(
     <React.StrictMode>
-      <GameWindow />
-      <DevAgentation />
+      <ErrorBoundary>
+        <GameWindow />
+        <DevAgentation />
+      </ErrorBoundary>
     </React.StrictMode>
   )
 }

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import '../app.css';
 
 // Restore theme preference before React mounts (prevents flash).
@@ -16,6 +17,8 @@ document.documentElement.classList.toggle('dark', shouldBeDark);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary

Adds four error resilience improvements to prevent the "this is broken" feeling during alpha testing:

- **Emulation crash modal:** `GameWindow` listens for `game:emulation-error` IPC events and shows an `AlertDialog` with the error message and a Close button that returns to the library
- **React error boundary:** Both the library window (`main.tsx`) and game window (`game-window.tsx`) are wrapped in an `ErrorBoundary` that catches render crashes and shows a "Something went wrong" fallback with a Restart button
- **BIOS pre-launch validation:** `EmulatorManager.validateBios()` checks for required BIOS files (Saturn, PlayStation) before launch and returns a clear error listing missing files and the target directory
- **IPC error surfacing:** Replaced all `alert()` calls in `App.tsx` with proper `AlertDialog` modals for launch errors

Core download retry (sub-item 4c) will be a separate PR.

Closes #161

## Test plan
- [x] 496 tests pass, including 4 new BIOS validation tests
- [x] Lint and typecheck clean
- [ ] Manual: kill emulation worker mid-game → error modal appears
- [ ] Manual: launch Saturn without BIOS files → validation error with file list
- [ ] Manual: trigger React render crash → error boundary fallback shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)