### PR TITLE
chore: remove all type assertions from codebase

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -69,6 +69,7 @@ apps/desktop/src/preload.ts   - Renderer API bridge
 - [x] Library scanner and game management
 - [x] **Incremental library scan** — Rewrote `scanDirectory` with three optimizations: (1) mtime-based cache skips re-hashing unchanged files (romMtime stored on Game), (2) new-files-first ordering processes unknown ROMs before known ones so new games appear in the UI immediately, (3) streamed progress events (`library:scanProgress`) push each discovered game to the renderer as it's found instead of waiting for the entire scan. Also added parallel hashing (4 files concurrently) and a romPath→gameId reverse index for O(1) lookups. Rescanning 2000+ unchanged ROMs now completes in under a second (stat-only) vs minutes (full hash). Scanning badge shows live progress count.
 - [x] Clean up debug logging from native addon and TypeScript
+- [x] **Remove all type assertions** — Eliminated ~204 `!` non-null assertions and `as any` casts across source and test files. Replaced with guard clauses, `assertDefined()` test helpers, typed mock interfaces, and `as unknown as SpecificType` patterns. Zero eslint warnings remain. — [#173](https://github.com/ryanmagoon/gamelord/issues/173)
 
 ---
 

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.test.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.test.ts
@@ -1,42 +1,40 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { EmulationWorkerClient } from "./EmulationWorkerClient";
-import type { WorkerEvent, AVInfo } from "../workers/core-worker-protocol";
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EmulationWorkerClient } from './EmulationWorkerClient'
+import type { WorkerEvent, AVInfo } from '../workers/core-worker-protocol'
 
 // ---------------------------------------------------------------------------
 // Mock Electron's utilityProcess.fork()
 // ---------------------------------------------------------------------------
 
-const mockPostMessage = vi.fn();
-const mockKill = vi.fn();
-const mockRemoveListener = vi.fn();
+const mockPostMessage = vi.fn()
+const mockKill = vi.fn()
+const mockRemoveListener = vi.fn()
 
 /** Listeners registered via mockProcess.on() */
-let processListeners: Record<string, Array<(...args: Array<unknown>) => void>> = {};
+let processListeners: Record<string, Array<(...args: unknown[]) => void>> = {}
 
 const mockProcess = {
-  kill: mockKill,
-  on: vi.fn((event: string, listener: (...args: Array<unknown>) => void) => {
-    if (!processListeners[event]) {
-      processListeners[event] = [];
-    }
-    processListeners[event].push(listener);
-  }),
   postMessage: mockPostMessage,
+  kill: mockKill,
   removeListener: mockRemoveListener,
-};
+  on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+    if (!processListeners[event]) processListeners[event] = []
+    processListeners[event].push(listener)
+  }),
+}
 
-vi.mock("electron", () => ({
+vi.mock('electron', () => ({
   utilityProcess: {
     fork: vi.fn(() => mockProcess),
   },
-}));
+}))
 
-vi.mock("electron-log/main", () => ({
+vi.mock('electron-log/main', () => ({
   default: {
-    scope: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
     transports: { file: {}, console: {} },
+    scope: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   },
-}));
+}))
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -44,33 +42,33 @@ vi.mock("electron-log/main", () => ({
 
 const TEST_AV_INFO: AVInfo = {
   geometry: {
-    aspectRatio: 1.333,
-    baseHeight: 240,
     baseWidth: 256,
-    maxHeight: 240,
+    baseHeight: 240,
     maxWidth: 256,
+    maxHeight: 240,
+    aspectRatio: 1.333,
   },
   timing: {
     fps: 60.0988,
-    sampleRate: 44_100,
+    sampleRate: 44100,
   },
-};
+}
 
 const TEST_INIT_OPTIONS = {
-  addonPath: "/native/gamelord_libretro.node",
-  corePath: "/cores/fceumm.dylib",
-  romPath: "/roms/zelda.nes",
-  saveDir: "/saves",
-  saveStatesDir: "/savestates",
-  sramDir: "/saves",
-  systemDir: "/bios",
-};
+  corePath: '/cores/fceumm.dylib',
+  romPath: '/roms/zelda.nes',
+  systemDir: '/bios',
+  saveDir: '/saves',
+  sramDir: '/saves',
+  saveStatesDir: '/savestates',
+  addonPath: '/native/gamelord_libretro.node',
+}
 
 /** Simulate the worker sending a message to the main process. */
 function emitWorkerMessage(event: WorkerEvent): void {
-  const listeners = processListeners["message"] ?? [];
+  const listeners = processListeners['message'] ?? []
   for (const listener of listeners) {
-    listener(event);
+    listener(event)
   }
 }
 
@@ -78,446 +76,447 @@ function emitWorkerMessage(event: WorkerEvent): void {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("EmulationWorkerClient", () => {
-  let client: EmulationWorkerClient;
+describe('EmulationWorkerClient', () => {
+  let client: EmulationWorkerClient
 
   beforeEach(() => {
-    vi.useFakeTimers();
-    processListeners = {};
-    mockPostMessage.mockClear();
-    mockKill.mockClear();
-    mockRemoveListener.mockClear();
-    mockProcess.on.mockClear();
-    client = new EmulationWorkerClient();
-  });
+    vi.useFakeTimers()
+    processListeners = {}
+    mockPostMessage.mockClear()
+    mockKill.mockClear()
+    mockRemoveListener.mockClear()
+    mockProcess.on.mockClear()
+    client = new EmulationWorkerClient()
+  })
 
   afterEach(() => {
-    vi.useRealTimers();
-  });
+    vi.useRealTimers()
+  })
 
-  describe("init", () => {
-    it("sends init command and resolves with AV info on ready", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
+  describe('init', () => {
+    it('sends init command and resolves with AV info on ready', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
 
       // Worker responds with ready
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
 
-      const avInfo = await initPromise;
+      const avInfo = await initPromise
 
-      expect(avInfo).toEqual(TEST_AV_INFO);
+      expect(avInfo).toEqual(TEST_AV_INFO)
       expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ action: "init", corePath: TEST_INIT_OPTIONS.corePath }),
-      );
-    });
+        expect.objectContaining({ action: 'init', corePath: TEST_INIT_OPTIONS.corePath }),
+      )
+    })
 
-    it("rejects on fatal error during init", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
+    it('rejects on fatal error during init', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
 
       emitWorkerMessage({
+        type: 'error',
+        message: 'Failed to load core',
         fatal: true,
-        message: "Failed to load core",
-        type: "error",
-      });
+      })
 
-      await expect(initPromise).rejects.toThrow("Failed to load core");
-    });
+      await expect(initPromise).rejects.toThrow('Failed to load core')
+    })
 
-    it("rejects on timeout if worker never becomes ready", async () => {
-      let caughtError: unknown = null;
-      const initPromise = client.init(TEST_INIT_OPTIONS).catch((error: unknown) => {
-        caughtError = error;
-      });
+    it('rejects on timeout if worker never becomes ready', async () => {
+      let caughtError: unknown = null
+      const initPromise = client.init(TEST_INIT_OPTIONS).catch((err: unknown) => {
+        caughtError = err
+      })
 
       // Advance past timeout
-      await vi.advanceTimersByTimeAsync(11_000);
+      await vi.advanceTimersByTimeAsync(11_000)
 
-      await initPromise;
-      expect(caughtError).toBeInstanceOf(Error);
-      expect((caughtError as Error).message).toMatch("did not become ready");
-    });
-  });
+      await initPromise
+      expect(caughtError).toBeInstanceOf(Error)
+      expect(caughtError instanceof Error ? caughtError.message : '').toMatch('did not become ready')
+    })
+  })
 
-  describe("fire-and-forget commands", () => {
+  describe('fire-and-forget commands', () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
-    });
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
+    })
 
-    it("setInput sends input command", () => {
-      client.setInput(0, 3, true);
+    it('setInput sends input command', () => {
+      client.setInput(0, 3, true)
       expect(mockPostMessage).toHaveBeenCalledWith({
-        action: "input",
-        id: 3,
+        action: 'input',
         port: 0,
+        id: 3,
         pressed: true,
-      });
-    });
+      })
+    })
 
-    it("pause sends pause command", () => {
-      client.pause();
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: "pause" });
-    });
+    it('pause sends pause command', () => {
+      client.pause()
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'pause' })
+    })
 
-    it("resume sends resume command", () => {
-      client.resume();
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: "resume" });
-    });
+    it('resume sends resume command', () => {
+      client.resume()
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'resume' })
+    })
 
-    it("reset sends reset command", () => {
-      client.reset();
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: "reset" });
-    });
-  });
+    it('reset sends reset command', () => {
+      client.reset()
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'reset' })
+    })
+  })
 
-  describe("request/response commands", () => {
+  describe('request/response commands', () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
-    });
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
+    })
 
-    it("saveState resolves on success response", async () => {
-      const savePromise = client.saveState(1);
+    it('saveState resolves on success response', async () => {
+      const savePromise = client.saveState(1)
 
       // Extract the requestId from the postMessage call
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
-      expect(lastCall.action).toBe("saveState");
-      expect(lastCall.slot).toBe(1);
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      expect(lastCall.action).toBe('saveState')
+      expect(lastCall.slot).toBe(1)
 
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
+      })
 
-      await expect(savePromise).resolves.toBeUndefined();
-    });
+      await expect(savePromise).resolves.toBeUndefined()
+    })
 
-    it("loadState rejects on error response", async () => {
-      const loadPromise = client.loadState(3);
+    it('loadState rejects on error response', async () => {
+      const loadPromise = client.loadState(3)
 
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
-        error: "No save state in slot 3",
+        type: 'response',
         requestId: lastCall.requestId,
         success: false,
-        type: "response",
-      });
+        error: 'No save state in slot 3',
+      })
 
-      await expect(loadPromise).rejects.toThrow("No save state in slot 3");
-    });
+      await expect(loadPromise).rejects.toThrow('No save state in slot 3')
+    })
 
-    it("saveSram resolves on success", async () => {
-      const sramPromise = client.saveSram();
+    it('saveSram resolves on success', async () => {
+      const sramPromise = client.saveSram()
 
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
+      })
 
-      await expect(sramPromise).resolves.toBeUndefined();
-    });
+      await expect(sramPromise).resolves.toBeUndefined()
+    })
 
-    it("screenshot returns the file path", async () => {
-      const screenshotPromise = client.screenshot("/tmp/shot.raw");
+    it('screenshot returns the file path', async () => {
+      const screenshotPromise = client.screenshot('/tmp/shot.raw')
 
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
-      expect(lastCall.action).toBe("screenshot");
-      expect(lastCall.outputPath).toBe("/tmp/shot.raw");
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      expect(lastCall.action).toBe('screenshot')
+      expect(lastCall.outputPath).toBe('/tmp/shot.raw')
 
       emitWorkerMessage({
-        data: { path: "/tmp/shot.raw" },
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
+        data: { path: '/tmp/shot.raw' },
+      })
 
-      await expect(screenshotPromise).resolves.toBe("/tmp/shot.raw");
-    });
+      await expect(screenshotPromise).resolves.toBe('/tmp/shot.raw')
+    })
 
-    it("request times out after 10 seconds", async () => {
-      let caughtError: unknown = null;
-      const savePromise = client.saveState(0).catch((error: unknown) => {
-        caughtError = error;
-      });
+    it('request times out after 10 seconds', async () => {
+      let caughtError: unknown = null
+      const savePromise = client.saveState(0).catch((err: unknown) => {
+        caughtError = err
+      })
 
       // Don't send a response — let it timeout
-      await vi.advanceTimersByTimeAsync(11_000);
+      await vi.advanceTimersByTimeAsync(11_000)
 
-      await savePromise;
-      expect(caughtError).toBeInstanceOf(Error);
-      expect((caughtError as Error).message).toMatch("timed out");
-    });
-  });
+      await savePromise
+      expect(caughtError).toBeInstanceOf(Error)
+      expect(caughtError instanceof Error ? caughtError.message : '').toMatch('timed out')
+    })
+  })
 
-  describe("event forwarding", () => {
+  describe('event forwarding', () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
-    });
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
+    })
 
-    it("emits videoFrame events from worker", () => {
-      const handler = vi.fn();
-      client.on("videoFrame", handler);
+    it('emits videoFrame events from worker', () => {
+      const handler = vi.fn()
+      client.on('videoFrame', handler)
 
-      const frameData = Buffer.alloc(256 * 240 * 4);
+      const frameData = Buffer.alloc(256 * 240 * 4)
       emitWorkerMessage({
+        type: 'videoFrame',
         data: frameData,
-        height: 240,
-        type: "videoFrame",
         width: 256,
-      });
+        height: 240,
+      })
 
       expect(handler).toHaveBeenCalledWith({
         data: frameData,
-        height: 240,
         width: 256,
-      });
-    });
+        height: 240,
+      })
+    })
 
-    it("emits audioSamples events from worker", () => {
-      const handler = vi.fn();
-      client.on("audioSamples", handler);
+    it('emits audioSamples events from worker', () => {
+      const handler = vi.fn()
+      client.on('audioSamples', handler)
 
-      const samples = Buffer.alloc(1470);
+      const samples = Buffer.alloc(1470)
       emitWorkerMessage({
-        sampleRate: 44_100,
+        type: 'audioSamples',
         samples,
-        type: "audioSamples",
-      });
+        sampleRate: 44100,
+      })
 
       expect(handler).toHaveBeenCalledWith({
-        sampleRate: 44_100,
         samples,
-      });
-    });
+        sampleRate: 44100,
+      })
+    })
 
-    it("emits error events from worker", () => {
-      const handler = vi.fn();
-      client.on("error", handler);
+    it('emits error events from worker', () => {
+      const handler = vi.fn()
+      client.on('error', handler)
 
       emitWorkerMessage({
+        type: 'error',
+        message: 'Emulation crashed',
         fatal: true,
-        message: "Emulation crashed",
-        type: "error",
-      });
+      })
 
       expect(handler).toHaveBeenCalledWith({
+        message: 'Emulation crashed',
         fatal: true,
-        message: "Emulation crashed",
-      });
-    });
-  });
+      })
+    })
+  })
 
-  describe("shutdown", () => {
+  describe('shutdown', () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
-    });
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
+    })
 
-    it("sends shutdown command and resolves on response", async () => {
-      const shutdownPromise = client.shutdown();
+    it('sends shutdown command and resolves on response', async () => {
+      const shutdownPromise = client.shutdown()
 
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
-      expect(lastCall.action).toBe("shutdown");
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      expect(lastCall.action).toBe('shutdown')
 
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
+      })
 
-      await shutdownPromise;
-      expect(client.isRunning()).toBe(false);
-    });
+      await shutdownPromise
+      expect(client.isRunning()).toBe(false)
+    })
 
-    it("force-kills if shutdown times out", async () => {
-      const shutdownPromise = client.shutdown();
+    it('force-kills if shutdown times out', async () => {
+      const shutdownPromise = client.shutdown()
 
       // Don't respond — let it timeout and force kill
-      await vi.advanceTimersByTimeAsync(6000);
+      await vi.advanceTimersByTimeAsync(6_000)
 
-      await shutdownPromise;
-      expect(mockKill).toHaveBeenCalled();
-      expect(client.isRunning()).toBe(false);
-    });
+      await shutdownPromise
+      expect(mockKill).toHaveBeenCalled()
+      expect(client.isRunning()).toBe(false)
+    })
 
-    it("rejects pending requests on cleanup", async () => {
-      const savePromise = client.saveState(1);
+    it('rejects pending requests on cleanup', async () => {
+      const savePromise = client.saveState(1)
 
       // Shutdown before save completes
-      const shutdownPromise = client.shutdown();
+      const shutdownPromise = client.shutdown()
 
-      const shutdownCall = mockPostMessage.mock.calls.at(-1)![0];
+      const shutdownCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
+        type: 'response',
         requestId: shutdownCall.requestId,
         success: true,
-        type: "response",
-      });
+      })
 
-      await shutdownPromise;
+      await shutdownPromise
 
       // The pending saveState should be rejected
-      await expect(savePromise).rejects.toThrow("terminated");
-    });
-  });
+      await expect(savePromise).rejects.toThrow('terminated')
+    })
+  })
 
-  describe("unexpected exit", () => {
+  describe('unexpected exit', () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
-    });
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
+    })
 
-    it("emits error when worker exits while still running", () => {
-      const handler = vi.fn();
-      client.on("error", handler);
+    it('emits error when worker exits while still running', () => {
+      const handler = vi.fn()
+      client.on('error', handler)
 
       // Simulate worker process exiting (e.g. Electron tearing down on quit)
-      const exitListeners = processListeners["exit"] ?? [];
+      const exitListeners = processListeners['exit'] ?? []
       for (const listener of exitListeners) {
-        listener(0);
+        listener(0)
       }
 
       expect(handler).toHaveBeenCalledWith({
+        message: 'Emulation worker exited unexpectedly (code 0)',
         fatal: true,
-        message: "Emulation worker exited unexpectedly (code 0)",
-      });
-      expect(client.isRunning()).toBe(false);
-    });
+      })
+      expect(client.isRunning()).toBe(false)
+    })
 
-    it("does not emit error when worker exits after shutdown", async () => {
-      const handler = vi.fn();
-      client.on("error", handler);
+    it('does not emit error when worker exits after shutdown', async () => {
+      const handler = vi.fn()
+      client.on('error', handler)
 
       // Graceful shutdown first
-      const shutdownPromise = client.shutdown();
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
+      const shutdownPromise = client.shutdown()
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
-      await shutdownPromise;
+      })
+      await shutdownPromise
 
       // Now simulate process exit
-      const exitListeners = processListeners["exit"] ?? [];
+      const exitListeners = processListeners['exit'] ?? []
       for (const listener of exitListeners) {
-        listener(0);
+        listener(0)
       }
 
-      expect(handler).not.toHaveBeenCalled();
-    });
+      expect(handler).not.toHaveBeenCalled()
+    })
 
-    it("does not emit error when prepareForQuit was called before process exits", () => {
-      const handler = vi.fn();
-      client.on("error", handler);
+    it('does not emit error when prepareForQuit was called before process exits', () => {
+      const handler = vi.fn()
+      client.on('error', handler)
 
       // Synchronously suppress errors before async shutdown
-      client.prepareForQuit();
+      client.prepareForQuit()
 
       // Process exits before shutdown() is called (race condition during app quit)
-      const exitListeners = processListeners["exit"] ?? [];
+      const exitListeners = processListeners['exit'] ?? []
       for (const listener of exitListeners) {
-        listener(0);
+        listener(0)
       }
 
-      expect(handler).not.toHaveBeenCalled();
-      expect(client.isRunning()).toBe(false);
-    });
-  });
+      expect(handler).not.toHaveBeenCalled()
+      expect(client.isRunning()).toBe(false)
+    })
+  })
 
-  describe("SharedArrayBuffer allocation", () => {
-    it("allocates SABs and sends setupSharedBuffers command after init", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
+  describe('SharedArrayBuffer allocation', () => {
+    it('allocates SABs and sends setupSharedBuffers command after init', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
 
-      const bufs = client.getSharedBuffers();
-      expect(bufs).not.toBeNull();
-      expect(bufs!.control).toBeInstanceOf(SharedArrayBuffer);
-      expect(bufs!.video).toBeInstanceOf(SharedArrayBuffer);
-      expect(bufs!.audio).toBeInstanceOf(SharedArrayBuffer);
+      const bufs = client.getSharedBuffers()
+      if (!bufs) throw new Error('Expected shared buffers to be allocated')
+      expect(bufs.control).toBeInstanceOf(SharedArrayBuffer)
+      expect(bufs.video).toBeInstanceOf(SharedArrayBuffer)
+      expect(bufs.audio).toBeInstanceOf(SharedArrayBuffer)
 
       // Verify setupSharedBuffers command was sent to the worker
       const setupCall = mockPostMessage.mock.calls.find(
-        (call) => call[0].action === "setupSharedBuffers",
-      );
-      expect(setupCall).toBeDefined();
-      expect(setupCall![0].controlSAB).toBe(bufs!.control);
-      expect(setupCall![0].videoSAB).toBe(bufs!.video);
-      expect(setupCall![0].audioSAB).toBe(bufs!.audio);
-      expect(setupCall![0].videoBufferSize).toBeGreaterThan(0);
-    });
+        (call) => call[0].action === 'setupSharedBuffers',
+      )
+      if (!setupCall) throw new Error('Expected setupSharedBuffers command to be sent')
+      expect(setupCall[0].controlSAB).toBe(bufs.control)
+      expect(setupCall[0].videoSAB).toBe(bufs.video)
+      expect(setupCall[0].audioSAB).toBe(bufs.audio)
+      expect(setupCall[0].videoBufferSize).toBeGreaterThan(0)
+    })
 
-    it("initializes audio sample rate in control buffer", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
+    it('initializes audio sample rate in control buffer', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
 
-      const bufs = client.getSharedBuffers()!;
-      const ctrl = new Int32Array(bufs.control);
+      const bufs = client.getSharedBuffers()
+      if (!bufs) throw new Error('Expected shared buffers to be allocated')
+      const ctrl = new Int32Array(bufs.control)
       // CTRL_AUDIO_SAMPLE_RATE is at index 6
-      expect(Atomics.load(ctrl, 6)).toBe(TEST_AV_INFO.timing.sampleRate);
-    });
+      expect(Atomics.load(ctrl, 6)).toBe(TEST_AV_INFO.timing.sampleRate)
+    })
 
-    it("clears shared buffers on shutdown", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
+    it('clears shared buffers on shutdown', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
 
-      expect(client.getSharedBuffers()).not.toBeNull();
+      expect(client.getSharedBuffers()).not.toBeNull()
 
-      const shutdownPromise = client.shutdown();
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
+      const shutdownPromise = client.shutdown()
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
-      await shutdownPromise;
+      })
+      await shutdownPromise
 
-      expect(client.getSharedBuffers()).toBeNull();
-    });
+      expect(client.getSharedBuffers()).toBeNull()
+    })
 
-    it("returns null for getSharedBuffers before init", () => {
-      expect(client.getSharedBuffers()).toBeNull();
-    });
-  });
+    it('returns null for getSharedBuffers before init', () => {
+      expect(client.getSharedBuffers()).toBeNull()
+    })
+  })
 
-  describe("isRunning", () => {
-    it("returns false before init", () => {
-      expect(client.isRunning()).toBe(false);
-    });
+  describe('isRunning', () => {
+    it('returns false before init', () => {
+      expect(client.isRunning()).toBe(false)
+    })
 
-    it("returns true after init", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
+    it('returns true after init', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
 
-      expect(client.isRunning()).toBe(true);
-    });
+      expect(client.isRunning()).toBe(true)
+    })
 
-    it("returns false after shutdown", async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS);
-      emitWorkerMessage({ avInfo: TEST_AV_INFO, type: "ready" });
-      await initPromise;
+    it('returns false after shutdown', async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS)
+      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      await initPromise
 
-      const shutdownPromise = client.shutdown();
-      const lastCall = mockPostMessage.mock.calls.at(-1)![0];
+      const shutdownPromise = client.shutdown()
+      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
       emitWorkerMessage({
+        type: 'response',
         requestId: lastCall.requestId,
         success: true,
-        type: "response",
-      });
-      await shutdownPromise;
+      })
+      await shutdownPromise
 
-      expect(client.isRunning()).toBe(false);
-    });
-  });
-});
+      expect(client.isRunning()).toBe(false)
+    })
+  })
+})

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.test.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.test.ts
@@ -1,40 +1,52 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { EmulationWorkerClient } from './EmulationWorkerClient'
-import type { WorkerEvent, AVInfo } from '../workers/core-worker-protocol'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EmulationWorkerClient } from "./EmulationWorkerClient";
+import type { WorkerEvent, AVInfo } from "../workers/core-worker-protocol";
 
 // ---------------------------------------------------------------------------
 // Mock Electron's utilityProcess.fork()
 // ---------------------------------------------------------------------------
 
-const mockPostMessage = vi.fn()
-const mockKill = vi.fn()
-const mockRemoveListener = vi.fn()
+const mockPostMessage = vi.fn();
+const mockKill = vi.fn();
+const mockRemoveListener = vi.fn();
+
+/** Return the payload of the most recent postMessage call, throwing if none exists. */
+function lastPostedMessage(): { type: string; requestId: string; [key: string]: unknown } {
+  const calls = mockPostMessage.mock.calls;
+  const last = calls.at(-1);
+  if (!last) {
+    throw new Error("Expected at least one postMessage call");
+  }
+  return last[0] as { type: string; requestId: string; [key: string]: unknown };
+}
 
 /** Listeners registered via mockProcess.on() */
-let processListeners: Record<string, Array<(...args: unknown[]) => void>> = {}
+let processListeners: Record<string, Array<(...args: Array<unknown>) => void>> = {};
 
 const mockProcess = {
   postMessage: mockPostMessage,
   kill: mockKill,
   removeListener: mockRemoveListener,
-  on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
-    if (!processListeners[event]) processListeners[event] = []
-    processListeners[event].push(listener)
+  on: vi.fn((event: string, listener: (...args: Array<unknown>) => void) => {
+    if (!processListeners[event]) {
+      processListeners[event] = [];
+    }
+    processListeners[event].push(listener);
   }),
-}
+};
 
-vi.mock('electron', () => ({
+vi.mock("electron", () => ({
   utilityProcess: {
     fork: vi.fn(() => mockProcess),
   },
-}))
+}));
 
-vi.mock('electron-log/main', () => ({
+vi.mock("electron-log/main", () => ({
   default: {
     transports: { file: {}, console: {} },
     scope: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   },
-}))
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,25 +62,25 @@ const TEST_AV_INFO: AVInfo = {
   },
   timing: {
     fps: 60.0988,
-    sampleRate: 44100,
+    sampleRate: 44_100,
   },
-}
+};
 
 const TEST_INIT_OPTIONS = {
-  corePath: '/cores/fceumm.dylib',
-  romPath: '/roms/zelda.nes',
-  systemDir: '/bios',
-  saveDir: '/saves',
-  sramDir: '/saves',
-  saveStatesDir: '/savestates',
-  addonPath: '/native/gamelord_libretro.node',
-}
+  corePath: "/cores/fceumm.dylib",
+  romPath: "/roms/zelda.nes",
+  systemDir: "/bios",
+  saveDir: "/saves",
+  sramDir: "/saves",
+  saveStatesDir: "/savestates",
+  addonPath: "/native/gamelord_libretro.node",
+};
 
 /** Simulate the worker sending a message to the main process. */
 function emitWorkerMessage(event: WorkerEvent): void {
-  const listeners = processListeners['message'] ?? []
+  const listeners = processListeners["message"] ?? [];
   for (const listener of listeners) {
-    listener(event)
+    listener(event);
   }
 }
 
@@ -76,447 +88,455 @@ function emitWorkerMessage(event: WorkerEvent): void {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('EmulationWorkerClient', () => {
-  let client: EmulationWorkerClient
+describe("EmulationWorkerClient", () => {
+  let client: EmulationWorkerClient;
 
   beforeEach(() => {
-    vi.useFakeTimers()
-    processListeners = {}
-    mockPostMessage.mockClear()
-    mockKill.mockClear()
-    mockRemoveListener.mockClear()
-    mockProcess.on.mockClear()
-    client = new EmulationWorkerClient()
-  })
+    vi.useFakeTimers();
+    processListeners = {};
+    mockPostMessage.mockClear();
+    mockKill.mockClear();
+    mockRemoveListener.mockClear();
+    mockProcess.on.mockClear();
+    client = new EmulationWorkerClient();
+  });
 
   afterEach(() => {
-    vi.useRealTimers()
-  })
+    vi.useRealTimers();
+  });
 
-  describe('init', () => {
-    it('sends init command and resolves with AV info on ready', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
+  describe("init", () => {
+    it("sends init command and resolves with AV info on ready", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
 
       // Worker responds with ready
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
 
-      const avInfo = await initPromise
+      const avInfo = await initPromise;
 
-      expect(avInfo).toEqual(TEST_AV_INFO)
+      expect(avInfo).toEqual(TEST_AV_INFO);
       expect(mockPostMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'init', corePath: TEST_INIT_OPTIONS.corePath }),
-      )
-    })
+        expect.objectContaining({ action: "init", corePath: TEST_INIT_OPTIONS.corePath }),
+      );
+    });
 
-    it('rejects on fatal error during init', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
+    it("rejects on fatal error during init", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
 
       emitWorkerMessage({
-        type: 'error',
-        message: 'Failed to load core',
+        type: "error",
+        message: "Failed to load core",
         fatal: true,
-      })
+      });
 
-      await expect(initPromise).rejects.toThrow('Failed to load core')
-    })
+      await expect(initPromise).rejects.toThrow("Failed to load core");
+    });
 
-    it('rejects on timeout if worker never becomes ready', async () => {
-      let caughtError: unknown = null
-      const initPromise = client.init(TEST_INIT_OPTIONS).catch((err: unknown) => {
-        caughtError = err
-      })
+    it("rejects on timeout if worker never becomes ready", async () => {
+      let caughtError: unknown = null;
+      const initPromise = client.init(TEST_INIT_OPTIONS).catch((error: unknown) => {
+        caughtError = error;
+      });
 
       // Advance past timeout
-      await vi.advanceTimersByTimeAsync(11_000)
+      await vi.advanceTimersByTimeAsync(11_000);
 
-      await initPromise
-      expect(caughtError).toBeInstanceOf(Error)
-      expect(caughtError instanceof Error ? caughtError.message : '').toMatch('did not become ready')
-    })
-  })
+      await initPromise;
+      expect(caughtError).toBeInstanceOf(Error);
+      expect(caughtError instanceof Error ? caughtError.message : "").toMatch(
+        "did not become ready",
+      );
+    });
+  });
 
-  describe('fire-and-forget commands', () => {
+  describe("fire-and-forget commands", () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
-    })
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
+    });
 
-    it('setInput sends input command', () => {
-      client.setInput(0, 3, true)
+    it("setInput sends input command", () => {
+      client.setInput(0, 3, true);
       expect(mockPostMessage).toHaveBeenCalledWith({
-        action: 'input',
+        action: "input",
         port: 0,
         id: 3,
         pressed: true,
-      })
-    })
+      });
+    });
 
-    it('pause sends pause command', () => {
-      client.pause()
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'pause' })
-    })
+    it("pause sends pause command", () => {
+      client.pause();
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: "pause" });
+    });
 
-    it('resume sends resume command', () => {
-      client.resume()
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'resume' })
-    })
+    it("resume sends resume command", () => {
+      client.resume();
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: "resume" });
+    });
 
-    it('reset sends reset command', () => {
-      client.reset()
-      expect(mockPostMessage).toHaveBeenCalledWith({ action: 'reset' })
-    })
-  })
+    it("reset sends reset command", () => {
+      client.reset();
+      expect(mockPostMessage).toHaveBeenCalledWith({ action: "reset" });
+    });
+  });
 
-  describe('request/response commands', () => {
+  describe("request/response commands", () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
-    })
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
+    });
 
-    it('saveState resolves on success response', async () => {
-      const savePromise = client.saveState(1)
+    it("saveState resolves on success response", async () => {
+      const savePromise = client.saveState(1);
 
       // Extract the requestId from the postMessage call
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
-      expect(lastCall.action).toBe('saveState')
-      expect(lastCall.slot).toBe(1)
+      const lastCall = lastPostedMessage();
+      expect(lastCall.action).toBe("saveState");
+      expect(lastCall.slot).toBe(1);
 
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
+      });
 
-      await expect(savePromise).resolves.toBeUndefined()
-    })
+      await expect(savePromise).resolves.toBeUndefined();
+    });
 
-    it('loadState rejects on error response', async () => {
-      const loadPromise = client.loadState(3)
+    it("loadState rejects on error response", async () => {
+      const loadPromise = client.loadState(3);
 
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const lastCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: false,
-        error: 'No save state in slot 3',
-      })
+        error: "No save state in slot 3",
+      });
 
-      await expect(loadPromise).rejects.toThrow('No save state in slot 3')
-    })
+      await expect(loadPromise).rejects.toThrow("No save state in slot 3");
+    });
 
-    it('saveSram resolves on success', async () => {
-      const sramPromise = client.saveSram()
+    it("saveSram resolves on success", async () => {
+      const sramPromise = client.saveSram();
 
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const lastCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
+      });
 
-      await expect(sramPromise).resolves.toBeUndefined()
-    })
+      await expect(sramPromise).resolves.toBeUndefined();
+    });
 
-    it('screenshot returns the file path', async () => {
-      const screenshotPromise = client.screenshot('/tmp/shot.raw')
+    it("screenshot returns the file path", async () => {
+      const screenshotPromise = client.screenshot("/tmp/shot.raw");
 
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
-      expect(lastCall.action).toBe('screenshot')
-      expect(lastCall.outputPath).toBe('/tmp/shot.raw')
+      const lastCall = lastPostedMessage();
+      expect(lastCall.action).toBe("screenshot");
+      expect(lastCall.outputPath).toBe("/tmp/shot.raw");
 
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-        data: { path: '/tmp/shot.raw' },
-      })
+        data: { path: "/tmp/shot.raw" },
+      });
 
-      await expect(screenshotPromise).resolves.toBe('/tmp/shot.raw')
-    })
+      await expect(screenshotPromise).resolves.toBe("/tmp/shot.raw");
+    });
 
-    it('request times out after 10 seconds', async () => {
-      let caughtError: unknown = null
-      const savePromise = client.saveState(0).catch((err: unknown) => {
-        caughtError = err
-      })
+    it("request times out after 10 seconds", async () => {
+      let caughtError: unknown = null;
+      const savePromise = client.saveState(0).catch((error: unknown) => {
+        caughtError = error;
+      });
 
       // Don't send a response — let it timeout
-      await vi.advanceTimersByTimeAsync(11_000)
+      await vi.advanceTimersByTimeAsync(11_000);
 
-      await savePromise
-      expect(caughtError).toBeInstanceOf(Error)
-      expect(caughtError instanceof Error ? caughtError.message : '').toMatch('timed out')
-    })
-  })
+      await savePromise;
+      expect(caughtError).toBeInstanceOf(Error);
+      expect(caughtError instanceof Error ? caughtError.message : "").toMatch("timed out");
+    });
+  });
 
-  describe('event forwarding', () => {
+  describe("event forwarding", () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
-    })
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
+    });
 
-    it('emits videoFrame events from worker', () => {
-      const handler = vi.fn()
-      client.on('videoFrame', handler)
+    it("emits videoFrame events from worker", () => {
+      const handler = vi.fn();
+      client.on("videoFrame", handler);
 
-      const frameData = Buffer.alloc(256 * 240 * 4)
+      const frameData = Buffer.alloc(256 * 240 * 4);
       emitWorkerMessage({
-        type: 'videoFrame',
+        type: "videoFrame",
         data: frameData,
         width: 256,
         height: 240,
-      })
+      });
 
       expect(handler).toHaveBeenCalledWith({
         data: frameData,
         width: 256,
         height: 240,
-      })
-    })
+      });
+    });
 
-    it('emits audioSamples events from worker', () => {
-      const handler = vi.fn()
-      client.on('audioSamples', handler)
+    it("emits audioSamples events from worker", () => {
+      const handler = vi.fn();
+      client.on("audioSamples", handler);
 
-      const samples = Buffer.alloc(1470)
+      const samples = Buffer.alloc(1470);
       emitWorkerMessage({
-        type: 'audioSamples',
+        type: "audioSamples",
         samples,
-        sampleRate: 44100,
-      })
+        sampleRate: 44_100,
+      });
 
       expect(handler).toHaveBeenCalledWith({
         samples,
-        sampleRate: 44100,
-      })
-    })
+        sampleRate: 44_100,
+      });
+    });
 
-    it('emits error events from worker', () => {
-      const handler = vi.fn()
-      client.on('error', handler)
+    it("emits error events from worker", () => {
+      const handler = vi.fn();
+      client.on("error", handler);
 
       emitWorkerMessage({
-        type: 'error',
-        message: 'Emulation crashed',
+        type: "error",
+        message: "Emulation crashed",
         fatal: true,
-      })
+      });
 
       expect(handler).toHaveBeenCalledWith({
-        message: 'Emulation crashed',
+        message: "Emulation crashed",
         fatal: true,
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('shutdown', () => {
+  describe("shutdown", () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
-    })
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
+    });
 
-    it('sends shutdown command and resolves on response', async () => {
-      const shutdownPromise = client.shutdown()
+    it("sends shutdown command and resolves on response", async () => {
+      const shutdownPromise = client.shutdown();
 
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
-      expect(lastCall.action).toBe('shutdown')
+      const lastCall = lastPostedMessage();
+      expect(lastCall.action).toBe("shutdown");
 
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
+      });
 
-      await shutdownPromise
-      expect(client.isRunning()).toBe(false)
-    })
+      await shutdownPromise;
+      expect(client.isRunning()).toBe(false);
+    });
 
-    it('force-kills if shutdown times out', async () => {
-      const shutdownPromise = client.shutdown()
+    it("force-kills if shutdown times out", async () => {
+      const shutdownPromise = client.shutdown();
 
       // Don't respond — let it timeout and force kill
-      await vi.advanceTimersByTimeAsync(6_000)
+      await vi.advanceTimersByTimeAsync(6000);
 
-      await shutdownPromise
-      expect(mockKill).toHaveBeenCalled()
-      expect(client.isRunning()).toBe(false)
-    })
+      await shutdownPromise;
+      expect(mockKill).toHaveBeenCalled();
+      expect(client.isRunning()).toBe(false);
+    });
 
-    it('rejects pending requests on cleanup', async () => {
-      const savePromise = client.saveState(1)
+    it("rejects pending requests on cleanup", async () => {
+      const savePromise = client.saveState(1);
 
       // Shutdown before save completes
-      const shutdownPromise = client.shutdown()
+      const shutdownPromise = client.shutdown();
 
-      const shutdownCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const shutdownCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: shutdownCall.requestId,
         success: true,
-      })
+      });
 
-      await shutdownPromise
+      await shutdownPromise;
 
       // The pending saveState should be rejected
-      await expect(savePromise).rejects.toThrow('terminated')
-    })
-  })
+      await expect(savePromise).rejects.toThrow("terminated");
+    });
+  });
 
-  describe('unexpected exit', () => {
+  describe("unexpected exit", () => {
     beforeEach(async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
-    })
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
+    });
 
-    it('emits error when worker exits while still running', () => {
-      const handler = vi.fn()
-      client.on('error', handler)
+    it("emits error when worker exits while still running", () => {
+      const handler = vi.fn();
+      client.on("error", handler);
 
       // Simulate worker process exiting (e.g. Electron tearing down on quit)
-      const exitListeners = processListeners['exit'] ?? []
+      const exitListeners = processListeners["exit"] ?? [];
       for (const listener of exitListeners) {
-        listener(0)
+        listener(0);
       }
 
       expect(handler).toHaveBeenCalledWith({
-        message: 'Emulation worker exited unexpectedly (code 0)',
+        message: "Emulation worker exited unexpectedly (code 0)",
         fatal: true,
-      })
-      expect(client.isRunning()).toBe(false)
-    })
+      });
+      expect(client.isRunning()).toBe(false);
+    });
 
-    it('does not emit error when worker exits after shutdown', async () => {
-      const handler = vi.fn()
-      client.on('error', handler)
+    it("does not emit error when worker exits after shutdown", async () => {
+      const handler = vi.fn();
+      client.on("error", handler);
 
       // Graceful shutdown first
-      const shutdownPromise = client.shutdown()
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const shutdownPromise = client.shutdown();
+      const lastCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
-      await shutdownPromise
+      });
+      await shutdownPromise;
 
       // Now simulate process exit
-      const exitListeners = processListeners['exit'] ?? []
+      const exitListeners = processListeners["exit"] ?? [];
       for (const listener of exitListeners) {
-        listener(0)
+        listener(0);
       }
 
-      expect(handler).not.toHaveBeenCalled()
-    })
+      expect(handler).not.toHaveBeenCalled();
+    });
 
-    it('does not emit error when prepareForQuit was called before process exits', () => {
-      const handler = vi.fn()
-      client.on('error', handler)
+    it("does not emit error when prepareForQuit was called before process exits", () => {
+      const handler = vi.fn();
+      client.on("error", handler);
 
       // Synchronously suppress errors before async shutdown
-      client.prepareForQuit()
+      client.prepareForQuit();
 
       // Process exits before shutdown() is called (race condition during app quit)
-      const exitListeners = processListeners['exit'] ?? []
+      const exitListeners = processListeners["exit"] ?? [];
       for (const listener of exitListeners) {
-        listener(0)
+        listener(0);
       }
 
-      expect(handler).not.toHaveBeenCalled()
-      expect(client.isRunning()).toBe(false)
-    })
-  })
+      expect(handler).not.toHaveBeenCalled();
+      expect(client.isRunning()).toBe(false);
+    });
+  });
 
-  describe('SharedArrayBuffer allocation', () => {
-    it('allocates SABs and sends setupSharedBuffers command after init', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
+  describe("SharedArrayBuffer allocation", () => {
+    it("allocates SABs and sends setupSharedBuffers command after init", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
 
-      const bufs = client.getSharedBuffers()
-      if (!bufs) throw new Error('Expected shared buffers to be allocated')
-      expect(bufs.control).toBeInstanceOf(SharedArrayBuffer)
-      expect(bufs.video).toBeInstanceOf(SharedArrayBuffer)
-      expect(bufs.audio).toBeInstanceOf(SharedArrayBuffer)
+      const bufs = client.getSharedBuffers();
+      if (!bufs) {
+        throw new Error("Expected shared buffers to be allocated");
+      }
+      expect(bufs.control).toBeInstanceOf(SharedArrayBuffer);
+      expect(bufs.video).toBeInstanceOf(SharedArrayBuffer);
+      expect(bufs.audio).toBeInstanceOf(SharedArrayBuffer);
 
       // Verify setupSharedBuffers command was sent to the worker
       const setupCall = mockPostMessage.mock.calls.find(
-        (call) => call[0].action === 'setupSharedBuffers',
-      )
-      if (!setupCall) throw new Error('Expected setupSharedBuffers command to be sent')
-      expect(setupCall[0].controlSAB).toBe(bufs.control)
-      expect(setupCall[0].videoSAB).toBe(bufs.video)
-      expect(setupCall[0].audioSAB).toBe(bufs.audio)
-      expect(setupCall[0].videoBufferSize).toBeGreaterThan(0)
-    })
+        (call) => call[0].action === "setupSharedBuffers",
+      );
+      if (!setupCall) {
+        throw new Error("Expected setupSharedBuffers command to be sent");
+      }
+      expect(setupCall[0].controlSAB).toBe(bufs.control);
+      expect(setupCall[0].videoSAB).toBe(bufs.video);
+      expect(setupCall[0].audioSAB).toBe(bufs.audio);
+      expect(setupCall[0].videoBufferSize).toBeGreaterThan(0);
+    });
 
-    it('initializes audio sample rate in control buffer', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
+    it("initializes audio sample rate in control buffer", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
 
-      const bufs = client.getSharedBuffers()
-      if (!bufs) throw new Error('Expected shared buffers to be allocated')
-      const ctrl = new Int32Array(bufs.control)
+      const bufs = client.getSharedBuffers();
+      if (!bufs) {
+        throw new Error("Expected shared buffers to be allocated");
+      }
+      const ctrl = new Int32Array(bufs.control);
       // CTRL_AUDIO_SAMPLE_RATE is at index 6
-      expect(Atomics.load(ctrl, 6)).toBe(TEST_AV_INFO.timing.sampleRate)
-    })
+      expect(Atomics.load(ctrl, 6)).toBe(TEST_AV_INFO.timing.sampleRate);
+    });
 
-    it('clears shared buffers on shutdown', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
+    it("clears shared buffers on shutdown", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
 
-      expect(client.getSharedBuffers()).not.toBeNull()
+      expect(client.getSharedBuffers()).not.toBeNull();
 
-      const shutdownPromise = client.shutdown()
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const shutdownPromise = client.shutdown();
+      const lastCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
-      await shutdownPromise
+      });
+      await shutdownPromise;
 
-      expect(client.getSharedBuffers()).toBeNull()
-    })
+      expect(client.getSharedBuffers()).toBeNull();
+    });
 
-    it('returns null for getSharedBuffers before init', () => {
-      expect(client.getSharedBuffers()).toBeNull()
-    })
-  })
+    it("returns null for getSharedBuffers before init", () => {
+      expect(client.getSharedBuffers()).toBeNull();
+    });
+  });
 
-  describe('isRunning', () => {
-    it('returns false before init', () => {
-      expect(client.isRunning()).toBe(false)
-    })
+  describe("isRunning", () => {
+    it("returns false before init", () => {
+      expect(client.isRunning()).toBe(false);
+    });
 
-    it('returns true after init', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
+    it("returns true after init", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
 
-      expect(client.isRunning()).toBe(true)
-    })
+      expect(client.isRunning()).toBe(true);
+    });
 
-    it('returns false after shutdown', async () => {
-      const initPromise = client.init(TEST_INIT_OPTIONS)
-      emitWorkerMessage({ type: 'ready', avInfo: TEST_AV_INFO })
-      await initPromise
+    it("returns false after shutdown", async () => {
+      const initPromise = client.init(TEST_INIT_OPTIONS);
+      emitWorkerMessage({ type: "ready", avInfo: TEST_AV_INFO });
+      await initPromise;
 
-      const shutdownPromise = client.shutdown()
-      const lastCall = mockPostMessage.mock.calls[mockPostMessage.mock.calls.length - 1][0]
+      const shutdownPromise = client.shutdown();
+      const lastCall = lastPostedMessage();
       emitWorkerMessage({
-        type: 'response',
+        type: "response",
         requestId: lastCall.requestId,
         success: true,
-      })
-      await shutdownPromise
+      });
+      await shutdownPromise;
 
-      expect(client.isRunning()).toBe(false)
-    })
-  })
-})
+      expect(client.isRunning()).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/main/emulator/EmulatorManager.test.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.test.ts
@@ -14,7 +14,7 @@ vi.mock('electron', () => ({
   },
 }))
 
-vi.mock('fs', () => ({
+vi.mock('node:fs', () => ({
   existsSync: vi.fn(() => false),
   readdirSync: vi.fn(() => []),
   mkdirSync: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('./LibretroNativeCore', async () => {
 vi.mock('./EmulationWorkerClient')
 
 import { powerSaveBlocker } from 'electron'
-import * as fs from 'fs'
+import * as fs from 'node:fs'
 import { EmulatorManager } from './EmulatorManager'
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/emulator/EmulatorManager.test.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.test.ts
@@ -1,177 +1,193 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // --- Module mocks (hoisted before imports) ---
 
-vi.mock('electron', () => ({
+vi.mock("electron", () => ({
   powerSaveBlocker: {
     start: vi.fn(() => 42),
     stop: vi.fn(),
     isStarted: vi.fn(() => true),
   },
   app: {
-    getPath: vi.fn(() => '/tmp/test'),
-    getAppPath: vi.fn(() => '/tmp/test-app'),
+    getPath: vi.fn(() => "/tmp/test"),
+    getAppPath: vi.fn(() => "/tmp/test-app"),
   },
-}))
+}));
 
-vi.mock('node:fs', () => ({
+vi.mock("node:fs", () => ({
   existsSync: vi.fn(() => false),
   readdirSync: vi.fn(() => []),
   mkdirSync: vi.fn(),
-}))
+}));
 
-vi.mock('os', () => ({
-  homedir: vi.fn(() => '/home/test'),
-}))
+vi.mock("os", () => ({
+  homedir: vi.fn(() => "/home/test"),
+}));
 
-vi.mock('./CoreDownloader', async () => {
-  const { EventEmitter } = await import('events')
+vi.mock("./CoreDownloader", async () => {
+  const { EventEmitter } = await import("node:events");
   class FakeCoreDownloader extends EventEmitter {
-    getCoresDirectory() { return '/tmp/cores' }
-    getCoresForSystem() { return [] }
-    getCorePath() { return '/tmp/cores/test_libretro.dylib' }
-    async downloadCore() { return '/tmp/cores/test_libretro.dylib' }
-    async downloadCoreForSystem() { return '/tmp/cores/test_libretro.dylib' }
+    getCoresDirectory() {
+      return "/tmp/cores";
+    }
+    getCoresForSystem() {
+      return [];
+    }
+    getCorePath() {
+      return "/tmp/cores/test_libretro.dylib";
+    }
+    async downloadCore() {
+      return "/tmp/cores/test_libretro.dylib";
+    }
+    async downloadCoreForSystem() {
+      return "/tmp/cores/test_libretro.dylib";
+    }
   }
-  return { CoreDownloader: FakeCoreDownloader }
-})
+  return { CoreDownloader: FakeCoreDownloader };
+});
 
-vi.mock('./RetroArchCore')
-vi.mock('./LibretroNativeCore', async () => {
-  const { EventEmitter } = await import('events')
+vi.mock("./RetroArchCore");
+vi.mock("./LibretroNativeCore", async () => {
+  const { EventEmitter } = await import("node:events");
   class FakeLibretroNativeCore extends EventEmitter {
-    isActive() { return false }
-    async launch() { /* no-op */ }
-    async terminate() { /* no-op */ }
+    isActive() {
+      return false;
+    }
+    async launch() {
+      /* no-op */
+    }
+    async terminate() {
+      /* no-op */
+    }
   }
-  return { LibretroNativeCore: FakeLibretroNativeCore }
-})
+  return { LibretroNativeCore: FakeLibretroNativeCore };
+});
 
-vi.mock('./EmulationWorkerClient')
+vi.mock("./EmulationWorkerClient");
 
-import { powerSaveBlocker } from 'electron'
-import * as fs from 'node:fs'
-import { EmulatorManager } from './EmulatorManager'
+import { powerSaveBlocker } from "electron";
+import * as fs from "node:fs";
+import { EmulatorManager } from "./EmulatorManager";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function internals(mgr: EmulatorManager) {
-  return mgr as unknown as Record<string, unknown>
+  return mgr as unknown as Record<string, unknown>;
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('EmulatorManager — power save blocker', () => {
-  let manager: EmulatorManager
+describe("EmulatorManager — power save blocker", () => {
+  let manager: EmulatorManager;
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    vi.mocked(powerSaveBlocker.start).mockReturnValue(42)
-    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(true)
-    manager = new EmulatorManager()
-  })
+    vi.clearAllMocks();
+    vi.mocked(powerSaveBlocker.start).mockReturnValue(42);
+    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(true);
+    manager = new EmulatorManager();
+  });
 
-  it('starts a power save blocker when launching a game', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
+  it("starts a power save blocker when launching a game", async () => {
+    await manager.launchGame("/rom.nes", "nes");
 
-    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-display-sleep')
-    expect(internals(manager).powerSaveBlockerId).toBe(42)
-  })
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith("prevent-display-sleep");
+    expect(internals(manager).powerSaveBlockerId).toBe(42);
+  });
 
-  it('stops the power save blocker when stopping the emulator', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
-    await manager.stopEmulator()
+  it("stops the power save blocker when stopping the emulator", async () => {
+    await manager.launchGame("/rom.nes", "nes");
+    await manager.stopEmulator();
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
-    expect(internals(manager).powerSaveBlockerId).toBeNull()
-  })
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
+    expect(internals(manager).powerSaveBlockerId).toBeNull();
+  });
 
-  it('does not start duplicate blockers on consecutive launches', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
-    await manager.launchGame('/rom2.nes', 'nes')
+  it("does not start duplicate blockers on consecutive launches", async () => {
+    await manager.launchGame("/rom.nes", "nes");
+    await manager.launchGame("/rom2.nes", "nes");
 
     // start is called once; the second launch sees the existing blocker
-    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1)
-  })
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
+  });
 
-  it('handles stopEmulator gracefully when no blocker is active', async () => {
-    await manager.stopEmulator()
+  it("handles stopEmulator gracefully when no blocker is active", async () => {
+    await manager.stopEmulator();
 
-    expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
-  })
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+  });
 
   it('releases the blocker when the emulator emits "exited"', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
-    const emulator = internals(manager).currentEmulator as import('events').EventEmitter
-    emulator.emit('exited', { code: 0 })
+    await manager.launchGame("/rom.nes", "nes");
+    const emulator = internals(manager).currentEmulator as import("events").EventEmitter;
+    emulator.emit("exited", { code: 0 });
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
-    expect(internals(manager).powerSaveBlockerId).toBeNull()
-  })
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
+    expect(internals(manager).powerSaveBlockerId).toBeNull();
+  });
 
   it('releases the blocker when the emulator emits "terminated"', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
-    const emulator = internals(manager).currentEmulator as import('events').EventEmitter
-    emulator.emit('terminated')
+    await manager.launchGame("/rom.nes", "nes");
+    const emulator = internals(manager).currentEmulator as import("events").EventEmitter;
+    emulator.emit("terminated");
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
-    expect(internals(manager).powerSaveBlockerId).toBeNull()
-  })
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
+    expect(internals(manager).powerSaveBlockerId).toBeNull();
+  });
 
-  it('handles already-stopped blocker gracefully', async () => {
-    await manager.launchGame('/rom.nes', 'nes')
+  it("handles already-stopped blocker gracefully", async () => {
+    await manager.launchGame("/rom.nes", "nes");
 
     // Simulate the blocker having been stopped externally
-    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(false)
+    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(false);
 
-    await manager.stopEmulator()
+    await manager.stopEmulator();
 
     // stop() should not be called since isStarted returned false
-    expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
-    expect(internals(manager).powerSaveBlockerId).toBeNull()
-  })
-})
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
+    expect(internals(manager).powerSaveBlockerId).toBeNull();
+  });
+});
 
-describe('EmulatorManager — BIOS validation', () => {
-  let manager: EmulatorManager
+describe("EmulatorManager — BIOS validation", () => {
+  let manager: EmulatorManager;
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    manager = new EmulatorManager()
-  })
+    vi.clearAllMocks();
+    manager = new EmulatorManager();
+  });
 
-  it('returns valid for systems without BIOS requirements', () => {
-    const result = manager.validateBios('nes')
-    expect(result.valid).toBe(true)
-    expect(result.missingFiles).toEqual([])
-  })
+  it("returns valid for systems without BIOS requirements", () => {
+    const result = manager.validateBios("nes");
+    expect(result.valid).toBe(true);
+    expect(result.missingFiles).toEqual([]);
+  });
 
-  it('returns valid when all BIOS files exist', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true)
-    const result = manager.validateBios('saturn')
-    expect(result.valid).toBe(true)
-    expect(result.missingFiles).toEqual([])
-  })
+  it("returns valid when all BIOS files exist", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const result = manager.validateBios("saturn");
+    expect(result.valid).toBe(true);
+    expect(result.missingFiles).toEqual([]);
+  });
 
-  it('returns missing files when BIOS files are absent', () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false)
-    const result = manager.validateBios('saturn')
-    expect(result.valid).toBe(false)
-    expect(result.missingFiles).toEqual(['sega_101.bin', 'mpr-17933.bin'])
-    expect(result.systemName).toBe('Sega Saturn')
-    expect(result.biosDir).toContain('BIOS')
-  })
+  it("returns missing files when BIOS files are absent", () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    const result = manager.validateBios("saturn");
+    expect(result.valid).toBe(false);
+    expect(result.missingFiles).toEqual(["sega_101.bin", "mpr-17933.bin"]);
+    expect(result.systemName).toBe("Sega Saturn");
+    expect(result.biosDir).toContain("BIOS");
+  });
 
-  it('detects partial BIOS files', () => {
+  it("detects partial BIOS files", () => {
     vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) =>
-      String(p).endsWith('sega_101.bin')
-    )
-    const result = manager.validateBios('saturn')
-    expect(result.valid).toBe(false)
-    expect(result.missingFiles).toEqual(['mpr-17933.bin'])
-  })
-})
+      String(p).endsWith("sega_101.bin"),
+    );
+    const result = manager.validateBios("saturn");
+    expect(result.valid).toBe(false);
+    expect(result.missingFiles).toEqual(["mpr-17933.bin"]);
+  });
+});

--- a/apps/desktop/src/main/emulator/EmulatorManager.test.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.test.ts
@@ -1,191 +1,177 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // --- Module mocks (hoisted before imports) ---
 
-vi.mock("electron", () => ({
-  app: {
-    getPath: vi.fn(() => "/tmp/test"),
-    getAppPath: vi.fn(() => "/tmp/test-app"),
-  },
+vi.mock('electron', () => ({
   powerSaveBlocker: {
     start: vi.fn(() => 42),
     stop: vi.fn(),
     isStarted: vi.fn(() => true),
   },
-}));
+  app: {
+    getPath: vi.fn(() => '/tmp/test'),
+    getAppPath: vi.fn(() => '/tmp/test-app'),
+  },
+}))
 
-vi.mock("node:fs", () => ({
+vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
-  mkdirSync: vi.fn(),
   readdirSync: vi.fn(() => []),
-}));
+  mkdirSync: vi.fn(),
+}))
 
-vi.mock("node:os", () => ({
-  homedir: vi.fn(() => "/home/test"),
-}));
+vi.mock('os', () => ({
+  homedir: vi.fn(() => '/home/test'),
+}))
 
-vi.mock("./CoreDownloader", async () => {
-  const { EventEmitter } = await import("node:events");
+vi.mock('./CoreDownloader', async () => {
+  const { EventEmitter } = await import('events')
   class FakeCoreDownloader extends EventEmitter {
-    getCoresDirectory() {
-      return "/tmp/cores";
-    }
-    getCoresForSystem() {
-      return [];
-    }
-    getCorePath() {
-      return "/tmp/cores/test_libretro.dylib";
-    }
-    async downloadCore() {
-      return "/tmp/cores/test_libretro.dylib";
-    }
-    async downloadCoreForSystem() {
-      return "/tmp/cores/test_libretro.dylib";
-    }
+    getCoresDirectory() { return '/tmp/cores' }
+    getCoresForSystem() { return [] }
+    getCorePath() { return '/tmp/cores/test_libretro.dylib' }
+    async downloadCore() { return '/tmp/cores/test_libretro.dylib' }
+    async downloadCoreForSystem() { return '/tmp/cores/test_libretro.dylib' }
   }
-  return { CoreDownloader: FakeCoreDownloader };
-});
+  return { CoreDownloader: FakeCoreDownloader }
+})
 
-vi.mock("./RetroArchCore");
-vi.mock("./LibretroNativeCore", async () => {
-  const { EventEmitter } = await import("node:events");
+vi.mock('./RetroArchCore')
+vi.mock('./LibretroNativeCore', async () => {
+  const { EventEmitter } = await import('events')
   class FakeLibretroNativeCore extends EventEmitter {
-    isActive() {
-      return false;
-    }
-    async launch() {
-      /* no-op */
-    }
-    async terminate() {
-      /* no-op */
-    }
+    isActive() { return false }
+    async launch() { /* no-op */ }
+    async terminate() { /* no-op */ }
   }
-  return { LibretroNativeCore: FakeLibretroNativeCore };
-});
+  return { LibretroNativeCore: FakeLibretroNativeCore }
+})
 
-vi.mock("./EmulationWorkerClient");
+vi.mock('./EmulationWorkerClient')
 
-import { powerSaveBlocker } from "electron";
-import * as fs from "node:fs";
-import { EmulatorManager } from "./EmulatorManager";
+import { powerSaveBlocker } from 'electron'
+import * as fs from 'fs'
+import { EmulatorManager } from './EmulatorManager'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function internals(mgr: EmulatorManager) {
-  return mgr as unknown as Record<string, unknown>;
+  return mgr as unknown as Record<string, unknown>
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("EmulatorManager — power save blocker", () => {
-  let manager: EmulatorManager;
+describe('EmulatorManager — power save blocker', () => {
+  let manager: EmulatorManager
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(powerSaveBlocker.start).mockReturnValue(42);
-    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(true);
-    manager = new EmulatorManager();
-  });
+    vi.clearAllMocks()
+    vi.mocked(powerSaveBlocker.start).mockReturnValue(42)
+    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(true)
+    manager = new EmulatorManager()
+  })
 
-  it("starts a power save blocker when launching a game", async () => {
-    await manager.launchGame("/rom.nes", "nes");
+  it('starts a power save blocker when launching a game', async () => {
+    await manager.launchGame('/rom.nes', 'nes')
 
-    expect(powerSaveBlocker.start).toHaveBeenCalledWith("prevent-display-sleep");
-    expect(internals(manager).powerSaveBlockerId).toBe(42);
-  });
+    expect(powerSaveBlocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+    expect(internals(manager).powerSaveBlockerId).toBe(42)
+  })
 
-  it("stops the power save blocker when stopping the emulator", async () => {
-    await manager.launchGame("/rom.nes", "nes");
-    await manager.stopEmulator();
+  it('stops the power save blocker when stopping the emulator', async () => {
+    await manager.launchGame('/rom.nes', 'nes')
+    await manager.stopEmulator()
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
-    expect(internals(manager).powerSaveBlockerId).toBeNull();
-  });
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
+    expect(internals(manager).powerSaveBlockerId).toBeNull()
+  })
 
-  it("does not start duplicate blockers on consecutive launches", async () => {
-    await manager.launchGame("/rom.nes", "nes");
-    await manager.launchGame("/rom2.nes", "nes");
+  it('does not start duplicate blockers on consecutive launches', async () => {
+    await manager.launchGame('/rom.nes', 'nes')
+    await manager.launchGame('/rom2.nes', 'nes')
 
     // start is called once; the second launch sees the existing blocker
-    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1);
-  });
+    expect(powerSaveBlocker.start).toHaveBeenCalledTimes(1)
+  })
 
-  it("handles stopEmulator gracefully when no blocker is active", async () => {
-    await manager.stopEmulator();
+  it('handles stopEmulator gracefully when no blocker is active', async () => {
+    await manager.stopEmulator()
 
-    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
-  });
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
+  })
 
   it('releases the blocker when the emulator emits "exited"', async () => {
-    await manager.launchGame("/rom.nes", "nes");
-    const emulator = internals(manager).currentEmulator as import("events").EventEmitter;
-    emulator.emit("exited", { code: 0 });
+    await manager.launchGame('/rom.nes', 'nes')
+    const emulator = internals(manager).currentEmulator as import('events').EventEmitter
+    emulator.emit('exited', { code: 0 })
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
-    expect(internals(manager).powerSaveBlockerId).toBeNull();
-  });
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
+    expect(internals(manager).powerSaveBlockerId).toBeNull()
+  })
 
   it('releases the blocker when the emulator emits "terminated"', async () => {
-    await manager.launchGame("/rom.nes", "nes");
-    const emulator = internals(manager).currentEmulator as import("events").EventEmitter;
-    emulator.emit("terminated");
+    await manager.launchGame('/rom.nes', 'nes')
+    const emulator = internals(manager).currentEmulator as import('events').EventEmitter
+    emulator.emit('terminated')
 
-    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42);
-    expect(internals(manager).powerSaveBlockerId).toBeNull();
-  });
+    expect(powerSaveBlocker.stop).toHaveBeenCalledWith(42)
+    expect(internals(manager).powerSaveBlockerId).toBeNull()
+  })
 
-  it("handles already-stopped blocker gracefully", async () => {
-    await manager.launchGame("/rom.nes", "nes");
+  it('handles already-stopped blocker gracefully', async () => {
+    await manager.launchGame('/rom.nes', 'nes')
 
     // Simulate the blocker having been stopped externally
-    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(false);
+    vi.mocked(powerSaveBlocker.isStarted).mockReturnValue(false)
 
-    await manager.stopEmulator();
+    await manager.stopEmulator()
 
     // stop() should not be called since isStarted returned false
-    expect(powerSaveBlocker.stop).not.toHaveBeenCalled();
-    expect(internals(manager).powerSaveBlockerId).toBeNull();
-  });
-});
+    expect(powerSaveBlocker.stop).not.toHaveBeenCalled()
+    expect(internals(manager).powerSaveBlockerId).toBeNull()
+  })
+})
 
-describe("EmulatorManager — BIOS validation", () => {
-  let manager: EmulatorManager;
+describe('EmulatorManager — BIOS validation', () => {
+  let manager: EmulatorManager
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    manager = new EmulatorManager();
-  });
+    vi.clearAllMocks()
+    manager = new EmulatorManager()
+  })
 
-  it("returns valid for systems without BIOS requirements", () => {
-    const result = manager.validateBios("nes");
-    expect(result.valid).toBe(true);
-    expect(result.missingFiles).toEqual([]);
-  });
+  it('returns valid for systems without BIOS requirements', () => {
+    const result = manager.validateBios('nes')
+    expect(result.valid).toBe(true)
+    expect(result.missingFiles).toEqual([])
+  })
 
-  it("returns valid when all BIOS files exist", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    const result = manager.validateBios("saturn");
-    expect(result.valid).toBe(true);
-    expect(result.missingFiles).toEqual([]);
-  });
+  it('returns valid when all BIOS files exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(true)
+    expect(result.missingFiles).toEqual([])
+  })
 
-  it("returns missing files when BIOS files are absent", () => {
-    vi.mocked(fs.existsSync).mockReturnValue(false);
-    const result = manager.validateBios("saturn");
-    expect(result.valid).toBe(false);
-    expect(result.missingFiles).toEqual(["sega_101.bin", "mpr-17933.bin"]);
-    expect(result.systemName).toBe("Sega Saturn");
-    expect(result.biosDir).toContain("BIOS");
-  });
+  it('returns missing files when BIOS files are absent', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(false)
+    expect(result.missingFiles).toEqual(['sega_101.bin', 'mpr-17933.bin'])
+    expect(result.systemName).toBe('Sega Saturn')
+    expect(result.biosDir).toContain('BIOS')
+  })
 
-  it("detects partial BIOS files", () => {
-    vi.mocked(fs.existsSync).mockImplementation((p: any) => String(p).endsWith("sega_101.bin"));
-    const result = manager.validateBios("saturn");
-    expect(result.valid).toBe(false);
-    expect(result.missingFiles).toEqual(["mpr-17933.bin"]);
-  });
-});
+  it('detects partial BIOS files', () => {
+    vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) =>
+      String(p).endsWith('sega_101.bin')
+    )
+    const result = manager.validateBios('saturn')
+    expect(result.valid).toBe(false)
+    expect(result.missingFiles).toEqual(['mpr-17933.bin'])
+  })
+})

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { app, powerSaveBlocker } from "electron";
-import { EmulatorCore, EmulatorInfo } from "./EmulatorCore";
+import { EmulatorCore, EmulatorInfo, EmulatorLaunchOptions } from "./EmulatorCore";
 import { RetroArchCore } from "./RetroArchCore";
 import { LibretroNativeCore } from "./LibretroNativeCore";
 import { EmulationWorkerClient } from "./EmulationWorkerClient";
@@ -224,16 +224,16 @@ export class EmulatorManager extends EventEmitter {
     this.setupEventForwarding(this.currentEmulator);
 
     // Get core path for the system (RetroArch or native libretro)
-    const options: any = {};
+    const options: EmulatorLaunchOptions = {};
     if (emulatorInfo.type === "retroarch" || emulatorInfo.type === "libretro-native") {
       if (coreName) {
         // Use the specific core requested by the user
-        options.corePath = this.coreDownloader.getCorePath(coreName);
+        options.corePath = this.coreDownloader.getCorePath(coreName) ?? undefined;
         if (!options.corePath) {
           options.corePath = await this.coreDownloader.downloadCore(coreName, systemId);
         }
       } else {
-        options.corePath = this.getCorePathForSystem(systemId);
+        options.corePath = this.getCorePathForSystem(systemId) ?? undefined;
         if (!options.corePath) {
           // Auto-download the preferred core
           options.corePath = await this.coreDownloader.downloadCoreForSystem(systemId);

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { EventEmitter } from "node:events";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { IpcMainInvokeEvent, BrowserWindow as BrowserWindowType } from 'electron';
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.mock calls are hoisted above imports by vitest
 // ---------------------------------------------------------------------------
 
-vi.mock("electron", () => ({
+vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn(), on: vi.fn() },
   BrowserWindow: {
     getFocusedWindow: vi.fn(),
@@ -13,79 +14,149 @@ vi.mock("electron", () => ({
     fromWebContents: vi.fn(),
   },
   dialog: { showOpenDialog: vi.fn() },
-  app: { getPath: vi.fn(() => "/tmp/test") },
+  app: { getPath: vi.fn(() => '/tmp/test') },
 }));
 
-vi.mock("fs");
-vi.mock("path", async () => {
-  const actual = await vi.importActual<typeof import("path")>("path");
+vi.mock('fs');
+vi.mock('path', async () => {
+  const actual = await vi.importActual<typeof import('path')>('path');
   return { ...actual, default: actual };
 });
 
-vi.mock("../emulator/EmulatorManager");
-vi.mock("../emulator/LibretroNativeCore");
-vi.mock("../emulator/EmulationWorkerClient");
-vi.mock("../emulator/resolveAddonPath");
-vi.mock("../services/LibraryService");
-vi.mock("../services/ArtworkService");
-vi.mock("../services/HomebrewService", () => {
-  const MockHomebrewService = vi.fn();
-  MockHomebrewService.prototype.importIfNeeded = vi.fn().mockResolvedValue(false);
-  return { HomebrewService: MockHomebrewService };
-});
-vi.mock("../GameWindowManager");
-vi.mock("../logger", () => ({
+vi.mock('../emulator/EmulatorManager');
+vi.mock('../emulator/LibretroNativeCore');
+vi.mock('../emulator/EmulationWorkerClient');
+vi.mock('../emulator/resolveAddonPath');
+vi.mock('../services/LibraryService');
+vi.mock('../services/ArtworkService');
+vi.mock('../GameWindowManager');
+vi.mock('../logger', () => ({
   ipcLog: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
-import { ipcMain, BrowserWindow, dialog, app } from "electron";
-import { EmulatorManager } from "../emulator/EmulatorManager";
-import { EmulationWorkerClient } from "../emulator/EmulationWorkerClient";
-import { resolveAddonPath } from "../emulator/resolveAddonPath";
-import { LibraryService } from "../services/LibraryService";
-import { HomebrewService } from "../services/HomebrewService";
-import { GameWindowManager } from "../GameWindowManager";
-import { IPCHandlers } from "./handlers";
-import type { Game, GameSystem } from "../../types/library";
+import { ipcMain, BrowserWindow, dialog, app } from 'electron';
+import { EmulatorManager } from '../emulator/EmulatorManager';
+import { EmulationWorkerClient } from '../emulator/EmulationWorkerClient';
+import { resolveAddonPath } from '../emulator/resolveAddonPath';
+import { LibraryService } from '../services/LibraryService';
+import { GameWindowManager } from '../GameWindowManager';
+import { IPCHandlers } from './handlers';
+import type { Game, GameSystem } from '../../types/library';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+type IpcHandler = (...args: unknown[]) => unknown;
+
 /**
  * Extract a registered ipcMain.handle handler by channel name.
+ * Throws if the channel was not registered.
  */
-function getHandler(channel: string): ((...args: Array<any>) => any) | undefined {
+function getHandler(channel: string): IpcHandler {
   const calls = vi.mocked(ipcMain.handle).mock.calls;
   const match = calls.find(([ch]) => ch === channel);
-  return match?.[1] as ((...args: Array<any>) => any) | undefined;
+  if (!match) throw new Error(`No handler registered for channel: ${channel}`);
+  return match[1] as IpcHandler;
 }
 
 /**
  * Extract a registered ipcMain.on listener by channel name.
+ * Throws if the channel was not registered.
  */
-function getOnListener(channel: string): ((...args: Array<any>) => any) | undefined {
+function getOnListener(channel: string): IpcHandler {
   const calls = vi.mocked(ipcMain.on).mock.calls;
   const match = calls.find(([ch]) => ch === channel);
-  return match?.[1] as ((...args: Array<any>) => any) | undefined;
+  if (!match) throw new Error(`No listener registered for channel: ${channel}`);
+  return match[1] as IpcHandler;
 }
 
 /** Stub IpcMainInvokeEvent */
-const fakeEvent = {} as any;
+const fakeEvent = {} as unknown as IpcMainInvokeEvent;
+
+// ---------------------------------------------------------------------------
+// Mock instance interfaces — typed alternatives to `any`
+// ---------------------------------------------------------------------------
+
+interface MockEmulatorManager {
+  on: ReturnType<typeof vi.fn>;
+  emit: (...args: unknown[]) => boolean;
+  removeListener: (...args: unknown[]) => EventEmitter;
+  getCoresForSystem: ReturnType<typeof vi.fn>;
+  getCoreDownloader: ReturnType<typeof vi.fn>;
+  launchGame: ReturnType<typeof vi.fn>;
+  stopEmulator: ReturnType<typeof vi.fn>;
+  getAvailableEmulators: ReturnType<typeof vi.fn>;
+  isEmulatorRunning: ReturnType<typeof vi.fn>;
+  isNativeMode: ReturnType<typeof vi.fn>;
+  getCurrentEmulator: ReturnType<typeof vi.fn>;
+  getCurrentEmulatorPid: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  saveState: ReturnType<typeof vi.fn>;
+  loadState: ReturnType<typeof vi.fn>;
+  screenshot: ReturnType<typeof vi.fn>;
+  setWorkerClient: ReturnType<typeof vi.fn>;
+  validateBios: ReturnType<typeof vi.fn>;
+  setSpeed?: ReturnType<typeof vi.fn>;
+  [key: string]: unknown;
+}
+
+interface MockLibraryService {
+  getSystems: ReturnType<typeof vi.fn>;
+  addSystem: ReturnType<typeof vi.fn>;
+  removeSystem: ReturnType<typeof vi.fn>;
+  updateSystemPath: ReturnType<typeof vi.fn>;
+  getGames: ReturnType<typeof vi.fn>;
+  addGame: ReturnType<typeof vi.fn>;
+  removeGame: ReturnType<typeof vi.fn>;
+  updateGame: ReturnType<typeof vi.fn>;
+  scanDirectory: ReturnType<typeof vi.fn>;
+  scanSystemFolders: ReturnType<typeof vi.fn>;
+  getConfig: ReturnType<typeof vi.fn>;
+  setRomsBasePath: ReturnType<typeof vi.fn>;
+  [key: string]: unknown;
+}
+
+interface MockGameWindowManager {
+  createNativeGameWindow: ReturnType<typeof vi.fn>;
+  createGameWindow: ReturnType<typeof vi.fn>;
+  startTrackingRetroArchWindow: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  [key: string]: unknown;
+}
+
+interface MockWorkerClient {
+  init: ReturnType<typeof vi.fn>;
+  setInput: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  saveState: ReturnType<typeof vi.fn>;
+  loadState: ReturnType<typeof vi.fn>;
+  saveSram: ReturnType<typeof vi.fn>;
+  screenshot: ReturnType<typeof vi.fn>;
+  shutdown: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  isRunning: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  [key: string]: unknown;
+}
 
 // ---------------------------------------------------------------------------
 // Test-level state
 // ---------------------------------------------------------------------------
 
-let emulatorManagerInstance: any;
-let libraryServiceInstance: any;
-let gameWindowManagerInstance: any;
-let workerClientInstance: any;
+let emulatorManagerInstance: MockEmulatorManager;
+let libraryServiceInstance: MockLibraryService;
+let gameWindowManagerInstance: MockGameWindowManager;
+let workerClientInstance: MockWorkerClient;
 let emulatorEmitter: EventEmitter;
 
 const fakeAvInfo = {
   geometry: { baseWidth: 256, baseHeight: 240, maxWidth: 256, maxHeight: 240, aspectRatio: 1.333 },
-  timing: { fps: 60, sampleRate: 44_100 },
+  timing: { fps: 60, sampleRate: 44100 },
 };
 
 beforeEach(() => {
@@ -94,7 +165,7 @@ beforeEach(() => {
 
   // Re-apply electron mock defaults that resetAllMocks wipes
   vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([]);
-  vi.mocked(app).getPath = vi.fn(() => "/tmp/test");
+  vi.mocked(app).getPath = vi.fn(() => '/tmp/test');
 
   // Fresh EventEmitter for EmulatorManager event forwarding
   emulatorEmitter = new EventEmitter();
@@ -121,10 +192,10 @@ beforeEach(() => {
       loadState: vi.fn(),
       screenshot: vi.fn(),
       setWorkerClient: vi.fn(),
-      validateBios: vi.fn(() => ({ valid: true, missingFiles: [], biosDir: "", systemName: "" })),
-    });
-    return emulatorManagerInstance;
-  } as any);
+      validateBios: vi.fn(() => ({ valid: true, missingFiles: [], biosDir: '', systemName: '' })),
+    }) as unknown as MockEmulatorManager;
+    return emulatorManagerInstance as unknown as EmulatorManager;
+  } as unknown as () => EmulatorManager);
 
   // Configure EmulationWorkerClient mock constructor
   vi.mocked(EmulationWorkerClient).mockImplementation(function (this: Record<string, unknown>) {
@@ -142,12 +213,12 @@ beforeEach(() => {
       destroy: vi.fn().mockResolvedValue(undefined),
       isRunning: vi.fn(() => true),
       on: vi.fn(),
-    });
-    return workerClientInstance;
-  } as any);
+    }) as unknown as MockWorkerClient;
+    return workerClientInstance as unknown as EmulationWorkerClient;
+  } as unknown as () => EmulationWorkerClient);
 
   // Configure resolveAddonPath mock
-  vi.mocked(resolveAddonPath).mockReturnValue("/fake/addon.node");
+  vi.mocked(resolveAddonPath).mockReturnValue('/fake/addon.node');
 
   // Configure LibraryService mock constructor
   vi.mocked(LibraryService).mockImplementation(function (this: Record<string, unknown>) {
@@ -164,9 +235,9 @@ beforeEach(() => {
       scanSystemFolders: vi.fn(),
       getConfig: vi.fn(),
       setRomsBasePath: vi.fn(),
-    });
-    return libraryServiceInstance;
-  } as any);
+    }) as unknown as MockLibraryService;
+    return libraryServiceInstance as unknown as LibraryService;
+  } as unknown as () => LibraryService);
 
   // Configure GameWindowManager mock constructor
   vi.mocked(GameWindowManager).mockImplementation(function (this: Record<string, unknown>) {
@@ -174,90 +245,83 @@ beforeEach(() => {
       createNativeGameWindow: vi.fn(),
       createGameWindow: vi.fn(),
       startTrackingRetroArchWindow: vi.fn(),
-    });
+    }) as unknown as MockGameWindowManager;
     gameWindowManagerInstance.on = vi.fn(() => gameWindowManagerInstance);
-    return gameWindowManagerInstance;
-  } as any);
-
-  // Configure HomebrewService mock constructor
-  vi.mocked(HomebrewService).mockImplementation(function (this: Record<string, unknown>) {
-    Object.assign(this, {
-      importIfNeeded: vi.fn().mockResolvedValue(false),
-    });
-  } as any);
+    return gameWindowManagerInstance as unknown as GameWindowManager;
+  } as unknown as () => GameWindowManager);
 
   // Instantiate IPCHandlers — triggers all handler registrations
-  new IPCHandlers("/fake/preload.js");
+  new IPCHandlers('/fake/preload.js');
 });
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("IPCHandlers", () => {
+describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 1. Registration
   // -----------------------------------------------------------------------
-  describe("constructor", () => {
-    it("registers all expected IPC channels", () => {
+  describe('constructor', () => {
+    it('registers all expected IPC channels', () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
       const onCalls = vi.mocked(ipcMain.on).mock.calls.map(([ch]) => ch);
 
       const expectedHandleChannels = [
-        "emulator:getCoresForSystem",
-        "emulator:downloadCore",
-        "emulator:launch",
-        "emulator:stop",
-        "emulator:getAvailable",
-        "emulator:isRunning",
-        "emulation:pause",
-        "emulation:resume",
-        "emulation:reset",
-        "emulation:setSpeed",
-        "savestate:save",
-        "savestate:load",
-        "emulation:screenshot",
-        "library:getSystems",
-        "library:addSystem",
-        "library:removeSystem",
-        "library:updateSystemPath",
-        "library:getGames",
-        "library:addGame",
-        "library:removeGame",
-        "library:updateGame",
-        "library:scanDirectory",
-        "library:scanSystemFolders",
-        "library:getConfig",
-        "library:setRomsBasePath",
-        "dialog:selectDirectory",
-        "dialog:selectRomFile",
+        'emulator:getCoresForSystem',
+        'emulator:downloadCore',
+        'emulator:launch',
+        'emulator:stop',
+        'emulator:getAvailable',
+        'emulator:isRunning',
+        'emulation:pause',
+        'emulation:resume',
+        'emulation:reset',
+        'emulation:setSpeed',
+        'savestate:save',
+        'savestate:load',
+        'emulation:screenshot',
+        'library:getSystems',
+        'library:addSystem',
+        'library:removeSystem',
+        'library:updateSystemPath',
+        'library:getGames',
+        'library:addGame',
+        'library:removeGame',
+        'library:updateGame',
+        'library:scanDirectory',
+        'library:scanSystemFolders',
+        'library:getConfig',
+        'library:setRomsBasePath',
+        'dialog:selectDirectory',
+        'dialog:selectRomFile',
       ];
 
       for (const channel of expectedHandleChannels) {
         expect(handleCalls, `Missing handle channel: ${channel}`).toContain(channel);
       }
 
-      expect(onCalls).toContain("dialog:resumeGameResponse");
+      expect(onCalls).toContain('dialog:resumeGameResponse');
     });
 
-    it("registers exactly the expected number of handle channels", () => {
+    it('registers exactly the expected number of handle channels', () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(36);
+      expect(handleCalls).toHaveLength(35);
     });
   });
 
   // -----------------------------------------------------------------------
   // 2. emulator:getCoresForSystem
   // -----------------------------------------------------------------------
-  describe("emulator:getCoresForSystem", () => {
-    it("delegates to EmulatorManager.getCoresForSystem", async () => {
-      const cores = [{ name: "fceumm", installed: true }];
+  describe('emulator:getCoresForSystem', () => {
+    it('delegates to EmulatorManager.getCoresForSystem', async () => {
+      const cores = [{ name: 'fceumm', installed: true }];
       emulatorManagerInstance.getCoresForSystem.mockReturnValue(cores);
 
-      const handler = getHandler("emulator:getCoresForSystem")!;
-      const result = await handler(fakeEvent, "nes");
+      const handler = getHandler('emulator:getCoresForSystem');
+      const result = await handler(fakeEvent, 'nes');
 
-      expect(emulatorManagerInstance.getCoresForSystem).toHaveBeenCalledWith("nes");
+      expect(emulatorManagerInstance.getCoresForSystem).toHaveBeenCalledWith('nes');
       expect(result).toEqual(cores);
     });
   });
@@ -265,43 +329,43 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 3-4. emulator:downloadCore
   // -----------------------------------------------------------------------
-  describe("emulator:downloadCore", () => {
-    it("returns success with corePath on successful download", async () => {
-      const downloadMock = vi.fn().mockResolvedValue("/cores/fceumm.dylib");
+  describe('emulator:downloadCore', () => {
+    it('returns success with corePath on successful download', async () => {
+      const downloadMock = vi.fn().mockResolvedValue('/cores/fceumm.dylib');
       emulatorManagerInstance.getCoreDownloader.mockReturnValue({ downloadCore: downloadMock });
 
-      const handler = getHandler("emulator:downloadCore")!;
-      const result = await handler(fakeEvent, "fceumm", "nes");
+      const handler = getHandler('emulator:downloadCore');
+      const result = await handler(fakeEvent, 'fceumm', 'nes');
 
-      expect(downloadMock).toHaveBeenCalledWith("fceumm", "nes");
-      expect(result).toEqual({ success: true, corePath: "/cores/fceumm.dylib" });
+      expect(downloadMock).toHaveBeenCalledWith('fceumm', 'nes');
+      expect(result).toEqual({ success: true, corePath: '/cores/fceumm.dylib' });
     });
 
-    it("returns { success: false, error } on failure", async () => {
-      const downloadMock = vi.fn().mockRejectedValue(new Error("Network error"));
+    it('returns { success: false, error } on failure', async () => {
+      const downloadMock = vi.fn().mockRejectedValue(new Error('Network error'));
       emulatorManagerInstance.getCoreDownloader.mockReturnValue({ downloadCore: downloadMock });
 
-      const handler = getHandler("emulator:downloadCore")!;
-      const result = await handler(fakeEvent, "fceumm", "nes");
+      const handler = getHandler('emulator:downloadCore');
+      const result = await handler(fakeEvent, 'fceumm', 'nes');
 
-      expect(result).toEqual({ success: false, error: "Network error" });
+      expect(result).toEqual({ success: false, error: 'Network error' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 5-6. emulator:launch
   // -----------------------------------------------------------------------
-  describe("emulator:launch", () => {
+  describe('emulator:launch', () => {
     const fakeGame: Game = {
-      id: "game-1",
-      title: "Super Mario Bros",
-      system: "NES",
-      systemId: "nes",
-      romPath: "/roms/smb.nes",
-      romHashes: { crc32: "deadbeef", sha1: "a".repeat(40), md5: "b".repeat(32) },
+      id: 'game-1',
+      title: 'Super Mario Bros',
+      system: 'NES',
+      systemId: 'nes',
+      romPath: '/roms/smb.nes',
+      romHashes: { crc32: 'deadbeef', sha1: 'a'.repeat(40), md5: 'b'.repeat(32) },
     };
 
-    it("launches in native mode successfully", async () => {
+    it('launches in native mode successfully', async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(true);
@@ -309,92 +373,81 @@ describe("IPCHandlers", () => {
       const nativeCoreMock = {
         hasAutoSave: vi.fn(() => false),
         deleteAutoSave: vi.fn(),
-        getCorePath: vi.fn(() => "/cores/fceumm.dylib"),
-        getRomPath: vi.fn(() => "/roms/smb.nes"),
-        getSystemDir: vi.fn(() => "/bios"),
-        getSaveDir: vi.fn(() => "/saves"),
-        getSramDir: vi.fn(() => "/saves"),
-        getSaveStatesDir: vi.fn(() => "/savestates"),
+        getCorePath: vi.fn(() => '/cores/fceumm.dylib'),
+        getRomPath: vi.fn(() => '/roms/smb.nes'),
+        getSystemDir: vi.fn(() => '/bios'),
+        getSaveDir: vi.fn(() => '/saves'),
+        getSramDir: vi.fn(() => '/saves'),
+        getSaveStatesDir: vi.fn(() => '/savestates'),
       };
       emulatorManagerInstance.getCurrentEmulator.mockReturnValue(nativeCoreMock);
       gameWindowManagerInstance.createNativeGameWindow.mockReturnValue({});
 
-      const handler = getHandler("emulator:launch")!;
-      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", undefined, "fceumm");
+      const handler = getHandler('emulator:launch');
+      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', undefined, 'fceumm');
 
-      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith("nes");
+      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith('nes');
       expect(emulatorManagerInstance.launchGame).toHaveBeenCalledWith(
-        "/roms/smb.nes",
-        "nes",
-        undefined,
-        undefined,
-        "fceumm",
+        '/roms/smb.nes', 'nes', undefined, undefined, 'fceumm',
       );
       // Worker client should have been initialized with paths from the native core
       expect(workerClientInstance.init).toHaveBeenCalledWith({
-        corePath: "/cores/fceumm.dylib",
-        romPath: "/roms/smb.nes",
-        systemDir: "/bios",
-        saveDir: "/saves",
-        sramDir: "/saves",
-        saveStatesDir: "/savestates",
-        addonPath: "/fake/addon.node",
+        corePath: '/cores/fceumm.dylib',
+        romPath: '/roms/smb.nes',
+        systemDir: '/bios',
+        saveDir: '/saves',
+        sramDir: '/saves',
+        saveStatesDir: '/savestates',
+        addonPath: '/fake/addon.node',
       });
       expect(emulatorManagerInstance.setWorkerClient).toHaveBeenCalledWith(workerClientInstance);
       expect(gameWindowManagerInstance.createNativeGameWindow).toHaveBeenCalledWith(
-        fakeGame,
-        workerClientInstance,
-        fakeAvInfo,
-        false,
-        undefined,
+        fakeGame, workerClientInstance, fakeAvInfo, false, undefined,
       );
       expect(result).toEqual({ success: true });
     });
 
-    it("launches in legacy overlay mode successfully", async () => {
+    it('launches in legacy overlay mode successfully', async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(false);
-      emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(12_345);
+      emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(12345);
 
-      const handler = getHandler("emulator:launch")!;
-      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", "retroarch");
+      const handler = getHandler('emulator:launch');
+      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', 'retroarch');
 
       expect(gameWindowManagerInstance.createGameWindow).toHaveBeenCalledWith(fakeGame);
-      expect(gameWindowManagerInstance.startTrackingRetroArchWindow).toHaveBeenCalledWith(
-        "game-1",
-        12_345,
-      );
+      expect(gameWindowManagerInstance.startTrackingRetroArchWindow).toHaveBeenCalledWith('game-1', 12345);
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when game is not found in library", async () => {
+    it('returns error when game is not found in library', async () => {
       libraryServiceInstance.getGames.mockReturnValue([]);
 
-      const handler = getHandler("emulator:launch")!;
-      const result = await handler(fakeEvent, "/roms/missing.nes", "nes");
+      const handler = getHandler('emulator:launch');
+      const result = await handler(fakeEvent, '/roms/missing.nes', 'nes');
 
-      expect(result).toEqual({ success: false, error: "Game not found in library" });
+      expect(result).toEqual({ success: false, error: 'Game not found in library' });
     });
 
-    it("returns error when launchGame throws", async () => {
+    it('returns error when launchGame throws', async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
-      emulatorManagerInstance.launchGame.mockRejectedValue(new Error("Core not found"));
+      emulatorManagerInstance.launchGame.mockRejectedValue(new Error('Core not found'));
 
-      const handler = getHandler("emulator:launch")!;
-      const result = await handler(fakeEvent, "/roms/smb.nes", "nes");
+      const handler = getHandler('emulator:launch');
+      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes');
 
-      expect(result).toEqual({ success: false, error: "Core not found" });
+      expect(result).toEqual({ success: false, error: 'Core not found' });
     });
 
-    it("does not track RetroArch window when PID is unavailable", async () => {
+    it('does not track RetroArch window when PID is unavailable', async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(false);
       emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(undefined);
 
-      const handler = getHandler("emulator:launch")!;
-      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", "retroarch");
+      const handler = getHandler('emulator:launch');
+      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', 'retroarch');
 
       expect(gameWindowManagerInstance.createGameWindow).toHaveBeenCalledWith(fakeGame);
       expect(gameWindowManagerInstance.startTrackingRetroArchWindow).not.toHaveBeenCalled();
@@ -405,36 +458,36 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 7. emulator:stop
   // -----------------------------------------------------------------------
-  describe("emulator:stop", () => {
-    it("returns success on successful stop", async () => {
+  describe('emulator:stop', () => {
+    it('returns success on successful stop', async () => {
       emulatorManagerInstance.stopEmulator.mockResolvedValue(undefined);
 
-      const handler = getHandler("emulator:stop")!;
+      const handler = getHandler('emulator:stop');
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.stopEmulator).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error on failure", async () => {
-      emulatorManagerInstance.stopEmulator.mockRejectedValue(new Error("Stop failed"));
+    it('returns error on failure', async () => {
+      emulatorManagerInstance.stopEmulator.mockRejectedValue(new Error('Stop failed'));
 
-      const handler = getHandler("emulator:stop")!;
+      const handler = getHandler('emulator:stop');
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: "Stop failed" });
+      expect(result).toEqual({ success: false, error: 'Stop failed' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 8. emulator:getAvailable
   // -----------------------------------------------------------------------
-  describe("emulator:getAvailable", () => {
-    it("delegates to EmulatorManager.getAvailableEmulators", () => {
-      const emulators = [{ id: "retroarch", name: "RetroArch" }];
+  describe('emulator:getAvailable', () => {
+    it('delegates to EmulatorManager.getAvailableEmulators', () => {
+      const emulators = [{ id: 'retroarch', name: 'RetroArch' }];
       emulatorManagerInstance.getAvailableEmulators.mockReturnValue(emulators);
 
-      const handler = getHandler("emulator:getAvailable")!;
+      const handler = getHandler('emulator:getAvailable');
       const result = handler(fakeEvent);
 
       expect(emulatorManagerInstance.getAvailableEmulators).toHaveBeenCalled();
@@ -445,11 +498,11 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 9. emulator:isRunning
   // -----------------------------------------------------------------------
-  describe("emulator:isRunning", () => {
-    it("delegates to EmulatorManager.isEmulatorRunning", () => {
+  describe('emulator:isRunning', () => {
+    it('delegates to EmulatorManager.isEmulatorRunning', () => {
       emulatorManagerInstance.isEmulatorRunning.mockReturnValue(true);
 
-      const handler = getHandler("emulator:isRunning")!;
+      const handler = getHandler('emulator:isRunning');
       const result = handler(fakeEvent);
 
       expect(emulatorManagerInstance.isEmulatorRunning).toHaveBeenCalled();
@@ -460,194 +513,194 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 10. emulation:pause
   // -----------------------------------------------------------------------
-  describe("emulation:pause", () => {
-    it("returns success when pause succeeds", async () => {
+  describe('emulation:pause', () => {
+    it('returns success when pause succeeds', async () => {
       emulatorManagerInstance.pause.mockResolvedValue(undefined);
 
-      const handler = getHandler("emulation:pause")!;
+      const handler = getHandler('emulation:pause');
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.pause).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when pause fails", async () => {
-      emulatorManagerInstance.pause.mockRejectedValue(new Error("No emulator running"));
+    it('returns error when pause fails', async () => {
+      emulatorManagerInstance.pause.mockRejectedValue(new Error('No emulator running'));
 
-      const handler = getHandler("emulation:pause")!;
+      const handler = getHandler('emulation:pause');
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: "No emulator running" });
+      expect(result).toEqual({ success: false, error: 'No emulator running' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 11. emulation:resume
   // -----------------------------------------------------------------------
-  describe("emulation:resume", () => {
-    it("returns success when resume succeeds", async () => {
+  describe('emulation:resume', () => {
+    it('returns success when resume succeeds', async () => {
       emulatorManagerInstance.resume.mockResolvedValue(undefined);
 
-      const handler = getHandler("emulation:resume")!;
+      const handler = getHandler('emulation:resume');
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.resume).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when resume fails", async () => {
-      emulatorManagerInstance.resume.mockRejectedValue(new Error("No emulator running"));
+    it('returns error when resume fails', async () => {
+      emulatorManagerInstance.resume.mockRejectedValue(new Error('No emulator running'));
 
-      const handler = getHandler("emulation:resume")!;
+      const handler = getHandler('emulation:resume');
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: "No emulator running" });
+      expect(result).toEqual({ success: false, error: 'No emulator running' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 12. emulation:reset
   // -----------------------------------------------------------------------
-  describe("emulation:reset", () => {
-    it("returns success when reset succeeds", async () => {
+  describe('emulation:reset', () => {
+    it('returns success when reset succeeds', async () => {
       emulatorManagerInstance.reset.mockResolvedValue(undefined);
 
-      const handler = getHandler("emulation:reset")!;
+      const handler = getHandler('emulation:reset');
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.reset).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when reset fails", async () => {
-      emulatorManagerInstance.reset.mockRejectedValue(new Error("No emulator running"));
+    it('returns error when reset fails', async () => {
+      emulatorManagerInstance.reset.mockRejectedValue(new Error('No emulator running'));
 
-      const handler = getHandler("emulation:reset")!;
+      const handler = getHandler('emulation:reset');
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: "No emulator running" });
+      expect(result).toEqual({ success: false, error: 'No emulator running' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 12b. emulation:setSpeed
   // -----------------------------------------------------------------------
-  describe("emulation:setSpeed", () => {
-    it("returns success when setSpeed succeeds", async () => {
+  describe('emulation:setSpeed', () => {
+    it('returns success when setSpeed succeeds', async () => {
       emulatorManagerInstance.setSpeed = vi.fn();
 
-      const handler = getHandler("emulation:setSpeed")!;
+      const handler = getHandler('emulation:setSpeed');
       const result = await handler(fakeEvent, 2);
 
       expect(emulatorManagerInstance.setSpeed).toHaveBeenCalledWith(2);
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when setSpeed fails", async () => {
+    it('returns error when setSpeed fails', async () => {
       emulatorManagerInstance.setSpeed = vi.fn(() => {
-        throw new Error("No emulator running");
+        throw new Error('No emulator running');
       });
 
-      const handler = getHandler("emulation:setSpeed")!;
+      const handler = getHandler('emulation:setSpeed');
       const result = await handler(fakeEvent, 4);
 
-      expect(result).toEqual({ success: false, error: "No emulator running" });
+      expect(result).toEqual({ success: false, error: 'No emulator running' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 13. savestate:save
   // -----------------------------------------------------------------------
-  describe("savestate:save", () => {
-    it("returns success when save state succeeds", async () => {
+  describe('savestate:save', () => {
+    it('returns success when save state succeeds', async () => {
       emulatorManagerInstance.saveState.mockResolvedValue(undefined);
 
-      const handler = getHandler("savestate:save")!;
+      const handler = getHandler('savestate:save');
       const result = await handler(fakeEvent, 2);
 
       expect(emulatorManagerInstance.saveState).toHaveBeenCalledWith(2);
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when save state fails", async () => {
-      emulatorManagerInstance.saveState.mockRejectedValue(new Error("Save failed"));
+    it('returns error when save state fails', async () => {
+      emulatorManagerInstance.saveState.mockRejectedValue(new Error('Save failed'));
 
-      const handler = getHandler("savestate:save")!;
+      const handler = getHandler('savestate:save');
       const result = await handler(fakeEvent, 1);
 
-      expect(result).toEqual({ success: false, error: "Save failed" });
+      expect(result).toEqual({ success: false, error: 'Save failed' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 14. savestate:load
   // -----------------------------------------------------------------------
-  describe("savestate:load", () => {
-    it("returns success when load state succeeds", async () => {
+  describe('savestate:load', () => {
+    it('returns success when load state succeeds', async () => {
       emulatorManagerInstance.loadState.mockResolvedValue(undefined);
 
-      const handler = getHandler("savestate:load")!;
+      const handler = getHandler('savestate:load');
       const result = await handler(fakeEvent, 3);
 
       expect(emulatorManagerInstance.loadState).toHaveBeenCalledWith(3);
       expect(result).toEqual({ success: true });
     });
 
-    it("returns error when load state fails", async () => {
-      emulatorManagerInstance.loadState.mockRejectedValue(new Error("Slot empty"));
+    it('returns error when load state fails', async () => {
+      emulatorManagerInstance.loadState.mockRejectedValue(new Error('Slot empty'));
 
-      const handler = getHandler("savestate:load")!;
+      const handler = getHandler('savestate:load');
       const result = await handler(fakeEvent, 0);
 
-      expect(result).toEqual({ success: false, error: "Slot empty" });
+      expect(result).toEqual({ success: false, error: 'Slot empty' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 15. emulation:screenshot
   // -----------------------------------------------------------------------
-  describe("emulation:screenshot", () => {
-    it("returns success with path when screenshot succeeds", async () => {
-      emulatorManagerInstance.screenshot.mockResolvedValue("/screenshots/screen.png");
+  describe('emulation:screenshot', () => {
+    it('returns success with path when screenshot succeeds', async () => {
+      emulatorManagerInstance.screenshot.mockResolvedValue('/screenshots/screen.png');
 
-      const handler = getHandler("emulation:screenshot")!;
-      const result = await handler(fakeEvent, "/screenshots/screen.png");
+      const handler = getHandler('emulation:screenshot');
+      const result = await handler(fakeEvent, '/screenshots/screen.png');
 
-      expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith("/screenshots/screen.png");
-      expect(result).toEqual({ success: true, path: "/screenshots/screen.png" });
+      expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith('/screenshots/screen.png');
+      expect(result).toEqual({ success: true, path: '/screenshots/screen.png' });
     });
 
-    it("uses default output path when none provided", async () => {
-      emulatorManagerInstance.screenshot.mockResolvedValue("/tmp/default.png");
+    it('uses default output path when none provided', async () => {
+      emulatorManagerInstance.screenshot.mockResolvedValue('/tmp/default.png');
 
-      const handler = getHandler("emulation:screenshot")!;
+      const handler = getHandler('emulation:screenshot');
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith(undefined);
-      expect(result).toEqual({ success: true, path: "/tmp/default.png" });
+      expect(result).toEqual({ success: true, path: '/tmp/default.png' });
     });
 
-    it("returns error when screenshot fails", async () => {
-      emulatorManagerInstance.screenshot.mockRejectedValue(new Error("No emulator running"));
+    it('returns error when screenshot fails', async () => {
+      emulatorManagerInstance.screenshot.mockRejectedValue(new Error('No emulator running'));
 
-      const handler = getHandler("emulation:screenshot")!;
+      const handler = getHandler('emulation:screenshot');
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: "No emulator running" });
+      expect(result).toEqual({ success: false, error: 'No emulator running' });
     });
   });
 
   // -----------------------------------------------------------------------
   // 16. library:getSystems
   // -----------------------------------------------------------------------
-  describe("library:getSystems", () => {
-    it("delegates to LibraryService.getSystems", () => {
-      const systems: Array<GameSystem> = [
-        { id: "nes", name: "NES", shortName: "NES", extensions: [".nes"] },
+  describe('library:getSystems', () => {
+    it('delegates to LibraryService.getSystems', () => {
+      const systems: GameSystem[] = [
+        { id: 'nes', name: 'NES', shortName: 'NES', extensions: ['.nes'] },
       ];
       libraryServiceInstance.getSystems.mockReturnValue(systems);
 
-      const handler = getHandler("library:getSystems")!;
+      const handler = getHandler('library:getSystems');
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getSystems).toHaveBeenCalled();
@@ -658,17 +711,17 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 17. library:addSystem
   // -----------------------------------------------------------------------
-  describe("library:addSystem", () => {
-    it("delegates to LibraryService.addSystem and returns success", async () => {
+  describe('library:addSystem', () => {
+    it('delegates to LibraryService.addSystem and returns success', async () => {
       const newSystem: GameSystem = {
-        id: "gba",
-        name: "Game Boy Advance",
-        shortName: "GBA",
-        extensions: [".gba"],
+        id: 'gba',
+        name: 'Game Boy Advance',
+        shortName: 'GBA',
+        extensions: ['.gba'],
       };
       libraryServiceInstance.addSystem.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:addSystem")!;
+      const handler = getHandler('library:addSystem');
       const result = await handler(fakeEvent, newSystem);
 
       expect(libraryServiceInstance.addSystem).toHaveBeenCalledWith(newSystem);
@@ -679,14 +732,14 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 18. library:removeSystem
   // -----------------------------------------------------------------------
-  describe("library:removeSystem", () => {
-    it("delegates to LibraryService.removeSystem and returns success", async () => {
+  describe('library:removeSystem', () => {
+    it('delegates to LibraryService.removeSystem and returns success', async () => {
       libraryServiceInstance.removeSystem.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:removeSystem")!;
-      const result = await handler(fakeEvent, "nes");
+      const handler = getHandler('library:removeSystem');
+      const result = await handler(fakeEvent, 'nes');
 
-      expect(libraryServiceInstance.removeSystem).toHaveBeenCalledWith("nes");
+      expect(libraryServiceInstance.removeSystem).toHaveBeenCalledWith('nes');
       expect(result).toEqual({ success: true });
     });
   });
@@ -694,14 +747,14 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:updateSystemPath
   // -----------------------------------------------------------------------
-  describe("library:updateSystemPath", () => {
-    it("delegates to LibraryService.updateSystemPath and returns success", async () => {
+  describe('library:updateSystemPath', () => {
+    it('delegates to LibraryService.updateSystemPath and returns success', async () => {
       libraryServiceInstance.updateSystemPath.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:updateSystemPath")!;
-      const result = await handler(fakeEvent, "nes", "/roms/nes");
+      const handler = getHandler('library:updateSystemPath');
+      const result = await handler(fakeEvent, 'nes', '/roms/nes');
 
-      expect(libraryServiceInstance.updateSystemPath).toHaveBeenCalledWith("nes", "/roms/nes");
+      expect(libraryServiceInstance.updateSystemPath).toHaveBeenCalledWith('nes', '/roms/nes');
       expect(result).toEqual({ success: true });
     });
   });
@@ -709,22 +762,22 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 19. library:getGames
   // -----------------------------------------------------------------------
-  describe("library:getGames", () => {
-    it("delegates with systemId filter", () => {
-      const games = [{ id: "g1", title: "SMB", systemId: "nes" }];
+  describe('library:getGames', () => {
+    it('delegates with systemId filter', () => {
+      const games = [{ id: 'g1', title: 'SMB', systemId: 'nes' }];
       libraryServiceInstance.getGames.mockReturnValue(games);
 
-      const handler = getHandler("library:getGames")!;
-      const result = handler(fakeEvent, "nes");
+      const handler = getHandler('library:getGames');
+      const result = handler(fakeEvent, 'nes');
 
-      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith("nes");
+      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith('nes');
       expect(result).toEqual(games);
     });
 
-    it("delegates without systemId to get all games", () => {
+    it('delegates without systemId to get all games', () => {
       libraryServiceInstance.getGames.mockReturnValue([]);
 
-      const handler = getHandler("library:getGames")!;
+      const handler = getHandler('library:getGames');
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getGames).toHaveBeenCalledWith(undefined);
@@ -735,15 +788,15 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 20. library:addGame
   // -----------------------------------------------------------------------
-  describe("library:addGame", () => {
-    it("delegates to LibraryService.addGame and returns the game", async () => {
-      const game = { id: "g1", title: "Zelda", systemId: "nes", romPath: "/roms/zelda.nes" };
+  describe('library:addGame', () => {
+    it('delegates to LibraryService.addGame and returns the game', async () => {
+      const game = { id: 'g1', title: 'Zelda', systemId: 'nes', romPath: '/roms/zelda.nes' };
       libraryServiceInstance.addGame.mockResolvedValue(game);
 
-      const handler = getHandler("library:addGame")!;
-      const result = await handler(fakeEvent, "/roms/zelda.nes", "nes");
+      const handler = getHandler('library:addGame');
+      const result = await handler(fakeEvent, '/roms/zelda.nes', 'nes');
 
-      expect(libraryServiceInstance.addGame).toHaveBeenCalledWith("/roms/zelda.nes", "nes");
+      expect(libraryServiceInstance.addGame).toHaveBeenCalledWith('/roms/zelda.nes', 'nes');
       expect(result).toEqual(game);
     });
   });
@@ -751,14 +804,14 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:removeGame
   // -----------------------------------------------------------------------
-  describe("library:removeGame", () => {
-    it("delegates to LibraryService.removeGame and returns success", async () => {
+  describe('library:removeGame', () => {
+    it('delegates to LibraryService.removeGame and returns success', async () => {
       libraryServiceInstance.removeGame.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:removeGame")!;
-      const result = await handler(fakeEvent, "game-123");
+      const handler = getHandler('library:removeGame');
+      const result = await handler(fakeEvent, 'game-123');
 
-      expect(libraryServiceInstance.removeGame).toHaveBeenCalledWith("game-123");
+      expect(libraryServiceInstance.removeGame).toHaveBeenCalledWith('game-123');
       expect(result).toEqual({ success: true });
     });
   });
@@ -766,16 +819,14 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:updateGame
   // -----------------------------------------------------------------------
-  describe("library:updateGame", () => {
-    it("delegates to LibraryService.updateGame and returns success", async () => {
+  describe('library:updateGame', () => {
+    it('delegates to LibraryService.updateGame and returns success', async () => {
       libraryServiceInstance.updateGame.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:updateGame")!;
-      const result = await handler(fakeEvent, "game-123", { favorite: true });
+      const handler = getHandler('library:updateGame');
+      const result = await handler(fakeEvent, 'game-123', { favorite: true });
 
-      expect(libraryServiceInstance.updateGame).toHaveBeenCalledWith("game-123", {
-        favorite: true,
-      });
+      expect(libraryServiceInstance.updateGame).toHaveBeenCalledWith('game-123', { favorite: true });
       expect(result).toEqual({ success: true });
     });
   });
@@ -783,25 +834,25 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 21. library:scanDirectory
   // -----------------------------------------------------------------------
-  describe("library:scanDirectory", () => {
-    it("delegates with directory and optional systemId", async () => {
-      const games = [{ id: "g1", title: "SMB" }];
+  describe('library:scanDirectory', () => {
+    it('delegates with directory and optional systemId', async () => {
+      const games = [{ id: 'g1', title: 'SMB' }];
       libraryServiceInstance.scanDirectory.mockResolvedValue(games);
 
-      const handler = getHandler("library:scanDirectory")!;
-      const result = await handler(fakeEvent, "/roms", "nes");
+      const handler = getHandler('library:scanDirectory');
+      const result = await handler(fakeEvent, '/roms', 'nes');
 
-      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith("/roms", "nes");
+      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith('/roms', 'nes');
       expect(result).toEqual(games);
     });
 
-    it("delegates without systemId", async () => {
+    it('delegates without systemId', async () => {
       libraryServiceInstance.scanDirectory.mockResolvedValue([]);
 
-      const handler = getHandler("library:scanDirectory")!;
-      const result = await handler(fakeEvent, "/roms");
+      const handler = getHandler('library:scanDirectory');
+      const result = await handler(fakeEvent, '/roms');
 
-      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith("/roms", undefined);
+      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith('/roms', undefined);
       expect(result).toEqual([]);
     });
   });
@@ -809,12 +860,12 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:scanSystemFolders
   // -----------------------------------------------------------------------
-  describe("library:scanSystemFolders", () => {
-    it("delegates to LibraryService.scanSystemFolders", async () => {
-      const games = [{ id: "g1", title: "SMB" }];
+  describe('library:scanSystemFolders', () => {
+    it('delegates to LibraryService.scanSystemFolders', async () => {
+      const games = [{ id: 'g1', title: 'SMB' }];
       libraryServiceInstance.scanSystemFolders.mockResolvedValue(games);
 
-      const handler = getHandler("library:scanSystemFolders")!;
+      const handler = getHandler('library:scanSystemFolders');
       const result = await handler(fakeEvent);
 
       expect(libraryServiceInstance.scanSystemFolders).toHaveBeenCalled();
@@ -825,12 +876,12 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:getConfig
   // -----------------------------------------------------------------------
-  describe("library:getConfig", () => {
-    it("delegates to LibraryService.getConfig", () => {
-      const config = { systems: [], romsBasePath: "/roms" };
+  describe('library:getConfig', () => {
+    it('delegates to LibraryService.getConfig', () => {
+      const config = { systems: [], romsBasePath: '/roms' };
       libraryServiceInstance.getConfig.mockReturnValue(config);
 
-      const handler = getHandler("library:getConfig")!;
+      const handler = getHandler('library:getConfig');
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getConfig).toHaveBeenCalled();
@@ -841,14 +892,14 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // library:setRomsBasePath
   // -----------------------------------------------------------------------
-  describe("library:setRomsBasePath", () => {
-    it("delegates to LibraryService.setRomsBasePath and returns success", async () => {
+  describe('library:setRomsBasePath', () => {
+    it('delegates to LibraryService.setRomsBasePath and returns success', async () => {
       libraryServiceInstance.setRomsBasePath.mockResolvedValue(undefined);
 
-      const handler = getHandler("library:setRomsBasePath")!;
-      const result = await handler(fakeEvent, "/new/roms");
+      const handler = getHandler('library:setRomsBasePath');
+      const result = await handler(fakeEvent, '/new/roms');
 
-      expect(libraryServiceInstance.setRomsBasePath).toHaveBeenCalledWith("/new/roms");
+      expect(libraryServiceInstance.setRomsBasePath).toHaveBeenCalledWith('/new/roms');
       expect(result).toEqual({ success: true });
     });
   });
@@ -856,30 +907,30 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 22. dialog:selectDirectory
   // -----------------------------------------------------------------------
-  describe("dialog:selectDirectory", () => {
-    it("returns the selected directory path", async () => {
+  describe('dialog:selectDirectory', () => {
+    it('returns the selected directory path', async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ["/selected/directory"],
+        filePaths: ['/selected/directory'],
       });
 
-      const handler = getHandler("dialog:selectDirectory")!;
+      const handler = getHandler('dialog:selectDirectory');
       const result = await handler(fakeEvent);
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ["openDirectory"],
-        title: "Select ROMs Directory",
+        properties: ['openDirectory'],
+        title: 'Select ROMs Directory',
       });
-      expect(result).toBe("/selected/directory");
+      expect(result).toBe('/selected/directory');
     });
 
-    it("returns null when dialog is canceled", async () => {
+    it('returns null when dialog is canceled', async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: true,
         filePaths: [],
       });
 
-      const handler = getHandler("dialog:selectDirectory")!;
+      const handler = getHandler('dialog:selectDirectory');
       const result = await handler(fakeEvent);
 
       expect(result).toBeNull();
@@ -889,57 +940,57 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 23. dialog:selectRomFile
   // -----------------------------------------------------------------------
-  describe("dialog:selectRomFile", () => {
-    it("filters by system extensions when system is found", async () => {
+  describe('dialog:selectRomFile', () => {
+    it('filters by system extensions when system is found', async () => {
       const nesSystem: GameSystem = {
-        id: "nes",
-        name: "Nintendo Entertainment System",
-        shortName: "NES",
-        extensions: [".nes", ".fds"],
+        id: 'nes',
+        name: 'Nintendo Entertainment System',
+        shortName: 'NES',
+        extensions: ['.nes', '.fds'],
       };
       libraryServiceInstance.getSystems.mockReturnValue([nesSystem]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ["/roms/smb.nes"],
+        filePaths: ['/roms/smb.nes'],
       });
 
-      const handler = getHandler("dialog:selectRomFile")!;
-      const result = await handler(fakeEvent, "nes");
+      const handler = getHandler('dialog:selectRomFile');
+      const result = await handler(fakeEvent, 'nes');
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ["openFile"],
-        title: "Select ROM File",
+        properties: ['openFile'],
+        title: 'Select ROM File',
         filters: [
           {
-            name: "Nintendo Entertainment System ROMs",
-            extensions: ["nes", "fds", "zip"],
+            name: 'Nintendo Entertainment System ROMs',
+            extensions: ['nes', 'fds', 'zip'],
           },
         ],
       });
-      expect(result).toBe("/roms/smb.nes");
+      expect(result).toBe('/roms/smb.nes');
     });
 
-    it("uses empty filters when system is not found", async () => {
+    it('uses empty filters when system is not found', async () => {
       libraryServiceInstance.getSystems.mockReturnValue([]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ["/roms/game.rom"],
+        filePaths: ['/roms/game.rom'],
       });
 
-      const handler = getHandler("dialog:selectRomFile")!;
-      const result = await handler(fakeEvent, "unknown");
+      const handler = getHandler('dialog:selectRomFile');
+      const result = await handler(fakeEvent, 'unknown');
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ["openFile"],
-        title: "Select ROM File",
+        properties: ['openFile'],
+        title: 'Select ROM File',
         filters: [],
       });
-      expect(result).toBe("/roms/game.rom");
+      expect(result).toBe('/roms/game.rom');
     });
 
-    it("returns null when dialog is canceled", async () => {
+    it('returns null when dialog is canceled', async () => {
       libraryServiceInstance.getSystems.mockReturnValue([]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
@@ -947,8 +998,8 @@ describe("IPCHandlers", () => {
         filePaths: [],
       });
 
-      const handler = getHandler("dialog:selectRomFile")!;
-      const result = await handler(fakeEvent, "nes");
+      const handler = getHandler('dialog:selectRomFile');
+      const result = await handler(fakeEvent, 'nes');
 
       expect(result).toBeNull();
     });
@@ -957,41 +1008,25 @@ describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 24. Event forwarding
   // -----------------------------------------------------------------------
-  describe("event forwarding", () => {
-    it("forwards emulatorManager events to all BrowserWindows", () => {
+  describe('event forwarding', () => {
+    it('forwards emulatorManager events to all BrowserWindows', () => {
       const sendMock = vi.fn();
       const fakeWindow = { webContents: { send: sendMock } };
-      vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([fakeWindow as any]);
+      vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([fakeWindow as unknown as BrowserWindowType]);
 
       const forwardedEvents = [
-        { emitterEvent: "gameLaunched", ipcEvent: "emulator:launched", data: { romPath: "/rom" } },
-        { emitterEvent: "emulator:exited", ipcEvent: "emulator:exited", data: { code: 0 } },
-        { emitterEvent: "emulator:error", ipcEvent: "emulator:error", data: { message: "oops" } },
-        { emitterEvent: "emulator:stateSaved", ipcEvent: "emulator:stateSaved", data: { slot: 1 } },
-        {
-          emitterEvent: "emulator:stateLoaded",
-          ipcEvent: "emulator:stateLoaded",
-          data: { slot: 1 },
-        },
-        {
-          emitterEvent: "emulator:screenshotTaken",
-          ipcEvent: "emulator:screenshotTaken",
-          data: { path: "/img.png" },
-        },
-        { emitterEvent: "emulator:paused", ipcEvent: "emulator:paused", data: undefined },
-        { emitterEvent: "emulator:resumed", ipcEvent: "emulator:resumed", data: undefined },
-        { emitterEvent: "emulator:reset", ipcEvent: "emulator:reset", data: undefined },
-        {
-          emitterEvent: "emulator:speedChanged",
-          ipcEvent: "emulator:speedChanged",
-          data: { multiplier: 2 },
-        },
-        { emitterEvent: "emulator:terminated", ipcEvent: "emulator:terminated", data: undefined },
-        {
-          emitterEvent: "core:downloadProgress",
-          ipcEvent: "core:downloadProgress",
-          data: { percent: 50 },
-        },
+        { emitterEvent: 'gameLaunched', ipcEvent: 'emulator:launched', data: { romPath: '/rom' } },
+        { emitterEvent: 'emulator:exited', ipcEvent: 'emulator:exited', data: { code: 0 } },
+        { emitterEvent: 'emulator:error', ipcEvent: 'emulator:error', data: { message: 'oops' } },
+        { emitterEvent: 'emulator:stateSaved', ipcEvent: 'emulator:stateSaved', data: { slot: 1 } },
+        { emitterEvent: 'emulator:stateLoaded', ipcEvent: 'emulator:stateLoaded', data: { slot: 1 } },
+        { emitterEvent: 'emulator:screenshotTaken', ipcEvent: 'emulator:screenshotTaken', data: { path: '/img.png' } },
+        { emitterEvent: 'emulator:paused', ipcEvent: 'emulator:paused', data: undefined },
+        { emitterEvent: 'emulator:resumed', ipcEvent: 'emulator:resumed', data: undefined },
+        { emitterEvent: 'emulator:reset', ipcEvent: 'emulator:reset', data: undefined },
+        { emitterEvent: 'emulator:speedChanged', ipcEvent: 'emulator:speedChanged', data: { multiplier: 2 } },
+        { emitterEvent: 'emulator:terminated', ipcEvent: 'emulator:terminated', data: undefined },
+        { emitterEvent: 'core:downloadProgress', ipcEvent: 'core:downloadProgress', data: { percent: 50 } },
       ];
 
       for (const { emitterEvent, ipcEvent, data } of forwardedEvents) {
@@ -1001,33 +1036,33 @@ describe("IPCHandlers", () => {
       }
     });
 
-    it("forwards events to multiple windows", () => {
+    it('forwards events to multiple windows', () => {
       const send1 = vi.fn();
       const send2 = vi.fn();
       vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
-        { webContents: { send: send1 } } as any,
-        { webContents: { send: send2 } } as any,
+        { webContents: { send: send1 } } as unknown as BrowserWindowType,
+        { webContents: { send: send2 } } as unknown as BrowserWindowType,
       ]);
 
-      emulatorEmitter.emit("emulator:paused");
+      emulatorEmitter.emit('emulator:paused');
 
-      expect(send1).toHaveBeenCalledWith("emulator:paused", undefined);
-      expect(send2).toHaveBeenCalledWith("emulator:paused", undefined);
+      expect(send1).toHaveBeenCalledWith('emulator:paused', undefined);
+      expect(send2).toHaveBeenCalledWith('emulator:paused', undefined);
     });
   });
 
   // -----------------------------------------------------------------------
   // 25. dialog:resumeGameResponse (ipcMain.on)
   // -----------------------------------------------------------------------
-  describe("dialog:resumeGameResponse", () => {
-    it("registers the resumeGameResponse listener", () => {
-      const listener = getOnListener("dialog:resumeGameResponse");
+  describe('dialog:resumeGameResponse', () => {
+    it('registers the resumeGameResponse listener', () => {
+      const listener = getOnListener('dialog:resumeGameResponse');
       expect(listener).toBeDefined();
     });
 
-    it("does not throw when called with an unknown requestId", () => {
-      const listener = getOnListener("dialog:resumeGameResponse")!;
-      expect(() => listener(fakeEvent, "unknown-id", true)).not.toThrow();
+    it('does not throw when called with an unknown requestId', () => {
+      const listener = getOnListener('dialog:resumeGameResponse');
+      expect(() => listener(fakeEvent, 'unknown-id', true)).not.toThrow();
     });
   });
 });

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EventEmitter } from 'events';
-import type { IpcMainInvokeEvent, BrowserWindow as BrowserWindowType } from 'electron';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { IpcMainInvokeEvent, BrowserWindow as BrowserWindowType } from "electron";
 
 // ---------------------------------------------------------------------------
 // Mocks — vi.mock calls are hoisted above imports by vitest
 // ---------------------------------------------------------------------------
 
-vi.mock('electron', () => ({
+vi.mock("electron", () => ({
   ipcMain: { handle: vi.fn(), on: vi.fn() },
   BrowserWindow: {
     getFocusedWindow: vi.fn(),
@@ -14,40 +14,40 @@ vi.mock('electron', () => ({
     fromWebContents: vi.fn(),
   },
   dialog: { showOpenDialog: vi.fn() },
-  app: { getPath: vi.fn(() => '/tmp/test') },
+  app: { getPath: vi.fn(() => "/tmp/test") },
 }));
 
-vi.mock('fs');
-vi.mock('path', async () => {
-  const actual = await vi.importActual<typeof import('path')>('path');
+vi.mock("fs");
+vi.mock("path", async () => {
+  const actual = await vi.importActual<typeof import("path")>("path");
   return { ...actual, default: actual };
 });
 
-vi.mock('../emulator/EmulatorManager');
-vi.mock('../emulator/LibretroNativeCore');
-vi.mock('../emulator/EmulationWorkerClient');
-vi.mock('../emulator/resolveAddonPath');
-vi.mock('../services/LibraryService');
-vi.mock('../services/ArtworkService');
-vi.mock('../GameWindowManager');
-vi.mock('../logger', () => ({
+vi.mock("../emulator/EmulatorManager");
+vi.mock("../emulator/LibretroNativeCore");
+vi.mock("../emulator/EmulationWorkerClient");
+vi.mock("../emulator/resolveAddonPath");
+vi.mock("../services/LibraryService");
+vi.mock("../services/ArtworkService");
+vi.mock("../GameWindowManager");
+vi.mock("../logger", () => ({
   ipcLog: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
-import { ipcMain, BrowserWindow, dialog, app } from 'electron';
-import { EmulatorManager } from '../emulator/EmulatorManager';
-import { EmulationWorkerClient } from '../emulator/EmulationWorkerClient';
-import { resolveAddonPath } from '../emulator/resolveAddonPath';
-import { LibraryService } from '../services/LibraryService';
-import { GameWindowManager } from '../GameWindowManager';
-import { IPCHandlers } from './handlers';
-import type { Game, GameSystem } from '../../types/library';
+import { ipcMain, BrowserWindow, dialog, app } from "electron";
+import { EmulatorManager } from "../emulator/EmulatorManager";
+import { EmulationWorkerClient } from "../emulator/EmulationWorkerClient";
+import { resolveAddonPath } from "../emulator/resolveAddonPath";
+import { LibraryService } from "../services/LibraryService";
+import { GameWindowManager } from "../GameWindowManager";
+import { IPCHandlers } from "./handlers";
+import type { Game, GameSystem } from "../../types/library";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-type IpcHandler = (...args: unknown[]) => unknown;
+type IpcHandler = (...args: Array<unknown>) => unknown;
 
 /**
  * Extract a registered ipcMain.handle handler by channel name.
@@ -56,7 +56,9 @@ type IpcHandler = (...args: unknown[]) => unknown;
 function getHandler(channel: string): IpcHandler {
   const calls = vi.mocked(ipcMain.handle).mock.calls;
   const match = calls.find(([ch]) => ch === channel);
-  if (!match) throw new Error(`No handler registered for channel: ${channel}`);
+  if (!match) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
   return match[1] as IpcHandler;
 }
 
@@ -67,7 +69,9 @@ function getHandler(channel: string): IpcHandler {
 function getOnListener(channel: string): IpcHandler {
   const calls = vi.mocked(ipcMain.on).mock.calls;
   const match = calls.find(([ch]) => ch === channel);
-  if (!match) throw new Error(`No listener registered for channel: ${channel}`);
+  if (!match) {
+    throw new Error(`No listener registered for channel: ${channel}`);
+  }
   return match[1] as IpcHandler;
 }
 
@@ -80,8 +84,8 @@ const fakeEvent = {} as unknown as IpcMainInvokeEvent;
 
 interface MockEmulatorManager {
   on: ReturnType<typeof vi.fn>;
-  emit: (...args: unknown[]) => boolean;
-  removeListener: (...args: unknown[]) => EventEmitter;
+  emit: (...args: Array<unknown>) => boolean;
+  removeListener: (...args: Array<unknown>) => EventEmitter;
   getCoresForSystem: ReturnType<typeof vi.fn>;
   getCoreDownloader: ReturnType<typeof vi.fn>;
   launchGame: ReturnType<typeof vi.fn>;
@@ -156,7 +160,7 @@ let emulatorEmitter: EventEmitter;
 
 const fakeAvInfo = {
   geometry: { baseWidth: 256, baseHeight: 240, maxWidth: 256, maxHeight: 240, aspectRatio: 1.333 },
-  timing: { fps: 60, sampleRate: 44100 },
+  timing: { fps: 60, sampleRate: 44_100 },
 };
 
 beforeEach(() => {
@@ -165,7 +169,7 @@ beforeEach(() => {
 
   // Re-apply electron mock defaults that resetAllMocks wipes
   vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([]);
-  vi.mocked(app).getPath = vi.fn(() => '/tmp/test');
+  vi.mocked(app).getPath = vi.fn(() => "/tmp/test");
 
   // Fresh EventEmitter for EmulatorManager event forwarding
   emulatorEmitter = new EventEmitter();
@@ -192,7 +196,7 @@ beforeEach(() => {
       loadState: vi.fn(),
       screenshot: vi.fn(),
       setWorkerClient: vi.fn(),
-      validateBios: vi.fn(() => ({ valid: true, missingFiles: [], biosDir: '', systemName: '' })),
+      validateBios: vi.fn(() => ({ valid: true, missingFiles: [], biosDir: "", systemName: "" })),
     }) as unknown as MockEmulatorManager;
     return emulatorManagerInstance as unknown as EmulatorManager;
   } as unknown as () => EmulatorManager);
@@ -218,7 +222,7 @@ beforeEach(() => {
   } as unknown as () => EmulationWorkerClient);
 
   // Configure resolveAddonPath mock
-  vi.mocked(resolveAddonPath).mockReturnValue('/fake/addon.node');
+  vi.mocked(resolveAddonPath).mockReturnValue("/fake/addon.node");
 
   // Configure LibraryService mock constructor
   vi.mocked(LibraryService).mockImplementation(function (this: Record<string, unknown>) {
@@ -251,61 +255,61 @@ beforeEach(() => {
   } as unknown as () => GameWindowManager);
 
   // Instantiate IPCHandlers — triggers all handler registrations
-  new IPCHandlers('/fake/preload.js');
+  new IPCHandlers("/fake/preload.js");
 });
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('IPCHandlers', () => {
+describe("IPCHandlers", () => {
   // -----------------------------------------------------------------------
   // 1. Registration
   // -----------------------------------------------------------------------
-  describe('constructor', () => {
-    it('registers all expected IPC channels', () => {
+  describe("constructor", () => {
+    it("registers all expected IPC channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
       const onCalls = vi.mocked(ipcMain.on).mock.calls.map(([ch]) => ch);
 
       const expectedHandleChannels = [
-        'emulator:getCoresForSystem',
-        'emulator:downloadCore',
-        'emulator:launch',
-        'emulator:stop',
-        'emulator:getAvailable',
-        'emulator:isRunning',
-        'emulation:pause',
-        'emulation:resume',
-        'emulation:reset',
-        'emulation:setSpeed',
-        'emulation:setFastForwardAudio',
-        'savestate:save',
-        'savestate:load',
-        'emulation:screenshot',
-        'library:getSystems',
-        'library:addSystem',
-        'library:removeSystem',
-        'library:updateSystemPath',
-        'library:getGames',
-        'library:addGame',
-        'library:removeGame',
-        'library:updateGame',
-        'library:scanDirectory',
-        'library:scanSystemFolders',
-        'library:getConfig',
-        'library:setRomsBasePath',
-        'dialog:selectDirectory',
-        'dialog:selectRomFile',
+        "emulator:getCoresForSystem",
+        "emulator:downloadCore",
+        "emulator:launch",
+        "emulator:stop",
+        "emulator:getAvailable",
+        "emulator:isRunning",
+        "emulation:pause",
+        "emulation:resume",
+        "emulation:reset",
+        "emulation:setSpeed",
+        "emulation:setFastForwardAudio",
+        "savestate:save",
+        "savestate:load",
+        "emulation:screenshot",
+        "library:getSystems",
+        "library:addSystem",
+        "library:removeSystem",
+        "library:updateSystemPath",
+        "library:getGames",
+        "library:addGame",
+        "library:removeGame",
+        "library:updateGame",
+        "library:scanDirectory",
+        "library:scanSystemFolders",
+        "library:getConfig",
+        "library:setRomsBasePath",
+        "dialog:selectDirectory",
+        "dialog:selectRomFile",
       ];
 
       for (const channel of expectedHandleChannels) {
         expect(handleCalls, `Missing handle channel: ${channel}`).toContain(channel);
       }
 
-      expect(onCalls).toContain('dialog:resumeGameResponse');
+      expect(onCalls).toContain("dialog:resumeGameResponse");
     });
 
-    it('registers exactly the expected number of handle channels', () => {
+    it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
       expect(handleCalls).toHaveLength(36);
     });
@@ -314,15 +318,15 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 2. emulator:getCoresForSystem
   // -----------------------------------------------------------------------
-  describe('emulator:getCoresForSystem', () => {
-    it('delegates to EmulatorManager.getCoresForSystem', async () => {
-      const cores = [{ name: 'fceumm', installed: true }];
+  describe("emulator:getCoresForSystem", () => {
+    it("delegates to EmulatorManager.getCoresForSystem", async () => {
+      const cores = [{ name: "fceumm", installed: true }];
       emulatorManagerInstance.getCoresForSystem.mockReturnValue(cores);
 
-      const handler = getHandler('emulator:getCoresForSystem');
-      const result = await handler(fakeEvent, 'nes');
+      const handler = getHandler("emulator:getCoresForSystem");
+      const result = await handler(fakeEvent, "nes");
 
-      expect(emulatorManagerInstance.getCoresForSystem).toHaveBeenCalledWith('nes');
+      expect(emulatorManagerInstance.getCoresForSystem).toHaveBeenCalledWith("nes");
       expect(result).toEqual(cores);
     });
   });
@@ -330,43 +334,43 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 3-4. emulator:downloadCore
   // -----------------------------------------------------------------------
-  describe('emulator:downloadCore', () => {
-    it('returns success with corePath on successful download', async () => {
-      const downloadMock = vi.fn().mockResolvedValue('/cores/fceumm.dylib');
+  describe("emulator:downloadCore", () => {
+    it("returns success with corePath on successful download", async () => {
+      const downloadMock = vi.fn().mockResolvedValue("/cores/fceumm.dylib");
       emulatorManagerInstance.getCoreDownloader.mockReturnValue({ downloadCore: downloadMock });
 
-      const handler = getHandler('emulator:downloadCore');
-      const result = await handler(fakeEvent, 'fceumm', 'nes');
+      const handler = getHandler("emulator:downloadCore");
+      const result = await handler(fakeEvent, "fceumm", "nes");
 
-      expect(downloadMock).toHaveBeenCalledWith('fceumm', 'nes');
-      expect(result).toEqual({ success: true, corePath: '/cores/fceumm.dylib' });
+      expect(downloadMock).toHaveBeenCalledWith("fceumm", "nes");
+      expect(result).toEqual({ success: true, corePath: "/cores/fceumm.dylib" });
     });
 
-    it('returns { success: false, error } on failure', async () => {
-      const downloadMock = vi.fn().mockRejectedValue(new Error('Network error'));
+    it("returns { success: false, error } on failure", async () => {
+      const downloadMock = vi.fn().mockRejectedValue(new Error("Network error"));
       emulatorManagerInstance.getCoreDownloader.mockReturnValue({ downloadCore: downloadMock });
 
-      const handler = getHandler('emulator:downloadCore');
-      const result = await handler(fakeEvent, 'fceumm', 'nes');
+      const handler = getHandler("emulator:downloadCore");
+      const result = await handler(fakeEvent, "fceumm", "nes");
 
-      expect(result).toEqual({ success: false, error: 'Network error' });
+      expect(result).toEqual({ success: false, error: "Network error" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 5-6. emulator:launch
   // -----------------------------------------------------------------------
-  describe('emulator:launch', () => {
+  describe("emulator:launch", () => {
     const fakeGame: Game = {
-      id: 'game-1',
-      title: 'Super Mario Bros',
-      system: 'NES',
-      systemId: 'nes',
-      romPath: '/roms/smb.nes',
-      romHashes: { crc32: 'deadbeef', sha1: 'a'.repeat(40), md5: 'b'.repeat(32) },
+      id: "game-1",
+      title: "Super Mario Bros",
+      system: "NES",
+      systemId: "nes",
+      romPath: "/roms/smb.nes",
+      romHashes: { crc32: "deadbeef", sha1: "a".repeat(40), md5: "b".repeat(32) },
     };
 
-    it('launches in native mode successfully', async () => {
+    it("launches in native mode successfully", async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(true);
@@ -374,81 +378,92 @@ describe('IPCHandlers', () => {
       const nativeCoreMock = {
         hasAutoSave: vi.fn(() => false),
         deleteAutoSave: vi.fn(),
-        getCorePath: vi.fn(() => '/cores/fceumm.dylib'),
-        getRomPath: vi.fn(() => '/roms/smb.nes'),
-        getSystemDir: vi.fn(() => '/bios'),
-        getSaveDir: vi.fn(() => '/saves'),
-        getSramDir: vi.fn(() => '/saves'),
-        getSaveStatesDir: vi.fn(() => '/savestates'),
+        getCorePath: vi.fn(() => "/cores/fceumm.dylib"),
+        getRomPath: vi.fn(() => "/roms/smb.nes"),
+        getSystemDir: vi.fn(() => "/bios"),
+        getSaveDir: vi.fn(() => "/saves"),
+        getSramDir: vi.fn(() => "/saves"),
+        getSaveStatesDir: vi.fn(() => "/savestates"),
       };
       emulatorManagerInstance.getCurrentEmulator.mockReturnValue(nativeCoreMock);
       gameWindowManagerInstance.createNativeGameWindow.mockReturnValue({});
 
-      const handler = getHandler('emulator:launch');
-      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', undefined, 'fceumm');
+      const handler = getHandler("emulator:launch");
+      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", undefined, "fceumm");
 
-      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith('nes');
+      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith("nes");
       expect(emulatorManagerInstance.launchGame).toHaveBeenCalledWith(
-        '/roms/smb.nes', 'nes', undefined, undefined, 'fceumm',
+        "/roms/smb.nes",
+        "nes",
+        undefined,
+        undefined,
+        "fceumm",
       );
       // Worker client should have been initialized with paths from the native core
       expect(workerClientInstance.init).toHaveBeenCalledWith({
-        corePath: '/cores/fceumm.dylib',
-        romPath: '/roms/smb.nes',
-        systemDir: '/bios',
-        saveDir: '/saves',
-        sramDir: '/saves',
-        saveStatesDir: '/savestates',
-        addonPath: '/fake/addon.node',
+        corePath: "/cores/fceumm.dylib",
+        romPath: "/roms/smb.nes",
+        systemDir: "/bios",
+        saveDir: "/saves",
+        sramDir: "/saves",
+        saveStatesDir: "/savestates",
+        addonPath: "/fake/addon.node",
       });
       expect(emulatorManagerInstance.setWorkerClient).toHaveBeenCalledWith(workerClientInstance);
       expect(gameWindowManagerInstance.createNativeGameWindow).toHaveBeenCalledWith(
-        fakeGame, workerClientInstance, fakeAvInfo, false, undefined,
+        fakeGame,
+        workerClientInstance,
+        fakeAvInfo,
+        false,
+        undefined,
       );
       expect(result).toEqual({ success: true });
     });
 
-    it('launches in legacy overlay mode successfully', async () => {
+    it("launches in legacy overlay mode successfully", async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(false);
-      emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(12345);
+      emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(12_345);
 
-      const handler = getHandler('emulator:launch');
-      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', 'retroarch');
+      const handler = getHandler("emulator:launch");
+      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", "retroarch");
 
       expect(gameWindowManagerInstance.createGameWindow).toHaveBeenCalledWith(fakeGame);
-      expect(gameWindowManagerInstance.startTrackingRetroArchWindow).toHaveBeenCalledWith('game-1', 12345);
+      expect(gameWindowManagerInstance.startTrackingRetroArchWindow).toHaveBeenCalledWith(
+        "game-1",
+        12_345,
+      );
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when game is not found in library', async () => {
+    it("returns error when game is not found in library", async () => {
       libraryServiceInstance.getGames.mockReturnValue([]);
 
-      const handler = getHandler('emulator:launch');
-      const result = await handler(fakeEvent, '/roms/missing.nes', 'nes');
+      const handler = getHandler("emulator:launch");
+      const result = await handler(fakeEvent, "/roms/missing.nes", "nes");
 
-      expect(result).toEqual({ success: false, error: 'Game not found in library' });
+      expect(result).toEqual({ success: false, error: "Game not found in library" });
     });
 
-    it('returns error when launchGame throws', async () => {
+    it("returns error when launchGame throws", async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
-      emulatorManagerInstance.launchGame.mockRejectedValue(new Error('Core not found'));
+      emulatorManagerInstance.launchGame.mockRejectedValue(new Error("Core not found"));
 
-      const handler = getHandler('emulator:launch');
-      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes');
+      const handler = getHandler("emulator:launch");
+      const result = await handler(fakeEvent, "/roms/smb.nes", "nes");
 
-      expect(result).toEqual({ success: false, error: 'Core not found' });
+      expect(result).toEqual({ success: false, error: "Core not found" });
     });
 
-    it('does not track RetroArch window when PID is unavailable', async () => {
+    it("does not track RetroArch window when PID is unavailable", async () => {
       libraryServiceInstance.getGames.mockReturnValue([fakeGame]);
       emulatorManagerInstance.launchGame.mockResolvedValue(undefined);
       emulatorManagerInstance.isNativeMode.mockReturnValue(false);
       emulatorManagerInstance.getCurrentEmulatorPid.mockReturnValue(undefined);
 
-      const handler = getHandler('emulator:launch');
-      const result = await handler(fakeEvent, '/roms/smb.nes', 'nes', 'retroarch');
+      const handler = getHandler("emulator:launch");
+      const result = await handler(fakeEvent, "/roms/smb.nes", "nes", "retroarch");
 
       expect(gameWindowManagerInstance.createGameWindow).toHaveBeenCalledWith(fakeGame);
       expect(gameWindowManagerInstance.startTrackingRetroArchWindow).not.toHaveBeenCalled();
@@ -459,36 +474,36 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 7. emulator:stop
   // -----------------------------------------------------------------------
-  describe('emulator:stop', () => {
-    it('returns success on successful stop', async () => {
+  describe("emulator:stop", () => {
+    it("returns success on successful stop", async () => {
       emulatorManagerInstance.stopEmulator.mockResolvedValue(undefined);
 
-      const handler = getHandler('emulator:stop');
+      const handler = getHandler("emulator:stop");
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.stopEmulator).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error on failure', async () => {
-      emulatorManagerInstance.stopEmulator.mockRejectedValue(new Error('Stop failed'));
+    it("returns error on failure", async () => {
+      emulatorManagerInstance.stopEmulator.mockRejectedValue(new Error("Stop failed"));
 
-      const handler = getHandler('emulator:stop');
+      const handler = getHandler("emulator:stop");
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: 'Stop failed' });
+      expect(result).toEqual({ success: false, error: "Stop failed" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 8. emulator:getAvailable
   // -----------------------------------------------------------------------
-  describe('emulator:getAvailable', () => {
-    it('delegates to EmulatorManager.getAvailableEmulators', () => {
-      const emulators = [{ id: 'retroarch', name: 'RetroArch' }];
+  describe("emulator:getAvailable", () => {
+    it("delegates to EmulatorManager.getAvailableEmulators", () => {
+      const emulators = [{ id: "retroarch", name: "RetroArch" }];
       emulatorManagerInstance.getAvailableEmulators.mockReturnValue(emulators);
 
-      const handler = getHandler('emulator:getAvailable');
+      const handler = getHandler("emulator:getAvailable");
       const result = handler(fakeEvent);
 
       expect(emulatorManagerInstance.getAvailableEmulators).toHaveBeenCalled();
@@ -499,11 +514,11 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 9. emulator:isRunning
   // -----------------------------------------------------------------------
-  describe('emulator:isRunning', () => {
-    it('delegates to EmulatorManager.isEmulatorRunning', () => {
+  describe("emulator:isRunning", () => {
+    it("delegates to EmulatorManager.isEmulatorRunning", () => {
       emulatorManagerInstance.isEmulatorRunning.mockReturnValue(true);
 
-      const handler = getHandler('emulator:isRunning');
+      const handler = getHandler("emulator:isRunning");
       const result = handler(fakeEvent);
 
       expect(emulatorManagerInstance.isEmulatorRunning).toHaveBeenCalled();
@@ -514,194 +529,194 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 10. emulation:pause
   // -----------------------------------------------------------------------
-  describe('emulation:pause', () => {
-    it('returns success when pause succeeds', async () => {
+  describe("emulation:pause", () => {
+    it("returns success when pause succeeds", async () => {
       emulatorManagerInstance.pause.mockResolvedValue(undefined);
 
-      const handler = getHandler('emulation:pause');
+      const handler = getHandler("emulation:pause");
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.pause).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when pause fails', async () => {
-      emulatorManagerInstance.pause.mockRejectedValue(new Error('No emulator running'));
+    it("returns error when pause fails", async () => {
+      emulatorManagerInstance.pause.mockRejectedValue(new Error("No emulator running"));
 
-      const handler = getHandler('emulation:pause');
+      const handler = getHandler("emulation:pause");
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: 'No emulator running' });
+      expect(result).toEqual({ success: false, error: "No emulator running" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 11. emulation:resume
   // -----------------------------------------------------------------------
-  describe('emulation:resume', () => {
-    it('returns success when resume succeeds', async () => {
+  describe("emulation:resume", () => {
+    it("returns success when resume succeeds", async () => {
       emulatorManagerInstance.resume.mockResolvedValue(undefined);
 
-      const handler = getHandler('emulation:resume');
+      const handler = getHandler("emulation:resume");
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.resume).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when resume fails', async () => {
-      emulatorManagerInstance.resume.mockRejectedValue(new Error('No emulator running'));
+    it("returns error when resume fails", async () => {
+      emulatorManagerInstance.resume.mockRejectedValue(new Error("No emulator running"));
 
-      const handler = getHandler('emulation:resume');
+      const handler = getHandler("emulation:resume");
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: 'No emulator running' });
+      expect(result).toEqual({ success: false, error: "No emulator running" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 12. emulation:reset
   // -----------------------------------------------------------------------
-  describe('emulation:reset', () => {
-    it('returns success when reset succeeds', async () => {
+  describe("emulation:reset", () => {
+    it("returns success when reset succeeds", async () => {
       emulatorManagerInstance.reset.mockResolvedValue(undefined);
 
-      const handler = getHandler('emulation:reset');
+      const handler = getHandler("emulation:reset");
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.reset).toHaveBeenCalled();
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when reset fails', async () => {
-      emulatorManagerInstance.reset.mockRejectedValue(new Error('No emulator running'));
+    it("returns error when reset fails", async () => {
+      emulatorManagerInstance.reset.mockRejectedValue(new Error("No emulator running"));
 
-      const handler = getHandler('emulation:reset');
+      const handler = getHandler("emulation:reset");
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: 'No emulator running' });
+      expect(result).toEqual({ success: false, error: "No emulator running" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 12b. emulation:setSpeed
   // -----------------------------------------------------------------------
-  describe('emulation:setSpeed', () => {
-    it('returns success when setSpeed succeeds', async () => {
+  describe("emulation:setSpeed", () => {
+    it("returns success when setSpeed succeeds", async () => {
       emulatorManagerInstance.setSpeed = vi.fn();
 
-      const handler = getHandler('emulation:setSpeed');
+      const handler = getHandler("emulation:setSpeed");
       const result = await handler(fakeEvent, 2);
 
       expect(emulatorManagerInstance.setSpeed).toHaveBeenCalledWith(2);
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when setSpeed fails', async () => {
+    it("returns error when setSpeed fails", async () => {
       emulatorManagerInstance.setSpeed = vi.fn(() => {
-        throw new Error('No emulator running');
+        throw new Error("No emulator running");
       });
 
-      const handler = getHandler('emulation:setSpeed');
+      const handler = getHandler("emulation:setSpeed");
       const result = await handler(fakeEvent, 4);
 
-      expect(result).toEqual({ success: false, error: 'No emulator running' });
+      expect(result).toEqual({ success: false, error: "No emulator running" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 13. savestate:save
   // -----------------------------------------------------------------------
-  describe('savestate:save', () => {
-    it('returns success when save state succeeds', async () => {
+  describe("savestate:save", () => {
+    it("returns success when save state succeeds", async () => {
       emulatorManagerInstance.saveState.mockResolvedValue(undefined);
 
-      const handler = getHandler('savestate:save');
+      const handler = getHandler("savestate:save");
       const result = await handler(fakeEvent, 2);
 
       expect(emulatorManagerInstance.saveState).toHaveBeenCalledWith(2);
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when save state fails', async () => {
-      emulatorManagerInstance.saveState.mockRejectedValue(new Error('Save failed'));
+    it("returns error when save state fails", async () => {
+      emulatorManagerInstance.saveState.mockRejectedValue(new Error("Save failed"));
 
-      const handler = getHandler('savestate:save');
+      const handler = getHandler("savestate:save");
       const result = await handler(fakeEvent, 1);
 
-      expect(result).toEqual({ success: false, error: 'Save failed' });
+      expect(result).toEqual({ success: false, error: "Save failed" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 14. savestate:load
   // -----------------------------------------------------------------------
-  describe('savestate:load', () => {
-    it('returns success when load state succeeds', async () => {
+  describe("savestate:load", () => {
+    it("returns success when load state succeeds", async () => {
       emulatorManagerInstance.loadState.mockResolvedValue(undefined);
 
-      const handler = getHandler('savestate:load');
+      const handler = getHandler("savestate:load");
       const result = await handler(fakeEvent, 3);
 
       expect(emulatorManagerInstance.loadState).toHaveBeenCalledWith(3);
       expect(result).toEqual({ success: true });
     });
 
-    it('returns error when load state fails', async () => {
-      emulatorManagerInstance.loadState.mockRejectedValue(new Error('Slot empty'));
+    it("returns error when load state fails", async () => {
+      emulatorManagerInstance.loadState.mockRejectedValue(new Error("Slot empty"));
 
-      const handler = getHandler('savestate:load');
+      const handler = getHandler("savestate:load");
       const result = await handler(fakeEvent, 0);
 
-      expect(result).toEqual({ success: false, error: 'Slot empty' });
+      expect(result).toEqual({ success: false, error: "Slot empty" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 15. emulation:screenshot
   // -----------------------------------------------------------------------
-  describe('emulation:screenshot', () => {
-    it('returns success with path when screenshot succeeds', async () => {
-      emulatorManagerInstance.screenshot.mockResolvedValue('/screenshots/screen.png');
+  describe("emulation:screenshot", () => {
+    it("returns success with path when screenshot succeeds", async () => {
+      emulatorManagerInstance.screenshot.mockResolvedValue("/screenshots/screen.png");
 
-      const handler = getHandler('emulation:screenshot');
-      const result = await handler(fakeEvent, '/screenshots/screen.png');
+      const handler = getHandler("emulation:screenshot");
+      const result = await handler(fakeEvent, "/screenshots/screen.png");
 
-      expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith('/screenshots/screen.png');
-      expect(result).toEqual({ success: true, path: '/screenshots/screen.png' });
+      expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith("/screenshots/screen.png");
+      expect(result).toEqual({ success: true, path: "/screenshots/screen.png" });
     });
 
-    it('uses default output path when none provided', async () => {
-      emulatorManagerInstance.screenshot.mockResolvedValue('/tmp/default.png');
+    it("uses default output path when none provided", async () => {
+      emulatorManagerInstance.screenshot.mockResolvedValue("/tmp/default.png");
 
-      const handler = getHandler('emulation:screenshot');
+      const handler = getHandler("emulation:screenshot");
       const result = await handler(fakeEvent);
 
       expect(emulatorManagerInstance.screenshot).toHaveBeenCalledWith(undefined);
-      expect(result).toEqual({ success: true, path: '/tmp/default.png' });
+      expect(result).toEqual({ success: true, path: "/tmp/default.png" });
     });
 
-    it('returns error when screenshot fails', async () => {
-      emulatorManagerInstance.screenshot.mockRejectedValue(new Error('No emulator running'));
+    it("returns error when screenshot fails", async () => {
+      emulatorManagerInstance.screenshot.mockRejectedValue(new Error("No emulator running"));
 
-      const handler = getHandler('emulation:screenshot');
+      const handler = getHandler("emulation:screenshot");
       const result = await handler(fakeEvent);
 
-      expect(result).toEqual({ success: false, error: 'No emulator running' });
+      expect(result).toEqual({ success: false, error: "No emulator running" });
     });
   });
 
   // -----------------------------------------------------------------------
   // 16. library:getSystems
   // -----------------------------------------------------------------------
-  describe('library:getSystems', () => {
-    it('delegates to LibraryService.getSystems', () => {
-      const systems: GameSystem[] = [
-        { id: 'nes', name: 'NES', shortName: 'NES', extensions: ['.nes'] },
+  describe("library:getSystems", () => {
+    it("delegates to LibraryService.getSystems", () => {
+      const systems: Array<GameSystem> = [
+        { id: "nes", name: "NES", shortName: "NES", extensions: [".nes"] },
       ];
       libraryServiceInstance.getSystems.mockReturnValue(systems);
 
-      const handler = getHandler('library:getSystems');
+      const handler = getHandler("library:getSystems");
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getSystems).toHaveBeenCalled();
@@ -712,17 +727,17 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 17. library:addSystem
   // -----------------------------------------------------------------------
-  describe('library:addSystem', () => {
-    it('delegates to LibraryService.addSystem and returns success', async () => {
+  describe("library:addSystem", () => {
+    it("delegates to LibraryService.addSystem and returns success", async () => {
       const newSystem: GameSystem = {
-        id: 'gba',
-        name: 'Game Boy Advance',
-        shortName: 'GBA',
-        extensions: ['.gba'],
+        id: "gba",
+        name: "Game Boy Advance",
+        shortName: "GBA",
+        extensions: [".gba"],
       };
       libraryServiceInstance.addSystem.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:addSystem');
+      const handler = getHandler("library:addSystem");
       const result = await handler(fakeEvent, newSystem);
 
       expect(libraryServiceInstance.addSystem).toHaveBeenCalledWith(newSystem);
@@ -733,14 +748,14 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 18. library:removeSystem
   // -----------------------------------------------------------------------
-  describe('library:removeSystem', () => {
-    it('delegates to LibraryService.removeSystem and returns success', async () => {
+  describe("library:removeSystem", () => {
+    it("delegates to LibraryService.removeSystem and returns success", async () => {
       libraryServiceInstance.removeSystem.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:removeSystem');
-      const result = await handler(fakeEvent, 'nes');
+      const handler = getHandler("library:removeSystem");
+      const result = await handler(fakeEvent, "nes");
 
-      expect(libraryServiceInstance.removeSystem).toHaveBeenCalledWith('nes');
+      expect(libraryServiceInstance.removeSystem).toHaveBeenCalledWith("nes");
       expect(result).toEqual({ success: true });
     });
   });
@@ -748,14 +763,14 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:updateSystemPath
   // -----------------------------------------------------------------------
-  describe('library:updateSystemPath', () => {
-    it('delegates to LibraryService.updateSystemPath and returns success', async () => {
+  describe("library:updateSystemPath", () => {
+    it("delegates to LibraryService.updateSystemPath and returns success", async () => {
       libraryServiceInstance.updateSystemPath.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:updateSystemPath');
-      const result = await handler(fakeEvent, 'nes', '/roms/nes');
+      const handler = getHandler("library:updateSystemPath");
+      const result = await handler(fakeEvent, "nes", "/roms/nes");
 
-      expect(libraryServiceInstance.updateSystemPath).toHaveBeenCalledWith('nes', '/roms/nes');
+      expect(libraryServiceInstance.updateSystemPath).toHaveBeenCalledWith("nes", "/roms/nes");
       expect(result).toEqual({ success: true });
     });
   });
@@ -763,22 +778,22 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 19. library:getGames
   // -----------------------------------------------------------------------
-  describe('library:getGames', () => {
-    it('delegates with systemId filter', () => {
-      const games = [{ id: 'g1', title: 'SMB', systemId: 'nes' }];
+  describe("library:getGames", () => {
+    it("delegates with systemId filter", () => {
+      const games = [{ id: "g1", title: "SMB", systemId: "nes" }];
       libraryServiceInstance.getGames.mockReturnValue(games);
 
-      const handler = getHandler('library:getGames');
-      const result = handler(fakeEvent, 'nes');
+      const handler = getHandler("library:getGames");
+      const result = handler(fakeEvent, "nes");
 
-      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith('nes');
+      expect(libraryServiceInstance.getGames).toHaveBeenCalledWith("nes");
       expect(result).toEqual(games);
     });
 
-    it('delegates without systemId to get all games', () => {
+    it("delegates without systemId to get all games", () => {
       libraryServiceInstance.getGames.mockReturnValue([]);
 
-      const handler = getHandler('library:getGames');
+      const handler = getHandler("library:getGames");
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getGames).toHaveBeenCalledWith(undefined);
@@ -789,15 +804,15 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 20. library:addGame
   // -----------------------------------------------------------------------
-  describe('library:addGame', () => {
-    it('delegates to LibraryService.addGame and returns the game', async () => {
-      const game = { id: 'g1', title: 'Zelda', systemId: 'nes', romPath: '/roms/zelda.nes' };
+  describe("library:addGame", () => {
+    it("delegates to LibraryService.addGame and returns the game", async () => {
+      const game = { id: "g1", title: "Zelda", systemId: "nes", romPath: "/roms/zelda.nes" };
       libraryServiceInstance.addGame.mockResolvedValue(game);
 
-      const handler = getHandler('library:addGame');
-      const result = await handler(fakeEvent, '/roms/zelda.nes', 'nes');
+      const handler = getHandler("library:addGame");
+      const result = await handler(fakeEvent, "/roms/zelda.nes", "nes");
 
-      expect(libraryServiceInstance.addGame).toHaveBeenCalledWith('/roms/zelda.nes', 'nes');
+      expect(libraryServiceInstance.addGame).toHaveBeenCalledWith("/roms/zelda.nes", "nes");
       expect(result).toEqual(game);
     });
   });
@@ -805,14 +820,14 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:removeGame
   // -----------------------------------------------------------------------
-  describe('library:removeGame', () => {
-    it('delegates to LibraryService.removeGame and returns success', async () => {
+  describe("library:removeGame", () => {
+    it("delegates to LibraryService.removeGame and returns success", async () => {
       libraryServiceInstance.removeGame.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:removeGame');
-      const result = await handler(fakeEvent, 'game-123');
+      const handler = getHandler("library:removeGame");
+      const result = await handler(fakeEvent, "game-123");
 
-      expect(libraryServiceInstance.removeGame).toHaveBeenCalledWith('game-123');
+      expect(libraryServiceInstance.removeGame).toHaveBeenCalledWith("game-123");
       expect(result).toEqual({ success: true });
     });
   });
@@ -820,14 +835,16 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:updateGame
   // -----------------------------------------------------------------------
-  describe('library:updateGame', () => {
-    it('delegates to LibraryService.updateGame and returns success', async () => {
+  describe("library:updateGame", () => {
+    it("delegates to LibraryService.updateGame and returns success", async () => {
       libraryServiceInstance.updateGame.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:updateGame');
-      const result = await handler(fakeEvent, 'game-123', { favorite: true });
+      const handler = getHandler("library:updateGame");
+      const result = await handler(fakeEvent, "game-123", { favorite: true });
 
-      expect(libraryServiceInstance.updateGame).toHaveBeenCalledWith('game-123', { favorite: true });
+      expect(libraryServiceInstance.updateGame).toHaveBeenCalledWith("game-123", {
+        favorite: true,
+      });
       expect(result).toEqual({ success: true });
     });
   });
@@ -835,25 +852,25 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 21. library:scanDirectory
   // -----------------------------------------------------------------------
-  describe('library:scanDirectory', () => {
-    it('delegates with directory and optional systemId', async () => {
-      const games = [{ id: 'g1', title: 'SMB' }];
+  describe("library:scanDirectory", () => {
+    it("delegates with directory and optional systemId", async () => {
+      const games = [{ id: "g1", title: "SMB" }];
       libraryServiceInstance.scanDirectory.mockResolvedValue(games);
 
-      const handler = getHandler('library:scanDirectory');
-      const result = await handler(fakeEvent, '/roms', 'nes');
+      const handler = getHandler("library:scanDirectory");
+      const result = await handler(fakeEvent, "/roms", "nes");
 
-      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith('/roms', 'nes');
+      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith("/roms", "nes");
       expect(result).toEqual(games);
     });
 
-    it('delegates without systemId', async () => {
+    it("delegates without systemId", async () => {
       libraryServiceInstance.scanDirectory.mockResolvedValue([]);
 
-      const handler = getHandler('library:scanDirectory');
-      const result = await handler(fakeEvent, '/roms');
+      const handler = getHandler("library:scanDirectory");
+      const result = await handler(fakeEvent, "/roms");
 
-      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith('/roms', undefined);
+      expect(libraryServiceInstance.scanDirectory).toHaveBeenCalledWith("/roms", undefined);
       expect(result).toEqual([]);
     });
   });
@@ -861,12 +878,12 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:scanSystemFolders
   // -----------------------------------------------------------------------
-  describe('library:scanSystemFolders', () => {
-    it('delegates to LibraryService.scanSystemFolders', async () => {
-      const games = [{ id: 'g1', title: 'SMB' }];
+  describe("library:scanSystemFolders", () => {
+    it("delegates to LibraryService.scanSystemFolders", async () => {
+      const games = [{ id: "g1", title: "SMB" }];
       libraryServiceInstance.scanSystemFolders.mockResolvedValue(games);
 
-      const handler = getHandler('library:scanSystemFolders');
+      const handler = getHandler("library:scanSystemFolders");
       const result = await handler(fakeEvent);
 
       expect(libraryServiceInstance.scanSystemFolders).toHaveBeenCalled();
@@ -877,12 +894,12 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:getConfig
   // -----------------------------------------------------------------------
-  describe('library:getConfig', () => {
-    it('delegates to LibraryService.getConfig', () => {
-      const config = { systems: [], romsBasePath: '/roms' };
+  describe("library:getConfig", () => {
+    it("delegates to LibraryService.getConfig", () => {
+      const config = { systems: [], romsBasePath: "/roms" };
       libraryServiceInstance.getConfig.mockReturnValue(config);
 
-      const handler = getHandler('library:getConfig');
+      const handler = getHandler("library:getConfig");
       const result = handler(fakeEvent);
 
       expect(libraryServiceInstance.getConfig).toHaveBeenCalled();
@@ -893,14 +910,14 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // library:setRomsBasePath
   // -----------------------------------------------------------------------
-  describe('library:setRomsBasePath', () => {
-    it('delegates to LibraryService.setRomsBasePath and returns success', async () => {
+  describe("library:setRomsBasePath", () => {
+    it("delegates to LibraryService.setRomsBasePath and returns success", async () => {
       libraryServiceInstance.setRomsBasePath.mockResolvedValue(undefined);
 
-      const handler = getHandler('library:setRomsBasePath');
-      const result = await handler(fakeEvent, '/new/roms');
+      const handler = getHandler("library:setRomsBasePath");
+      const result = await handler(fakeEvent, "/new/roms");
 
-      expect(libraryServiceInstance.setRomsBasePath).toHaveBeenCalledWith('/new/roms');
+      expect(libraryServiceInstance.setRomsBasePath).toHaveBeenCalledWith("/new/roms");
       expect(result).toEqual({ success: true });
     });
   });
@@ -908,30 +925,30 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 22. dialog:selectDirectory
   // -----------------------------------------------------------------------
-  describe('dialog:selectDirectory', () => {
-    it('returns the selected directory path', async () => {
+  describe("dialog:selectDirectory", () => {
+    it("returns the selected directory path", async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ['/selected/directory'],
+        filePaths: ["/selected/directory"],
       });
 
-      const handler = getHandler('dialog:selectDirectory');
+      const handler = getHandler("dialog:selectDirectory");
       const result = await handler(fakeEvent);
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ['openDirectory'],
-        title: 'Select ROMs Directory',
+        properties: ["openDirectory"],
+        title: "Select ROMs Directory",
       });
-      expect(result).toBe('/selected/directory');
+      expect(result).toBe("/selected/directory");
     });
 
-    it('returns null when dialog is canceled', async () => {
+    it("returns null when dialog is canceled", async () => {
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: true,
         filePaths: [],
       });
 
-      const handler = getHandler('dialog:selectDirectory');
+      const handler = getHandler("dialog:selectDirectory");
       const result = await handler(fakeEvent);
 
       expect(result).toBeNull();
@@ -941,57 +958,57 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 23. dialog:selectRomFile
   // -----------------------------------------------------------------------
-  describe('dialog:selectRomFile', () => {
-    it('filters by system extensions when system is found', async () => {
+  describe("dialog:selectRomFile", () => {
+    it("filters by system extensions when system is found", async () => {
       const nesSystem: GameSystem = {
-        id: 'nes',
-        name: 'Nintendo Entertainment System',
-        shortName: 'NES',
-        extensions: ['.nes', '.fds'],
+        id: "nes",
+        name: "Nintendo Entertainment System",
+        shortName: "NES",
+        extensions: [".nes", ".fds"],
       };
       libraryServiceInstance.getSystems.mockReturnValue([nesSystem]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ['/roms/smb.nes'],
+        filePaths: ["/roms/smb.nes"],
       });
 
-      const handler = getHandler('dialog:selectRomFile');
-      const result = await handler(fakeEvent, 'nes');
+      const handler = getHandler("dialog:selectRomFile");
+      const result = await handler(fakeEvent, "nes");
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ['openFile'],
-        title: 'Select ROM File',
+        properties: ["openFile"],
+        title: "Select ROM File",
         filters: [
           {
-            name: 'Nintendo Entertainment System ROMs',
-            extensions: ['nes', 'fds', 'zip'],
+            name: "Nintendo Entertainment System ROMs",
+            extensions: ["nes", "fds", "zip"],
           },
         ],
       });
-      expect(result).toBe('/roms/smb.nes');
+      expect(result).toBe("/roms/smb.nes");
     });
 
-    it('uses empty filters when system is not found', async () => {
+    it("uses empty filters when system is not found", async () => {
       libraryServiceInstance.getSystems.mockReturnValue([]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
         canceled: false,
-        filePaths: ['/roms/game.rom'],
+        filePaths: ["/roms/game.rom"],
       });
 
-      const handler = getHandler('dialog:selectRomFile');
-      const result = await handler(fakeEvent, 'unknown');
+      const handler = getHandler("dialog:selectRomFile");
+      const result = await handler(fakeEvent, "unknown");
 
       expect(dialog.showOpenDialog).toHaveBeenCalledWith({
-        properties: ['openFile'],
-        title: 'Select ROM File',
+        properties: ["openFile"],
+        title: "Select ROM File",
         filters: [],
       });
-      expect(result).toBe('/roms/game.rom');
+      expect(result).toBe("/roms/game.rom");
     });
 
-    it('returns null when dialog is canceled', async () => {
+    it("returns null when dialog is canceled", async () => {
       libraryServiceInstance.getSystems.mockReturnValue([]);
 
       vi.mocked(dialog.showOpenDialog).mockResolvedValue({
@@ -999,8 +1016,8 @@ describe('IPCHandlers', () => {
         filePaths: [],
       });
 
-      const handler = getHandler('dialog:selectRomFile');
-      const result = await handler(fakeEvent, 'nes');
+      const handler = getHandler("dialog:selectRomFile");
+      const result = await handler(fakeEvent, "nes");
 
       expect(result).toBeNull();
     });
@@ -1009,25 +1026,43 @@ describe('IPCHandlers', () => {
   // -----------------------------------------------------------------------
   // 24. Event forwarding
   // -----------------------------------------------------------------------
-  describe('event forwarding', () => {
-    it('forwards emulatorManager events to all BrowserWindows', () => {
+  describe("event forwarding", () => {
+    it("forwards emulatorManager events to all BrowserWindows", () => {
       const sendMock = vi.fn();
       const fakeWindow = { webContents: { send: sendMock } };
-      vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([fakeWindow as unknown as BrowserWindowType]);
+      vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+        fakeWindow as unknown as BrowserWindowType,
+      ]);
 
       const forwardedEvents = [
-        { emitterEvent: 'gameLaunched', ipcEvent: 'emulator:launched', data: { romPath: '/rom' } },
-        { emitterEvent: 'emulator:exited', ipcEvent: 'emulator:exited', data: { code: 0 } },
-        { emitterEvent: 'emulator:error', ipcEvent: 'emulator:error', data: { message: 'oops' } },
-        { emitterEvent: 'emulator:stateSaved', ipcEvent: 'emulator:stateSaved', data: { slot: 1 } },
-        { emitterEvent: 'emulator:stateLoaded', ipcEvent: 'emulator:stateLoaded', data: { slot: 1 } },
-        { emitterEvent: 'emulator:screenshotTaken', ipcEvent: 'emulator:screenshotTaken', data: { path: '/img.png' } },
-        { emitterEvent: 'emulator:paused', ipcEvent: 'emulator:paused', data: undefined },
-        { emitterEvent: 'emulator:resumed', ipcEvent: 'emulator:resumed', data: undefined },
-        { emitterEvent: 'emulator:reset', ipcEvent: 'emulator:reset', data: undefined },
-        { emitterEvent: 'emulator:speedChanged', ipcEvent: 'emulator:speedChanged', data: { multiplier: 2 } },
-        { emitterEvent: 'emulator:terminated', ipcEvent: 'emulator:terminated', data: undefined },
-        { emitterEvent: 'core:downloadProgress', ipcEvent: 'core:downloadProgress', data: { percent: 50 } },
+        { emitterEvent: "gameLaunched", ipcEvent: "emulator:launched", data: { romPath: "/rom" } },
+        { emitterEvent: "emulator:exited", ipcEvent: "emulator:exited", data: { code: 0 } },
+        { emitterEvent: "emulator:error", ipcEvent: "emulator:error", data: { message: "oops" } },
+        { emitterEvent: "emulator:stateSaved", ipcEvent: "emulator:stateSaved", data: { slot: 1 } },
+        {
+          emitterEvent: "emulator:stateLoaded",
+          ipcEvent: "emulator:stateLoaded",
+          data: { slot: 1 },
+        },
+        {
+          emitterEvent: "emulator:screenshotTaken",
+          ipcEvent: "emulator:screenshotTaken",
+          data: { path: "/img.png" },
+        },
+        { emitterEvent: "emulator:paused", ipcEvent: "emulator:paused", data: undefined },
+        { emitterEvent: "emulator:resumed", ipcEvent: "emulator:resumed", data: undefined },
+        { emitterEvent: "emulator:reset", ipcEvent: "emulator:reset", data: undefined },
+        {
+          emitterEvent: "emulator:speedChanged",
+          ipcEvent: "emulator:speedChanged",
+          data: { multiplier: 2 },
+        },
+        { emitterEvent: "emulator:terminated", ipcEvent: "emulator:terminated", data: undefined },
+        {
+          emitterEvent: "core:downloadProgress",
+          ipcEvent: "core:downloadProgress",
+          data: { percent: 50 },
+        },
       ];
 
       for (const { emitterEvent, ipcEvent, data } of forwardedEvents) {
@@ -1037,7 +1072,7 @@ describe('IPCHandlers', () => {
       }
     });
 
-    it('forwards events to multiple windows', () => {
+    it("forwards events to multiple windows", () => {
       const send1 = vi.fn();
       const send2 = vi.fn();
       vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
@@ -1045,25 +1080,25 @@ describe('IPCHandlers', () => {
         { webContents: { send: send2 } } as unknown as BrowserWindowType,
       ]);
 
-      emulatorEmitter.emit('emulator:paused');
+      emulatorEmitter.emit("emulator:paused");
 
-      expect(send1).toHaveBeenCalledWith('emulator:paused', undefined);
-      expect(send2).toHaveBeenCalledWith('emulator:paused', undefined);
+      expect(send1).toHaveBeenCalledWith("emulator:paused", undefined);
+      expect(send2).toHaveBeenCalledWith("emulator:paused", undefined);
     });
   });
 
   // -----------------------------------------------------------------------
   // 25. dialog:resumeGameResponse (ipcMain.on)
   // -----------------------------------------------------------------------
-  describe('dialog:resumeGameResponse', () => {
-    it('registers the resumeGameResponse listener', () => {
-      const listener = getOnListener('dialog:resumeGameResponse');
+  describe("dialog:resumeGameResponse", () => {
+    it("registers the resumeGameResponse listener", () => {
+      const listener = getOnListener("dialog:resumeGameResponse");
       expect(listener).toBeDefined();
     });
 
-    it('does not throw when called with an unknown requestId', () => {
-      const listener = getOnListener('dialog:resumeGameResponse');
-      expect(() => listener(fakeEvent, 'unknown-id', true)).not.toThrow();
+    it("does not throw when called with an unknown requestId", () => {
+      const listener = getOnListener("dialog:resumeGameResponse");
+      expect(() => listener(fakeEvent, "unknown-id", true)).not.toThrow();
     });
   });
 });

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -278,6 +278,7 @@ describe('IPCHandlers', () => {
         'emulation:resume',
         'emulation:reset',
         'emulation:setSpeed',
+        'emulation:setFastForwardAudio',
         'savestate:save',
         'savestate:load',
         'emulation:screenshot',
@@ -306,7 +307,7 @@ describe('IPCHandlers', () => {
 
     it('registers exactly the expected number of handle channels', () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(35);
+      expect(handleCalls).toHaveLength(36);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -8,8 +8,12 @@ import { ArtworkService } from "../services/ArtworkService";
 import { HomebrewService } from "../services/HomebrewService";
 import { ScreenScraperError } from "../services/ScreenScraperClient";
 import { GameWindowManager } from "../GameWindowManager";
-import { GameSystem } from "../../types/library";
+import { Game, GameSystem } from "../../types/library";
 import { ipcLog } from "../logger";
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export class IPCHandlers {
   private emulatorManager: EmulatorManager;
@@ -67,7 +71,7 @@ export class IPCHandlers {
           return { success: true, corePath };
         } catch (error) {
           ipcLog.error("Failed to download core:", error);
-          return { success: false, error: (error as Error).message };
+          return { success: false, error: errorMessage(error) };
         }
       },
     );
@@ -174,7 +178,7 @@ export class IPCHandlers {
           return { success: true };
         } catch (error) {
           ipcLog.error("Failed to launch emulator:", error);
-          return { success: false, error: (error as Error).message };
+          return { success: false, error: errorMessage(error) };
         }
       },
     );
@@ -185,7 +189,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to stop emulator:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -204,7 +208,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to pause emulation:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -214,7 +218,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to resume emulation:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -224,7 +228,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to reset emulation:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -234,7 +238,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to set emulation speed:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -244,7 +248,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to set fast-forward audio:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -255,7 +259,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to save state:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -265,7 +269,7 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to load state:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -276,7 +280,7 @@ export class IPCHandlers {
         return { success: true, path };
       } catch (error) {
         ipcLog.error("Failed to take screenshot:", error);
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
   }
@@ -361,7 +365,7 @@ export class IPCHandlers {
       return { success: true };
     });
 
-    ipcMain.handle("library:updateGame", async (event, gameId: string, updates: any) => {
+    ipcMain.handle("library:updateGame", async (event, gameId: string, updates: Partial<Game>) => {
       await this.libraryService.updateGame(gameId, updates);
       return { success: true };
     });
@@ -447,7 +451,7 @@ export class IPCHandlers {
         const success = await this.artworkService.syncGame(gameId);
         return { success };
       } catch (error) {
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
 
@@ -503,7 +507,7 @@ export class IPCHandlers {
           await this.artworkService.setCredentials(userId, userPassword);
           return { success: true };
         } catch (error) {
-          return { success: false, error: (error as Error).message };
+          return { success: false, error: errorMessage(error) };
         }
       },
     );
@@ -513,7 +517,7 @@ export class IPCHandlers {
         await this.artworkService.clearCredentials();
         return { success: true };
       } catch (error) {
-        return { success: false, error: (error as Error).message };
+        return { success: false, error: errorMessage(error) };
       }
     });
   }

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -1,14 +1,12 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock electron before importing ArtworkService
-vi.mock("electron", () => ({
+vi.mock('electron', () => ({
   app: {
     getPath: (name: string) => {
-      if (name === "userData") {
-        return "/tmp/gamelord-test";
-      }
-      return "/tmp";
+      if (name === 'userData') return '/tmp/gamelord-test';
+      return '/tmp';
     },
   },
 }));
@@ -19,22 +17,20 @@ const {
   mockCreateWriteStream,
   mockExistsSync,
   mockMkdirSync,
-  mockReadFile,
   mockUnlink,
+  mockReadFile,
   mockWriteFile,
 } = vi.hoisted(() => ({
   mockCreateReadStream: vi.fn(),
   mockCreateWriteStream: vi.fn(),
   mockExistsSync: vi.fn().mockReturnValue(true),
   mockMkdirSync: vi.fn(),
-  mockReadFile: vi.fn().mockResolvedValue("{}"),
   mockUnlink: vi.fn(),
+  mockReadFile: vi.fn().mockResolvedValue('{}'),
   mockWriteFile: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("fs", () => ({
-  createReadStream: mockCreateReadStream,
-  createWriteStream: mockCreateWriteStream,
+vi.mock('fs', () => ({
   default: {
     existsSync: mockExistsSync,
     mkdirSync: mockMkdirSync,
@@ -44,11 +40,13 @@ vi.mock("fs", () => ({
   },
   existsSync: mockExistsSync,
   mkdirSync: mockMkdirSync,
+  createReadStream: mockCreateReadStream,
+  createWriteStream: mockCreateWriteStream,
+  unlink: mockUnlink,
   promises: {
     readFile: mockReadFile,
     writeFile: mockWriteFile,
   },
-  unlink: mockUnlink,
 }));
 
 // vi.hoisted mock for ScreenScraperClient — lets us control API responses per test
@@ -58,8 +56,8 @@ const { mockFetchByHash, mockFetchByName, mockValidateCredentials } = vi.hoisted
   mockValidateCredentials: vi.fn(),
 }));
 
-vi.mock("./ScreenScraperClient", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./ScreenScraperClient")>();
+vi.mock('./ScreenScraperClient', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./ScreenScraperClient')>();
 
   // Use a real class so `new ScreenScraperClient(...)` works
   class MockScreenScraperClient {
@@ -74,14 +72,14 @@ vi.mock("./ScreenScraperClient", async (importOriginal) => {
   };
 });
 
-import { ArtworkService } from "./ArtworkService";
-import { ScreenScraperError } from "./ScreenScraperClient";
-import { LibraryService } from "./LibraryService";
-import type { Game } from "../../types/library";
-import type { ArtworkProgress } from "../../types/artwork";
+import { ArtworkService } from './ArtworkService';
+import { ScreenScraperError } from './ScreenScraperClient';
+import { LibraryService } from './LibraryService';
+import type { Game } from '../../types/library';
+import type { ArtworkProgress } from '../../types/artwork';
 
-function createMockLibraryService(games: Array<Game> = []): LibraryService {
-  const gameMap = new Map(games.map((g) => [g.id, { ...g }]));
+function createMockLibraryService(games: Game[] = []): LibraryService {
+  const gameMap = new Map(games.map(g => [g.id, { ...g }]));
   return {
     getGame: vi.fn((id: string) => gameMap.get(id)),
     getGames: vi.fn(() => [...gameMap.values()]),
@@ -96,16 +94,16 @@ function createMockLibraryService(games: Array<Game> = []): LibraryService {
 
 function makeGame(overrides: Partial<Game> = {}): Game {
   return {
-    id: "game1",
+    id: 'game1',
+    title: 'Super Mario Bros.',
+    system: 'Nintendo Entertainment System',
+    systemId: 'nes',
+    romPath: '/roms/smb.nes',
     romHashes: {
-      crc32: "deadbeef",
-      sha1: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
-      md5: "d41d8cd98f00b204e9800998ecf8427e",
+      crc32: 'deadbeef',
+      sha1: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
+      md5: 'd41d8cd98f00b204e9800998ecf8427e',
     },
-    romPath: "/roms/smb.nes",
-    system: "Nintendo Entertainment System",
-    systemId: "nes",
-    title: "Super Mario Bros.",
     ...overrides,
   };
 }
@@ -115,13 +113,13 @@ function makeGame(overrides: Partial<Game> = {}): Game {
  * async loadConfig() resolves before we interact with the service.
  */
 async function flushPromises(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 0));
 }
 
-describe("ArtworkService", () => {
+describe('ArtworkService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockReadFile.mockResolvedValue("{}");
+    mockReadFile.mockResolvedValue('{}');
     mockWriteFile.mockResolvedValue(undefined);
     mockFetchByHash.mockResolvedValue(null);
     mockFetchByName.mockResolvedValue(null);
@@ -129,67 +127,67 @@ describe("ArtworkService", () => {
 
     // Provide dev credentials so createClient() doesn't bail out.
     // The ScreenScraperClient is mocked, so these values are never sent to the API.
-    process.env.SCREENSCRAPER_DEV_ID = "test-dev-id";
-    process.env.SCREENSCRAPER_DEV_PASSWORD = "test-dev-password";
+    process.env.SCREENSCRAPER_DEV_ID = 'test-dev-id';
+    process.env.SCREENSCRAPER_DEV_PASSWORD = 'test-dev-password';
 
     // Stub the internal sleep/rate-limit to avoid real delays in tests.
     // The prototype methods are patched so every ArtworkService instance is fast.
-    vi.spyOn(ArtworkService.prototype as any, "sleep").mockResolvedValue(undefined);
-    vi.spyOn(ArtworkService.prototype as any, "waitForRateLimit").mockResolvedValue(undefined);
+    vi.spyOn(ArtworkService.prototype as unknown as Record<string, () => Promise<void>>, 'sleep').mockResolvedValue(undefined);
+    vi.spyOn(ArtworkService.prototype as unknown as Record<string, () => Promise<void>>, 'waitForRateLimit').mockResolvedValue(undefined);
   });
 
-  describe("credentials management", () => {
-    it("reports no credentials initially", async () => {
+  describe('credentials management', () => {
+    it('reports no credentials initially', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       expect(service.hasCredentials()).toBe(false);
     });
 
-    it("reports credentials after setting them", async () => {
+    it('reports credentials after setting them', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
       expect(service.hasCredentials()).toBe(true);
     });
 
-    it("removes credentials on clear", async () => {
+    it('removes credentials on clear', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
       await service.clearCredentials();
       expect(service.hasCredentials()).toBe(false);
     });
 
-    it("persists credentials to config file", async () => {
+    it('persists credentials to config file', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials("myuser", "mypass");
+      await service.setCredentials('myuser', 'mypass');
       expect(mockWriteFile).toHaveBeenCalledWith(
-        "/tmp/gamelord-test/artwork-config.json",
+        '/tmp/gamelord-test/artwork-config.json',
         expect.stringContaining('"myuser"'),
       );
     });
   });
 
-  describe("syncAllGames", () => {
-    it("returns immediately if already syncing", async () => {
+  describe('syncAllGames', () => {
+    it('returns immediately if already syncing', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
-      (service as any).syncing = true;
+      (service as unknown as Record<string, boolean>).syncing = true;
 
       const status = await service.syncAllGames();
       expect(status.inProgress).toBe(true);
       expect(status.total).toBe(0);
     });
 
-    it("skips games that already have cover art", async () => {
-      const game = makeGame({ coverArt: "artwork://game1.png" });
+    it('skips games that already have cover art', async () => {
+      const game = makeGame({ coverArt: 'artwork://game1.png' });
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
@@ -198,12 +196,12 @@ describe("ArtworkService", () => {
       expect(status.total).toBe(0);
     });
 
-    it("emits syncComplete event when done", async () => {
+    it('emits syncComplete event when done', async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
 
-      const syncCompletePromise = new Promise<any>((resolve) => {
-        service.on("syncComplete", resolve);
+      const syncCompletePromise = new Promise<{ inProgress: boolean }>(resolve => {
+        service.on('syncComplete', resolve);
       });
 
       await service.syncAllGames();
@@ -211,17 +209,17 @@ describe("ArtworkService", () => {
       expect(status.inProgress).toBe(false);
     });
 
-    it("respects cancellation between games", async () => {
+    it('respects cancellation between games', async () => {
       const games = [
-        makeGame({ id: "game1", title: "Game 1" }),
-        makeGame({ id: "game2", title: "Game 2" }),
-        makeGame({ id: "game3", title: "Game 3" }),
+        makeGame({ id: 'game1', title: 'Game 1' }),
+        makeGame({ id: 'game2', title: 'Game 2' }),
+        makeGame({ id: 'game3', title: 'Game 3' }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const progressEvents: Array<ArtworkProgress> = [];
-      service.on("progress", (p: ArtworkProgress) => {
+      const progressEvents: ArtworkProgress[] = [];
+      service.on('progress', (p: ArtworkProgress) => {
         progressEvents.push(p);
         if (p.current === 1) {
           service.cancelSync();
@@ -231,13 +229,13 @@ describe("ArtworkService", () => {
       await service.syncAllGames();
 
       // Should have processed at most 1 game before cancellation took effect
-      const uniqueGames = new Set(progressEvents.map((p) => p.gameId));
+      const uniqueGames = new Set(progressEvents.map(p => p.gameId));
       expect(uniqueGames.size).toBeLessThanOrEqual(1);
     });
   });
 
-  describe("getSyncStatus", () => {
-    it("reports not syncing by default", async () => {
+  describe('getSyncStatus', () => {
+    it('reports not syncing by default', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
@@ -245,316 +243,318 @@ describe("ArtworkService", () => {
     });
   });
 
-  describe("getImageExtension", () => {
-    it("extracts .png extension from URL", async () => {
+  describe('getImageExtension', () => {
+    it('extracts .png extension from URL', async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as any).getImageExtension("https://example.com/image.png");
-      expect(ext).toBe(".png");
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.png');
+      expect(ext).toBe('.png');
     });
 
-    it("extracts .jpg extension from URL", async () => {
+    it('extracts .jpg extension from URL', async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as any).getImageExtension("https://example.com/image.jpg");
-      expect(ext).toBe(".jpg");
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.jpg');
+      expect(ext).toBe('.jpg');
     });
 
-    it("defaults to .png for unknown extensions", async () => {
+    it('defaults to .png for unknown extensions', async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as any).getImageExtension("https://example.com/image.bmp");
-      expect(ext).toBe(".png");
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.bmp');
+      expect(ext).toBe('.png');
     });
 
-    it("handles URLs with query parameters", async () => {
+    it('handles URLs with query parameters', async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as any).getImageExtension("https://example.com/image.jpeg?quality=80");
-      expect(ext).toBe(".jpeg");
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.jpeg?quality=80');
+      expect(ext).toBe('.jpeg');
     });
   });
 
-  describe("syncGame", () => {
-    it("skips game that already has cover art when force is false", async () => {
-      const game = makeGame({ coverArt: "artwork://game1.png" });
+  describe('syncGame', () => {
+    it('skips game that already has cover art when force is false', async () => {
+      const game = makeGame({ coverArt: 'artwork://game1.png' });
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
-      const result = await service.syncGame("game1", false);
+      const result = await service.syncGame('game1', false);
       expect(result).toBe(true);
     });
 
-    it("returns false for unknown game ID", async () => {
+    it('returns false for unknown game ID', async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
 
-      const result = await service.syncGame("nonexistent");
+      const result = await service.syncGame('nonexistent');
       expect(result).toBe(false);
     });
 
-    it("throws when no credentials are configured", async () => {
+    it('throws when no credentials are configured', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
-      await expect(service.syncGame("game1")).rejects.toThrow(
-        "ScreenScraper user credentials are not configured",
+      await expect(service.syncGame('game1')).rejects.toThrow(
+        'ScreenScraper user credentials are not configured',
       );
     });
 
-    it("throws ScreenScraperError when hash lookup returns auth error", async () => {
+    it('throws ScreenScraperError when hash lookup returns auth error', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
+        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
       );
 
-      await expect(service.syncGame("game1")).rejects.toThrow("Invalid username or password.");
+      await expect(service.syncGame('game1')).rejects.toThrow('Invalid username or password.');
       // Should NOT fall through to name search after auth failure
       expect(mockFetchByName).not.toHaveBeenCalled();
     });
 
-    it("throws ScreenScraperError when name search returns auth error", async () => {
+    it('throws ScreenScraperError when name search returns auth error', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       // Hash lookup returns null (not found), but name search hits auth error
       mockFetchByHash.mockResolvedValue(null);
       mockFetchByName.mockRejectedValue(
-        new ScreenScraperError("Invalid username or password.", 403, "auth-failed"),
+        new ScreenScraperError('Invalid username or password.', 403, 'auth-failed'),
       );
 
-      await expect(service.syncGame("game1")).rejects.toThrow("Invalid username or password.");
+      await expect(service.syncGame('game1')).rejects.toThrow('Invalid username or password.');
     });
 
-    it("updates system to regional name when ScreenScraper returns JP region for SNES game", async () => {
+    it('updates system to regional name when ScreenScraper returns JP region for SNES game', async () => {
       const game = makeGame({
-        id: "jp-snes-game",
-        system: "Super Nintendo Entertainment System",
-        systemId: "snes",
-        title: "Some Japanese Game",
+        id: 'jp-snes-game',
+        title: 'Some Japanese Game',
+        system: 'Super Nintendo Entertainment System',
+        systemId: 'snes',
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       mockFetchByHash.mockResolvedValue({
-        developer: "Nintendo",
-        genre: "Platform",
-        media: {},
+        title: 'スーパーマリオワールド',
+        region: 'jp',
+        developer: 'Nintendo',
+        publisher: 'Nintendo',
+        genre: 'Platform',
         players: 1,
-        publisher: "Nintendo",
         rating: 0.9,
-        region: "jp",
-        releaseDate: "1990-11-21",
-        title: "スーパーマリオワールド",
+        releaseDate: '1990-11-21',
+        media: {},
       });
 
-      await service.syncGame("jp-snes-game");
+      await service.syncGame('jp-snes-game');
 
       expect(libraryService.updateGame).toHaveBeenCalledWith(
-        "jp-snes-game",
-        expect.objectContaining({ system: "Super Famicom" }),
+        'jp-snes-game',
+        expect.objectContaining({ system: 'Super Famicom' }),
       );
     });
 
-    it("updates system to Mega Drive for Genesis game with EU region", async () => {
+    it('updates system to Mega Drive for Genesis game with EU region', async () => {
       const game = makeGame({
-        id: "eu-genesis-game",
-        system: "Sega Genesis",
-        systemId: "genesis",
-        title: "Sonic The Hedgehog",
+        id: 'eu-genesis-game',
+        title: 'Sonic The Hedgehog',
+        system: 'Sega Genesis',
+        systemId: 'genesis',
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       mockFetchByHash.mockResolvedValue({
-        developer: "Sonic Team",
-        genre: "Platform",
-        media: {},
+        title: 'Sonic The Hedgehog',
+        region: 'eu',
+        developer: 'Sonic Team',
+        publisher: 'Sega',
+        genre: 'Platform',
         players: 1,
-        publisher: "Sega",
         rating: 0.85,
-        region: "eu",
-        releaseDate: "1991-06-23",
-        title: "Sonic The Hedgehog",
+        releaseDate: '1991-06-23',
+        media: {},
       });
 
-      await service.syncGame("eu-genesis-game");
+      await service.syncGame('eu-genesis-game');
 
       expect(libraryService.updateGame).toHaveBeenCalledWith(
-        "eu-genesis-game",
-        expect.objectContaining({ system: "Mega Drive" }),
+        'eu-genesis-game',
+        expect.objectContaining({ system: 'Mega Drive' }),
       );
     });
 
-    it("does not set system field when region has no variant for that system", async () => {
+    it('does not set system field when region has no variant for that system', async () => {
       const game = makeGame({
-        id: "jp-gb-game",
-        system: "Game Boy",
-        systemId: "gb",
-        title: "Pokemon Red",
+        id: 'jp-gb-game',
+        title: 'Pokemon Red',
+        system: 'Game Boy',
+        systemId: 'gb',
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       mockFetchByHash.mockResolvedValue({
-        developer: "Game Freak",
-        genre: "RPG",
-        media: {},
+        title: 'Pocket Monsters Red',
+        region: 'jp',
+        developer: 'Game Freak',
+        publisher: 'Nintendo',
+        genre: 'RPG',
         players: 1,
-        publisher: "Nintendo",
         rating: 0.9,
-        region: "jp",
-        releaseDate: "1996-02-27",
-        title: "Pocket Monsters Red",
+        releaseDate: '1996-02-27',
+        media: {},
       });
 
-      await service.syncGame("jp-gb-game");
+      await service.syncGame('jp-gb-game');
 
       // updateGame should NOT contain a 'system' key since Game Boy has no regional variants
-      const updateCall = (libraryService.updateGame as any).mock.calls[0][1];
-      expect(updateCall).not.toHaveProperty("system");
+      const updateCall = vi.mocked(libraryService.updateGame).mock.calls[0][1];
+      expect(updateCall).not.toHaveProperty('system');
     });
 
-    it("falls through to name search on non-auth errors from hash lookup", async () => {
+    it('falls through to name search on non-auth errors from hash lookup', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       // Hash lookup times out, but name search succeeds
-      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
+      mockFetchByHash.mockRejectedValue(
+        new ScreenScraperError('Timed out', 0, 'timeout'),
+      );
       mockFetchByName.mockResolvedValue(null);
 
       // Should not throw — timeout on hash is recoverable
-      const result = await service.syncGame("game1");
+      const result = await service.syncGame('game1');
       expect(result).toBe(false);
       expect(mockFetchByName).toHaveBeenCalled();
     });
   });
 
-  describe("validateCredentials", () => {
-    it("returns valid: true when credentials are accepted", async () => {
+  describe('validateCredentials', () => {
+    it('returns valid: true when credentials are accepted', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockResolvedValue(undefined);
 
-      const result = await service.validateCredentials("user", "pass");
+      const result = await service.validateCredentials('user', 'pass');
       expect(result.valid).toBe(true);
       expect(result.error).toBeUndefined();
     });
 
-    it("returns valid: false with auth-failed errorCode on 401", async () => {
+    it('returns valid: false with auth-failed errorCode on 401', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockRejectedValue(
-        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
+        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
       );
 
-      const result = await service.validateCredentials("baduser", "badpass");
+      const result = await service.validateCredentials('baduser', 'badpass');
       expect(result.valid).toBe(false);
-      expect(result.error).toBe("Invalid username or password.");
-      expect(result.errorCode).toBe("auth-failed");
+      expect(result.error).toBe('Invalid username or password.');
+      expect(result.errorCode).toBe('auth-failed');
     });
 
-    it("returns valid: false with timeout errorCode on timeout", async () => {
+    it('returns valid: false with timeout errorCode on timeout', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockRejectedValue(
-        new ScreenScraperError("Request timed out.", 0, "timeout"),
+        new ScreenScraperError('Request timed out.', 0, 'timeout'),
       );
 
-      const result = await service.validateCredentials("user", "pass");
+      const result = await service.validateCredentials('user', 'pass');
       expect(result.valid).toBe(false);
-      expect(result.errorCode).toBe("timeout");
+      expect(result.errorCode).toBe('timeout');
     });
 
-    it("handles non-ScreenScraperError exceptions", async () => {
+    it('handles non-ScreenScraperError exceptions', async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      mockValidateCredentials.mockRejectedValue(new Error("DNS resolution failed"));
+      mockValidateCredentials.mockRejectedValue(new Error('DNS resolution failed'));
 
-      const result = await service.validateCredentials("user", "pass");
+      const result = await service.validateCredentials('user', 'pass');
       expect(result.valid).toBe(false);
-      expect(result.error).toBe("DNS resolution failed");
+      expect(result.error).toBe('DNS resolution failed');
       expect(result.errorCode).toBeUndefined();
     });
   });
 
-  describe("syncGames (targeted sync)", () => {
-    it("only processes specified game IDs", async () => {
+  describe('syncGames (targeted sync)', () => {
+    it('only processes specified game IDs', async () => {
       const games = [
-        makeGame({ id: "game1", title: "Game 1" }),
-        makeGame({ id: "game2", title: "Game 2" }),
-        makeGame({ id: "game3", title: "Game 3" }),
+        makeGame({ id: 'game1', title: 'Game 1' }),
+        makeGame({ id: 'game2', title: 'Game 2' }),
+        makeGame({ id: 'game3', title: 'Game 3' }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const progressEvents: Array<ArtworkProgress> = [];
-      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: ArtworkProgress[] = [];
+      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
 
-      const status = await service.syncGames(["game1", "game3"]);
+      const status = await service.syncGames(['game1', 'game3']);
 
       // Should only have progress for game1 and game3, not game2
-      const syncedIds = new Set(progressEvents.map((p) => p.gameId));
-      expect(syncedIds.has("game2")).toBe(false);
+      const syncedIds = new Set(progressEvents.map(p => p.gameId));
+      expect(syncedIds.has('game2')).toBe(false);
       expect(status.total).toBe(2);
     });
 
-    it("skips games that already have cover art", async () => {
+    it('skips games that already have cover art', async () => {
       const games = [
-        makeGame({ coverArt: "artwork://game1.png", id: "game1", title: "Game 1" }),
-        makeGame({ id: "game2", title: "Game 2" }),
+        makeGame({ id: 'game1', title: 'Game 1', coverArt: 'artwork://game1.png' }),
+        makeGame({ id: 'game2', title: 'Game 2' }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const status = await service.syncGames(["game1", "game2"]);
+      const status = await service.syncGames(['game1', 'game2']);
       // game1 should be filtered out since it has cover art
       expect(status.total).toBe(1);
     });
 
-    it("returns immediately if already syncing", async () => {
+    it('returns immediately if already syncing', async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
-      (service as any).syncing = true;
+      (service as unknown as Record<string, boolean>).syncing = true;
 
-      const status = await service.syncGames(["game1"]);
+      const status = await service.syncGames(['game1']);
       expect(status.inProgress).toBe(true);
       expect(status.total).toBe(0);
     });
   });
 
-  describe("batch sync error handling", () => {
-    it("stops batch on auth-failed error", async () => {
+  describe('batch sync error handling', () => {
+    it('stops batch on auth-failed error', async () => {
       const games = [
-        makeGame({ id: "game1", title: "Game 1" }),
-        makeGame({ id: "game2", title: "Game 2" }),
-        makeGame({ id: "game3", title: "Game 3" }),
+        makeGame({ id: 'game1', title: 'Game 1' }),
+        makeGame({ id: 'game2', title: 'Game 2' }),
+        makeGame({ id: 'game3', title: 'Game 3' }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
-      await service.setCredentials("baduser", "badpass");
+      await service.setCredentials('baduser', 'badpass');
 
       mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
+        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
       );
 
-      const progressEvents: Array<ArtworkProgress> = [];
-      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: ArtworkProgress[] = [];
+      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
 
       const status = await service.syncAllGames();
 
@@ -563,22 +563,24 @@ describe("ArtworkService", () => {
       expect(status.processed).toBeLessThanOrEqual(1);
 
       // Verify the error event has the correct errorCode
-      const errorEvent = progressEvents.find((p) => p.phase === "error");
-      expect(errorEvent).toBeDefined();
-      expect(errorEvent!.errorCode).toBe("auth-failed");
+      const errorEvent = progressEvents.find(p => p.phase === 'error');
+      if (!errorEvent) throw new Error('Expected an error progress event');
+      expect(errorEvent.errorCode).toBe('auth-failed');
     });
 
-    it("continues batch on non-auth errors", async () => {
+    it('continues batch on non-auth errors', async () => {
       const games = [
-        makeGame({ id: "game1", title: "Game 1" }),
-        makeGame({ id: "game2", title: "Game 2" }),
+        makeGame({ id: 'game1', title: 'Game 1' }),
+        makeGame({ id: 'game2', title: 'Game 2' }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       // Timeout errors should NOT stop the batch
-      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
+      mockFetchByHash.mockRejectedValue(
+        new ScreenScraperError('Timed out', 0, 'timeout'),
+      );
       mockFetchByName.mockResolvedValue(null);
 
       const status = await service.syncAllGames();
@@ -587,25 +589,29 @@ describe("ArtworkService", () => {
       expect(status.processed).toBe(2);
     });
 
-    it("emits progress with not-found when API lookups fail with non-auth errors", async () => {
+    it('emits progress with not-found when API lookups fail with non-auth errors', async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials("user", "pass");
+      await service.setCredentials('user', 'pass');
 
       // Timeout errors are non-fatal and fall through to name search
-      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
+      mockFetchByHash.mockRejectedValue(
+        new ScreenScraperError('Timed out', 0, 'timeout'),
+      );
       // Name search also fails with a non-auth error — gets swallowed
-      mockFetchByName.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
+      mockFetchByName.mockRejectedValue(
+        new ScreenScraperError('Timed out', 0, 'timeout'),
+      );
 
-      const progressEvents: Array<ArtworkProgress> = [];
-      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: ArtworkProgress[] = [];
+      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
 
       await service.syncAllGames();
 
       // Game should show as not-found since both lookups failed non-fatally
-      const lastEvent = progressEvents.at(-1)!;
-      expect(lastEvent.phase).toBe("not-found");
+      const lastEvent = progressEvents[progressEvents.length - 1];
+      expect(lastEvent.phase).toBe('not-found');
     });
   });
 });

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -1,12 +1,14 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mock electron before importing ArtworkService
-vi.mock('electron', () => ({
+vi.mock("electron", () => ({
   app: {
     getPath: (name: string) => {
-      if (name === 'userData') return '/tmp/gamelord-test';
-      return '/tmp';
+      if (name === "userData") {
+        return "/tmp/gamelord-test";
+      }
+      return "/tmp";
     },
   },
 }));
@@ -26,11 +28,11 @@ const {
   mockExistsSync: vi.fn().mockReturnValue(true),
   mockMkdirSync: vi.fn(),
   mockUnlink: vi.fn(),
-  mockReadFile: vi.fn().mockResolvedValue('{}'),
+  mockReadFile: vi.fn().mockResolvedValue("{}"),
   mockWriteFile: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('fs', () => ({
+vi.mock("fs", () => ({
   default: {
     existsSync: mockExistsSync,
     mkdirSync: mockMkdirSync,
@@ -56,8 +58,8 @@ const { mockFetchByHash, mockFetchByName, mockValidateCredentials } = vi.hoisted
   mockValidateCredentials: vi.fn(),
 }));
 
-vi.mock('./ScreenScraperClient', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./ScreenScraperClient')>();
+vi.mock("./ScreenScraperClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ScreenScraperClient")>();
 
   // Use a real class so `new ScreenScraperClient(...)` works
   class MockScreenScraperClient {
@@ -72,14 +74,14 @@ vi.mock('./ScreenScraperClient', async (importOriginal) => {
   };
 });
 
-import { ArtworkService } from './ArtworkService';
-import { ScreenScraperError } from './ScreenScraperClient';
-import { LibraryService } from './LibraryService';
-import type { Game } from '../../types/library';
-import type { ArtworkProgress } from '../../types/artwork';
+import { ArtworkService } from "./ArtworkService";
+import { ScreenScraperError } from "./ScreenScraperClient";
+import { LibraryService } from "./LibraryService";
+import type { Game } from "../../types/library";
+import type { ArtworkProgress } from "../../types/artwork";
 
-function createMockLibraryService(games: Game[] = []): LibraryService {
-  const gameMap = new Map(games.map(g => [g.id, { ...g }]));
+function createMockLibraryService(games: Array<Game> = []): LibraryService {
+  const gameMap = new Map(games.map((g) => [g.id, { ...g }]));
   return {
     getGame: vi.fn((id: string) => gameMap.get(id)),
     getGames: vi.fn(() => [...gameMap.values()]),
@@ -94,15 +96,15 @@ function createMockLibraryService(games: Game[] = []): LibraryService {
 
 function makeGame(overrides: Partial<Game> = {}): Game {
   return {
-    id: 'game1',
-    title: 'Super Mario Bros.',
-    system: 'Nintendo Entertainment System',
-    systemId: 'nes',
-    romPath: '/roms/smb.nes',
+    id: "game1",
+    title: "Super Mario Bros.",
+    system: "Nintendo Entertainment System",
+    systemId: "nes",
+    romPath: "/roms/smb.nes",
     romHashes: {
-      crc32: 'deadbeef',
-      sha1: 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
-      md5: 'd41d8cd98f00b204e9800998ecf8427e',
+      crc32: "deadbeef",
+      sha1: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+      md5: "d41d8cd98f00b204e9800998ecf8427e",
     },
     ...overrides,
   };
@@ -113,13 +115,13 @@ function makeGame(overrides: Partial<Game> = {}): Game {
  * async loadConfig() resolves before we interact with the service.
  */
 async function flushPromises(): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-describe('ArtworkService', () => {
+describe("ArtworkService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockReadFile.mockResolvedValue('{}');
+    mockReadFile.mockResolvedValue("{}");
     mockWriteFile.mockResolvedValue(undefined);
     mockFetchByHash.mockResolvedValue(null);
     mockFetchByName.mockResolvedValue(null);
@@ -127,54 +129,60 @@ describe('ArtworkService', () => {
 
     // Provide dev credentials so createClient() doesn't bail out.
     // The ScreenScraperClient is mocked, so these values are never sent to the API.
-    process.env.SCREENSCRAPER_DEV_ID = 'test-dev-id';
-    process.env.SCREENSCRAPER_DEV_PASSWORD = 'test-dev-password';
+    process.env.SCREENSCRAPER_DEV_ID = "test-dev-id";
+    process.env.SCREENSCRAPER_DEV_PASSWORD = "test-dev-password";
 
     // Stub the internal sleep/rate-limit to avoid real delays in tests.
     // The prototype methods are patched so every ArtworkService instance is fast.
-    vi.spyOn(ArtworkService.prototype as unknown as Record<string, () => Promise<void>>, 'sleep').mockResolvedValue(undefined);
-    vi.spyOn(ArtworkService.prototype as unknown as Record<string, () => Promise<void>>, 'waitForRateLimit').mockResolvedValue(undefined);
+    vi.spyOn(
+      ArtworkService.prototype as unknown as Record<string, () => Promise<void>>,
+      "sleep",
+    ).mockResolvedValue(undefined);
+    vi.spyOn(
+      ArtworkService.prototype as unknown as Record<string, () => Promise<void>>,
+      "waitForRateLimit",
+    ).mockResolvedValue(undefined);
   });
 
-  describe('credentials management', () => {
-    it('reports no credentials initially', async () => {
+  describe("credentials management", () => {
+    it("reports no credentials initially", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       expect(service.hasCredentials()).toBe(false);
     });
 
-    it('reports credentials after setting them', async () => {
+    it("reports credentials after setting them", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
       expect(service.hasCredentials()).toBe(true);
     });
 
-    it('removes credentials on clear', async () => {
+    it("removes credentials on clear", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
       await service.clearCredentials();
       expect(service.hasCredentials()).toBe(false);
     });
 
-    it('persists credentials to config file', async () => {
+    it("persists credentials to config file", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      await service.setCredentials('myuser', 'mypass');
+      await service.setCredentials("myuser", "mypass");
       expect(mockWriteFile).toHaveBeenCalledWith(
-        '/tmp/gamelord-test/artwork-config.json',
+        "/tmp/gamelord-test/artwork-config.json",
         expect.stringContaining('"myuser"'),
       );
     });
   });
 
-  describe('syncAllGames', () => {
-    it('returns immediately if already syncing', async () => {
+  describe("syncAllGames", () => {
+    it("returns immediately if already syncing", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
@@ -186,8 +194,8 @@ describe('ArtworkService', () => {
       expect(status.total).toBe(0);
     });
 
-    it('skips games that already have cover art', async () => {
-      const game = makeGame({ coverArt: 'artwork://game1.png' });
+    it("skips games that already have cover art", async () => {
+      const game = makeGame({ coverArt: "artwork://game1.png" });
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
@@ -196,12 +204,12 @@ describe('ArtworkService', () => {
       expect(status.total).toBe(0);
     });
 
-    it('emits syncComplete event when done', async () => {
+    it("emits syncComplete event when done", async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
 
-      const syncCompletePromise = new Promise<{ inProgress: boolean }>(resolve => {
-        service.on('syncComplete', resolve);
+      const syncCompletePromise = new Promise<{ inProgress: boolean }>((resolve) => {
+        service.on("syncComplete", resolve);
       });
 
       await service.syncAllGames();
@@ -209,17 +217,17 @@ describe('ArtworkService', () => {
       expect(status.inProgress).toBe(false);
     });
 
-    it('respects cancellation between games', async () => {
+    it("respects cancellation between games", async () => {
       const games = [
-        makeGame({ id: 'game1', title: 'Game 1' }),
-        makeGame({ id: 'game2', title: 'Game 2' }),
-        makeGame({ id: 'game3', title: 'Game 3' }),
+        makeGame({ id: "game1", title: "Game 1" }),
+        makeGame({ id: "game2", title: "Game 2" }),
+        makeGame({ id: "game3", title: "Game 3" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const progressEvents: ArtworkProgress[] = [];
-      service.on('progress', (p: ArtworkProgress) => {
+      const progressEvents: Array<ArtworkProgress> = [];
+      service.on("progress", (p: ArtworkProgress) => {
         progressEvents.push(p);
         if (p.current === 1) {
           service.cancelSync();
@@ -229,13 +237,13 @@ describe('ArtworkService', () => {
       await service.syncAllGames();
 
       // Should have processed at most 1 game before cancellation took effect
-      const uniqueGames = new Set(progressEvents.map(p => p.gameId));
+      const uniqueGames = new Set(progressEvents.map((p) => p.gameId));
       expect(uniqueGames.size).toBeLessThanOrEqual(1);
     });
   });
 
-  describe('getSyncStatus', () => {
-    it('reports not syncing by default', async () => {
+  describe("getSyncStatus", () => {
+    it("reports not syncing by default", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
@@ -243,318 +251,324 @@ describe('ArtworkService', () => {
     });
   });
 
-  describe('getImageExtension', () => {
-    it('extracts .png extension from URL', async () => {
+  describe("getImageExtension", () => {
+    it("extracts .png extension from URL", async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.png');
-      expect(ext).toBe('.png');
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension(
+        "https://example.com/image.png",
+      );
+      expect(ext).toBe(".png");
     });
 
-    it('extracts .jpg extension from URL', async () => {
+    it("extracts .jpg extension from URL", async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.jpg');
-      expect(ext).toBe('.jpg');
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension(
+        "https://example.com/image.jpg",
+      );
+      expect(ext).toBe(".jpg");
     });
 
-    it('defaults to .png for unknown extensions', async () => {
+    it("defaults to .png for unknown extensions", async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.bmp');
-      expect(ext).toBe('.png');
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension(
+        "https://example.com/image.bmp",
+      );
+      expect(ext).toBe(".png");
     });
 
-    it('handles URLs with query parameters', async () => {
+    it("handles URLs with query parameters", async () => {
       const service = new ArtworkService(createMockLibraryService());
-      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension('https://example.com/image.jpeg?quality=80');
-      expect(ext).toBe('.jpeg');
+      const ext = (service as unknown as Record<string, (url: string) => string>).getImageExtension(
+        "https://example.com/image.jpeg?quality=80",
+      );
+      expect(ext).toBe(".jpeg");
     });
   });
 
-  describe('syncGame', () => {
-    it('skips game that already has cover art when force is false', async () => {
-      const game = makeGame({ coverArt: 'artwork://game1.png' });
+  describe("syncGame", () => {
+    it("skips game that already has cover art when force is false", async () => {
+      const game = makeGame({ coverArt: "artwork://game1.png" });
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
-      const result = await service.syncGame('game1', false);
+      const result = await service.syncGame("game1", false);
       expect(result).toBe(true);
     });
 
-    it('returns false for unknown game ID', async () => {
+    it("returns false for unknown game ID", async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
 
-      const result = await service.syncGame('nonexistent');
+      const result = await service.syncGame("nonexistent");
       expect(result).toBe(false);
     });
 
-    it('throws when no credentials are configured', async () => {
+    it("throws when no credentials are configured", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
 
-      await expect(service.syncGame('game1')).rejects.toThrow(
-        'ScreenScraper user credentials are not configured',
+      await expect(service.syncGame("game1")).rejects.toThrow(
+        "ScreenScraper user credentials are not configured",
       );
     });
 
-    it('throws ScreenScraperError when hash lookup returns auth error', async () => {
+    it("throws ScreenScraperError when hash lookup returns auth error", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
+        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
       );
 
-      await expect(service.syncGame('game1')).rejects.toThrow('Invalid username or password.');
+      await expect(service.syncGame("game1")).rejects.toThrow("Invalid username or password.");
       // Should NOT fall through to name search after auth failure
       expect(mockFetchByName).not.toHaveBeenCalled();
     });
 
-    it('throws ScreenScraperError when name search returns auth error', async () => {
+    it("throws ScreenScraperError when name search returns auth error", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       // Hash lookup returns null (not found), but name search hits auth error
       mockFetchByHash.mockResolvedValue(null);
       mockFetchByName.mockRejectedValue(
-        new ScreenScraperError('Invalid username or password.', 403, 'auth-failed'),
+        new ScreenScraperError("Invalid username or password.", 403, "auth-failed"),
       );
 
-      await expect(service.syncGame('game1')).rejects.toThrow('Invalid username or password.');
+      await expect(service.syncGame("game1")).rejects.toThrow("Invalid username or password.");
     });
 
-    it('updates system to regional name when ScreenScraper returns JP region for SNES game', async () => {
+    it("updates system to regional name when ScreenScraper returns JP region for SNES game", async () => {
       const game = makeGame({
-        id: 'jp-snes-game',
-        title: 'Some Japanese Game',
-        system: 'Super Nintendo Entertainment System',
-        systemId: 'snes',
+        id: "jp-snes-game",
+        title: "Some Japanese Game",
+        system: "Super Nintendo Entertainment System",
+        systemId: "snes",
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       mockFetchByHash.mockResolvedValue({
-        title: 'スーパーマリオワールド',
-        region: 'jp',
-        developer: 'Nintendo',
-        publisher: 'Nintendo',
-        genre: 'Platform',
+        title: "スーパーマリオワールド",
+        region: "jp",
+        developer: "Nintendo",
+        publisher: "Nintendo",
+        genre: "Platform",
         players: 1,
         rating: 0.9,
-        releaseDate: '1990-11-21',
+        releaseDate: "1990-11-21",
         media: {},
       });
 
-      await service.syncGame('jp-snes-game');
+      await service.syncGame("jp-snes-game");
 
       expect(libraryService.updateGame).toHaveBeenCalledWith(
-        'jp-snes-game',
-        expect.objectContaining({ system: 'Super Famicom' }),
+        "jp-snes-game",
+        expect.objectContaining({ system: "Super Famicom" }),
       );
     });
 
-    it('updates system to Mega Drive for Genesis game with EU region', async () => {
+    it("updates system to Mega Drive for Genesis game with EU region", async () => {
       const game = makeGame({
-        id: 'eu-genesis-game',
-        title: 'Sonic The Hedgehog',
-        system: 'Sega Genesis',
-        systemId: 'genesis',
+        id: "eu-genesis-game",
+        title: "Sonic The Hedgehog",
+        system: "Sega Genesis",
+        systemId: "genesis",
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       mockFetchByHash.mockResolvedValue({
-        title: 'Sonic The Hedgehog',
-        region: 'eu',
-        developer: 'Sonic Team',
-        publisher: 'Sega',
-        genre: 'Platform',
+        title: "Sonic The Hedgehog",
+        region: "eu",
+        developer: "Sonic Team",
+        publisher: "Sega",
+        genre: "Platform",
         players: 1,
         rating: 0.85,
-        releaseDate: '1991-06-23',
+        releaseDate: "1991-06-23",
         media: {},
       });
 
-      await service.syncGame('eu-genesis-game');
+      await service.syncGame("eu-genesis-game");
 
       expect(libraryService.updateGame).toHaveBeenCalledWith(
-        'eu-genesis-game',
-        expect.objectContaining({ system: 'Mega Drive' }),
+        "eu-genesis-game",
+        expect.objectContaining({ system: "Mega Drive" }),
       );
     });
 
-    it('does not set system field when region has no variant for that system', async () => {
+    it("does not set system field when region has no variant for that system", async () => {
       const game = makeGame({
-        id: 'jp-gb-game',
-        title: 'Pokemon Red',
-        system: 'Game Boy',
-        systemId: 'gb',
+        id: "jp-gb-game",
+        title: "Pokemon Red",
+        system: "Game Boy",
+        systemId: "gb",
       });
       const libraryService = createMockLibraryService([game]);
       const service = new ArtworkService(libraryService);
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       mockFetchByHash.mockResolvedValue({
-        title: 'Pocket Monsters Red',
-        region: 'jp',
-        developer: 'Game Freak',
-        publisher: 'Nintendo',
-        genre: 'RPG',
+        title: "Pocket Monsters Red",
+        region: "jp",
+        developer: "Game Freak",
+        publisher: "Nintendo",
+        genre: "RPG",
         players: 1,
         rating: 0.9,
-        releaseDate: '1996-02-27',
+        releaseDate: "1996-02-27",
         media: {},
       });
 
-      await service.syncGame('jp-gb-game');
+      await service.syncGame("jp-gb-game");
 
       // updateGame should NOT contain a 'system' key since Game Boy has no regional variants
       const updateCall = vi.mocked(libraryService.updateGame).mock.calls[0][1];
-      expect(updateCall).not.toHaveProperty('system');
+      expect(updateCall).not.toHaveProperty("system");
     });
 
-    it('falls through to name search on non-auth errors from hash lookup', async () => {
+    it("falls through to name search on non-auth errors from hash lookup", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       // Hash lookup times out, but name search succeeds
-      mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError('Timed out', 0, 'timeout'),
-      );
+      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
       mockFetchByName.mockResolvedValue(null);
 
       // Should not throw — timeout on hash is recoverable
-      const result = await service.syncGame('game1');
+      const result = await service.syncGame("game1");
       expect(result).toBe(false);
       expect(mockFetchByName).toHaveBeenCalled();
     });
   });
 
-  describe('validateCredentials', () => {
-    it('returns valid: true when credentials are accepted', async () => {
+  describe("validateCredentials", () => {
+    it("returns valid: true when credentials are accepted", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockResolvedValue(undefined);
 
-      const result = await service.validateCredentials('user', 'pass');
+      const result = await service.validateCredentials("user", "pass");
       expect(result.valid).toBe(true);
       expect(result.error).toBeUndefined();
     });
 
-    it('returns valid: false with auth-failed errorCode on 401', async () => {
+    it("returns valid: false with auth-failed errorCode on 401", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockRejectedValue(
-        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
+        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
       );
 
-      const result = await service.validateCredentials('baduser', 'badpass');
+      const result = await service.validateCredentials("baduser", "badpass");
       expect(result.valid).toBe(false);
-      expect(result.error).toBe('Invalid username or password.');
-      expect(result.errorCode).toBe('auth-failed');
+      expect(result.error).toBe("Invalid username or password.");
+      expect(result.errorCode).toBe("auth-failed");
     });
 
-    it('returns valid: false with timeout errorCode on timeout', async () => {
+    it("returns valid: false with timeout errorCode on timeout", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
       mockValidateCredentials.mockRejectedValue(
-        new ScreenScraperError('Request timed out.', 0, 'timeout'),
+        new ScreenScraperError("Request timed out.", 0, "timeout"),
       );
 
-      const result = await service.validateCredentials('user', 'pass');
+      const result = await service.validateCredentials("user", "pass");
       expect(result.valid).toBe(false);
-      expect(result.errorCode).toBe('timeout');
+      expect(result.errorCode).toBe("timeout");
     });
 
-    it('handles non-ScreenScraperError exceptions', async () => {
+    it("handles non-ScreenScraperError exceptions", async () => {
       const service = new ArtworkService(createMockLibraryService());
       await flushPromises();
 
-      mockValidateCredentials.mockRejectedValue(new Error('DNS resolution failed'));
+      mockValidateCredentials.mockRejectedValue(new Error("DNS resolution failed"));
 
-      const result = await service.validateCredentials('user', 'pass');
+      const result = await service.validateCredentials("user", "pass");
       expect(result.valid).toBe(false);
-      expect(result.error).toBe('DNS resolution failed');
+      expect(result.error).toBe("DNS resolution failed");
       expect(result.errorCode).toBeUndefined();
     });
   });
 
-  describe('syncGames (targeted sync)', () => {
-    it('only processes specified game IDs', async () => {
+  describe("syncGames (targeted sync)", () => {
+    it("only processes specified game IDs", async () => {
       const games = [
-        makeGame({ id: 'game1', title: 'Game 1' }),
-        makeGame({ id: 'game2', title: 'Game 2' }),
-        makeGame({ id: 'game3', title: 'Game 3' }),
+        makeGame({ id: "game1", title: "Game 1" }),
+        makeGame({ id: "game2", title: "Game 2" }),
+        makeGame({ id: "game3", title: "Game 3" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const progressEvents: ArtworkProgress[] = [];
-      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: Array<ArtworkProgress> = [];
+      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
 
-      const status = await service.syncGames(['game1', 'game3']);
+      const status = await service.syncGames(["game1", "game3"]);
 
       // Should only have progress for game1 and game3, not game2
-      const syncedIds = new Set(progressEvents.map(p => p.gameId));
-      expect(syncedIds.has('game2')).toBe(false);
+      const syncedIds = new Set(progressEvents.map((p) => p.gameId));
+      expect(syncedIds.has("game2")).toBe(false);
       expect(status.total).toBe(2);
     });
 
-    it('skips games that already have cover art', async () => {
+    it("skips games that already have cover art", async () => {
       const games = [
-        makeGame({ id: 'game1', title: 'Game 1', coverArt: 'artwork://game1.png' }),
-        makeGame({ id: 'game2', title: 'Game 2' }),
+        makeGame({ id: "game1", title: "Game 1", coverArt: "artwork://game1.png" }),
+        makeGame({ id: "game2", title: "Game 2" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
 
-      const status = await service.syncGames(['game1', 'game2']);
+      const status = await service.syncGames(["game1", "game2"]);
       // game1 should be filtered out since it has cover art
       expect(status.total).toBe(1);
     });
 
-    it('returns immediately if already syncing', async () => {
+    it("returns immediately if already syncing", async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
       (service as unknown as Record<string, boolean>).syncing = true;
 
-      const status = await service.syncGames(['game1']);
+      const status = await service.syncGames(["game1"]);
       expect(status.inProgress).toBe(true);
       expect(status.total).toBe(0);
     });
   });
 
-  describe('batch sync error handling', () => {
-    it('stops batch on auth-failed error', async () => {
+  describe("batch sync error handling", () => {
+    it("stops batch on auth-failed error", async () => {
       const games = [
-        makeGame({ id: 'game1', title: 'Game 1' }),
-        makeGame({ id: 'game2', title: 'Game 2' }),
-        makeGame({ id: 'game3', title: 'Game 3' }),
+        makeGame({ id: "game1", title: "Game 1" }),
+        makeGame({ id: "game2", title: "Game 2" }),
+        makeGame({ id: "game3", title: "Game 3" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
-      await service.setCredentials('baduser', 'badpass');
+      await service.setCredentials("baduser", "badpass");
 
       mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError('Invalid username or password.', 401, 'auth-failed'),
+        new ScreenScraperError("Invalid username or password.", 401, "auth-failed"),
       );
 
-      const progressEvents: ArtworkProgress[] = [];
-      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: Array<ArtworkProgress> = [];
+      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
 
       const status = await service.syncAllGames();
 
@@ -563,24 +577,24 @@ describe('ArtworkService', () => {
       expect(status.processed).toBeLessThanOrEqual(1);
 
       // Verify the error event has the correct errorCode
-      const errorEvent = progressEvents.find(p => p.phase === 'error');
-      if (!errorEvent) throw new Error('Expected an error progress event');
-      expect(errorEvent.errorCode).toBe('auth-failed');
+      const errorEvent = progressEvents.find((p) => p.phase === "error");
+      if (!errorEvent) {
+        throw new Error("Expected an error progress event");
+      }
+      expect(errorEvent.errorCode).toBe("auth-failed");
     });
 
-    it('continues batch on non-auth errors', async () => {
+    it("continues batch on non-auth errors", async () => {
       const games = [
-        makeGame({ id: 'game1', title: 'Game 1' }),
-        makeGame({ id: 'game2', title: 'Game 2' }),
+        makeGame({ id: "game1", title: "Game 1" }),
+        makeGame({ id: "game2", title: "Game 2" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       // Timeout errors should NOT stop the batch
-      mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError('Timed out', 0, 'timeout'),
-      );
+      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
       mockFetchByName.mockResolvedValue(null);
 
       const status = await service.syncAllGames();
@@ -589,29 +603,26 @@ describe('ArtworkService', () => {
       expect(status.processed).toBe(2);
     });
 
-    it('emits progress with not-found when API lookups fail with non-auth errors', async () => {
+    it("emits progress with not-found when API lookups fail with non-auth errors", async () => {
       const game = makeGame();
       const service = new ArtworkService(createMockLibraryService([game]));
       await flushPromises();
-      await service.setCredentials('user', 'pass');
+      await service.setCredentials("user", "pass");
 
       // Timeout errors are non-fatal and fall through to name search
-      mockFetchByHash.mockRejectedValue(
-        new ScreenScraperError('Timed out', 0, 'timeout'),
-      );
+      mockFetchByHash.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
       // Name search also fails with a non-auth error — gets swallowed
-      mockFetchByName.mockRejectedValue(
-        new ScreenScraperError('Timed out', 0, 'timeout'),
-      );
+      mockFetchByName.mockRejectedValue(new ScreenScraperError("Timed out", 0, "timeout"));
 
-      const progressEvents: ArtworkProgress[] = [];
-      service.on('progress', (p: ArtworkProgress) => progressEvents.push(p));
+      const progressEvents: Array<ArtworkProgress> = [];
+      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
 
       await service.syncAllGames();
 
       // Game should show as not-found since both lookups failed non-fatally
-      const lastEvent = progressEvents[progressEvents.length - 1];
-      expect(lastEvent.phase).toBe('not-found');
+      const lastEvent = progressEvents.at(-1);
+      expect(lastEvent).toBeDefined();
+      expect(lastEvent?.phase).toBe("not-found");
     });
   });
 });

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -81,7 +81,7 @@ export class ArtworkService extends EventEmitter {
     for (const game of needsBackfill) {
       try {
         // Resolve artwork:// URL to filesystem path
-        const filename = game.coverArt!.replace("artwork://", "");
+        const filename = (game.coverArt ?? "").replace("artwork://", "");
         const filePath = path.join(this.artworkDirectory, filename);
 
         const dimensions = await readImageDimensions(filePath);
@@ -248,8 +248,8 @@ export class ArtworkService extends EventEmitter {
     // Step 5: Update game record (including regional system name if applicable)
     const regionalName = getRegionalSystemName(game.systemId, gameInfo.region);
     await this.libraryService.updateGame(gameId, {
-      ...(coverArtPath
-        ? { coverArt: `artwork://${gameId}${this.getImageExtension(artworkUrl!)}` }
+      ...(coverArtPath && artworkUrl
+        ? { coverArt: `artwork://${gameId}${this.getImageExtension(artworkUrl)}` }
         : {}),
       ...(coverArtAspectRatio !== undefined ? { coverArtAspectRatio } : {}),
       ...(regionalName ? { system: regionalName } : {}),

--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -67,6 +67,14 @@ async function createService(): Promise<LibraryService> {
   return service;
 }
 
+/** Assert a value is defined, returning the narrowed type. Throws with a descriptive error if not. */
+function assertDefined<T>(value: T | null | undefined, message = "Expected value to be defined"): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
+  return value;
+}
+
 /** Compute the SHA-256 of a file's content (mirrors computeRomHashes gameId). */
 function sha256File(filePath: string): string {
   const content = fs.readFileSync(filePath);
@@ -278,7 +286,7 @@ describe("LibraryService", () => {
       const found = systems.find((s) => s.id === "custom");
 
       expect(found).toBeDefined();
-      expect(found!.name).toBe("Custom System");
+      expect(assertDefined(found).name).toBe("Custom System");
     });
 
     it("does not add a duplicate system with the same id", async () => {

--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -67,14 +67,6 @@ async function createService(): Promise<LibraryService> {
   return service;
 }
 
-/** Assert a value is defined, returning the narrowed type. Throws with a descriptive error if not. */
-function assertDefined<T>(value: T | null | undefined, message = "Expected value to be defined"): T {
-  if (value === null || value === undefined) {
-    throw new Error(message);
-  }
-  return value;
-}
-
 /** Compute the SHA-256 of a file's content (mirrors computeRomHashes gameId). */
 function sha256File(filePath: string): string {
   const content = fs.readFileSync(filePath);
@@ -286,7 +278,7 @@ describe("LibraryService", () => {
       const found = systems.find((s) => s.id === "custom");
 
       expect(found).toBeDefined();
-      expect(assertDefined(found).name).toBe("Custom System");
+      expect(found!.name).toBe("Custom System");
     });
 
     it("does not add a duplicate system with the same id", async () => {

--- a/apps/desktop/src/main/services/ScreenScraperClient.test.ts
+++ b/apps/desktop/src/main/services/ScreenScraperClient.test.ts
@@ -1,91 +1,61 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
-import { ScreenScraperClient, ScreenScraperError } from "./ScreenScraperClient";
+import { describe, it, expect } from 'vitest';
+import { ScreenScraperClient, ScreenScraperError } from './ScreenScraperClient';
 
 const dummyCredentials = {
-  devId: "testdev",
-  devPassword: "testpass",
-  userId: "testuser",
-  userPassword: "testuserpass",
+  devId: 'testdev',
+  devPassword: 'testpass',
+  userId: 'testuser',
+  userPassword: 'testuserpass',
 };
 
 /** Realistic fixture based on actual ScreenScraper jeuInfos responses. */
 function makeGameResponseFixture(overrides?: Record<string, unknown>) {
   return {
-    header: { APIversion: "2", success: "true" },
+    header: { APIversion: '2', success: 'true' },
     response: {
       jeu: {
-        dates: [
-          { region: "jp", text: "1985-09-13" },
-          { region: "us", text: "1985-10-18" },
-          { region: "eu", text: "1987-05-15" },
+        id: '12345',
+        noms: [
+          { region: 'jp', text: 'Super Mario Bros.' },
+          { region: 'us', text: 'Super Mario Bros.' },
+          { region: 'eu', text: 'Super Mario Bros.' },
         ],
-        developpeur: { text: "Nintendo R&D4" },
-        editeur: { text: "Nintendo" },
+        synopsis: [
+          { langue: 'fr', text: 'Un jeu de plateforme classique.' },
+          { langue: 'en', text: 'A classic platform game featuring Mario.' },
+          { langue: 'de', text: 'Ein klassisches Plattformspiel.' },
+        ],
+        developpeur: { text: 'Nintendo R&D4' },
+        editeur: { text: 'Nintendo' },
+        joueurs: { text: '2' },
+        note: { text: '18' },
+        dates: [
+          { region: 'jp', text: '1985-09-13' },
+          { region: 'us', text: '1985-10-18' },
+          { region: 'eu', text: '1987-05-15' },
+        ],
         genres: [
           {
             noms: [
-              { langue: "en", text: "Platform" },
-              { langue: "fr", text: "Plateforme" },
+              { langue: 'en', text: 'Platform' },
+              { langue: 'fr', text: 'Plateforme' },
             ],
           },
           {
             noms: [
-              { langue: "en", text: "Action" },
-              { langue: "fr", text: "Action" },
+              { langue: 'en', text: 'Action' },
+              { langue: 'fr', text: 'Action' },
             ],
           },
         ],
-        id: "12345",
-        joueurs: { text: "2" },
         medias: [
-          {
-            type: "box-2D",
-            region: "us",
-            url: "https://screenscraper.fr/medias/box2d-us.png",
-            format: "png",
-          },
-          {
-            type: "box-2D",
-            region: "jp",
-            url: "https://screenscraper.fr/medias/box2d-jp.png",
-            format: "png",
-          },
-          {
-            type: "box-2D",
-            region: "eu",
-            url: "https://screenscraper.fr/medias/box2d-eu.png",
-            format: "png",
-          },
-          {
-            type: "box-3D",
-            region: "us",
-            url: "https://screenscraper.fr/medias/box3d-us.png",
-            format: "png",
-          },
-          {
-            type: "ss",
-            region: "us",
-            url: "https://screenscraper.fr/medias/ss-us.png",
-            format: "png",
-          },
-          {
-            type: "fanart",
-            region: "wor",
-            url: "https://screenscraper.fr/medias/fanart-wor.png",
-            format: "png",
-          },
-        ],
-        noms: [
-          { region: "jp", text: "Super Mario Bros." },
-          { region: "us", text: "Super Mario Bros." },
-          { region: "eu", text: "Super Mario Bros." },
-        ],
-        note: { text: "18" },
-        synopsis: [
-          { langue: "fr", text: "Un jeu de plateforme classique." },
-          { langue: "en", text: "A classic platform game featuring Mario." },
-          { langue: "de", text: "Ein klassisches Plattformspiel." },
+          { type: 'box-2D', region: 'us', url: 'https://screenscraper.fr/medias/box2d-us.png', format: 'png' },
+          { type: 'box-2D', region: 'jp', url: 'https://screenscraper.fr/medias/box2d-jp.png', format: 'png' },
+          { type: 'box-2D', region: 'eu', url: 'https://screenscraper.fr/medias/box2d-eu.png', format: 'png' },
+          { type: 'box-3D', region: 'us', url: 'https://screenscraper.fr/medias/box3d-us.png', format: 'png' },
+          { type: 'ss', region: 'us', url: 'https://screenscraper.fr/medias/ss-us.png', format: 'png' },
+          { type: 'fanart', region: 'wor', url: 'https://screenscraper.fr/medias/fanart-wor.png', format: 'png' },
         ],
         ...overrides,
       },
@@ -95,280 +65,279 @@ function makeGameResponseFixture(overrides?: Record<string, unknown>) {
 
 function makeSearchResponseFixture() {
   return {
-    header: { APIversion: "2", success: "true" },
+    header: { APIversion: '2', success: 'true' },
     response: {
       jeux: [
         {
-          dates: [{ region: "us", text: "1985-10-18" }],
-          developpeur: { text: "Nintendo R&D4" },
-          editeur: { text: "Nintendo" },
-          genres: [{ noms: [{ langue: "en", text: "Platform" }] }],
-          id: "12345",
-          joueurs: { text: "2" },
+          id: '12345',
+          noms: [{ region: 'us', text: 'Super Mario Bros.' }],
+          developpeur: { text: 'Nintendo R&D4' },
+          editeur: { text: 'Nintendo' },
+          joueurs: { text: '2' },
+          note: { text: '18' },
+          dates: [{ region: 'us', text: '1985-10-18' }],
+          genres: [{ noms: [{ langue: 'en', text: 'Platform' }] }],
+          synopsis: [{ langue: 'en', text: 'A classic platformer.' }],
           medias: [
-            {
-              type: "box-2D",
-              region: "us",
-              url: "https://screenscraper.fr/medias/box2d-us.png",
-              format: "png",
-            },
+            { type: 'box-2D', region: 'us', url: 'https://screenscraper.fr/medias/box2d-us.png', format: 'png' },
           ],
-          noms: [{ region: "us", text: "Super Mario Bros." }],
-          note: { text: "18" },
-          synopsis: [{ langue: "en", text: "A classic platformer." }],
         },
       ],
     },
   };
 }
 
-describe("ScreenScraperClient", () => {
-  describe("parseGameResponse", () => {
-    it("parses a full game response with all fields", () => {
+/** Assert a value is non-null and return it with narrowed type. */
+function assertDefined<T>(value: T | null | undefined, message = 'Expected value to be defined'): T {
+  if (value === null || value === undefined) throw new Error(message);
+  return value;
+}
+
+describe('ScreenScraperClient', () => {
+  describe('parseGameResponse', () => {
+    it('parses a full game response with all fields', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(result!.title).toBe("Super Mario Bros.");
-      expect(result!.region).toBe("us");
-      expect(result!.developer).toBe("Nintendo R&D4");
-      expect(result!.publisher).toBe("Nintendo");
-      expect(result!.genre).toBe("Platform");
-      expect(result!.synopsis).toBe("A classic platform game featuring Mario.");
-      expect(result!.players).toBe(2);
-      expect(result!.rating).toBeCloseTo(0.9); // 18/20
-      expect(result!.releaseDate).toBe("1985-10-18"); // US preferred
+      expect(assertDefined(result).title).toBe('Super Mario Bros.');
+      expect(assertDefined(result).region).toBe('us');
+      expect(assertDefined(result).developer).toBe('Nintendo R&D4');
+      expect(assertDefined(result).publisher).toBe('Nintendo');
+      expect(assertDefined(result).genre).toBe('Platform');
+      expect(assertDefined(result).synopsis).toBe('A classic platform game featuring Mario.');
+      expect(assertDefined(result).players).toBe(2);
+      expect(assertDefined(result).rating).toBeCloseTo(0.9); // 18/20
+      expect(assertDefined(result).releaseDate).toBe('1985-10-18'); // US preferred
     });
 
-    it("selects US region for box art and screenshots", () => {
+    it('selects US region for box art and screenshots', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.media.boxArt2d).toBe("https://screenscraper.fr/medias/box2d-us.png");
-      expect(result!.media.boxArt3d).toBe("https://screenscraper.fr/medias/box3d-us.png");
-      expect(result!.media.screenshot).toBe("https://screenscraper.fr/medias/ss-us.png");
+      expect(assertDefined(result).media.boxArt2d).toBe('https://screenscraper.fr/medias/box2d-us.png');
+      expect(assertDefined(result).media.boxArt3d).toBe('https://screenscraper.fr/medias/box3d-us.png');
+      expect(assertDefined(result).media.screenshot).toBe('https://screenscraper.fr/medias/ss-us.png');
     });
 
-    it("falls back to world region when US is not available", () => {
+    it('falls back to world region when US is not available', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
       // fanart only has 'wor' region in fixture
-      expect(result!.media.fanart).toBe("https://screenscraper.fr/medias/fanart-wor.png");
+      expect(assertDefined(result).media.fanart).toBe('https://screenscraper.fr/medias/fanart-wor.png');
     });
 
-    it("prefers English synopsis over other languages", () => {
+    it('prefers English synopsis over other languages', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.synopsis).toBe("A classic platform game featuring Mario.");
+      expect(assertDefined(result).synopsis).toBe('A classic platform game featuring Mario.');
     });
 
-    it("falls back to French synopsis when English is unavailable", () => {
+    it('falls back to French synopsis when English is unavailable', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         synopsis: [
-          { langue: "fr", text: "Un jeu de plateforme." },
-          { langue: "de", text: "Ein Plattformspiel." },
+          { langue: 'fr', text: 'Un jeu de plateforme.' },
+          { langue: 'de', text: 'Ein Plattformspiel.' },
         ],
       });
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.synopsis).toBe("Un jeu de plateforme.");
+      expect(assertDefined(result).synopsis).toBe('Un jeu de plateforme.');
     });
 
-    it("returns null for empty response", () => {
+    it('returns null for empty response', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseGameResponse({});
       expect(result).toBeNull();
     });
 
-    it("returns null when response has no jeu", () => {
+    it('returns null when response has no jeu', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseGameResponse({ response: {} });
       expect(result).toBeNull();
     });
 
-    it("handles missing optional fields gracefully", () => {
+    it('handles missing optional fields gracefully', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
+        synopsis: undefined,
         developpeur: undefined,
         editeur: undefined,
-        genres: undefined,
         joueurs: undefined,
-        medias: undefined,
         note: undefined,
-        synopsis: undefined,
+        genres: undefined,
+        medias: undefined,
       });
       const result = client.parseGameResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(result!.title).toBe("Super Mario Bros.");
-      expect(result!.synopsis).toBeUndefined();
-      expect(result!.developer).toBeUndefined();
-      expect(result!.publisher).toBeUndefined();
-      expect(result!.players).toBeUndefined();
-      expect(result!.rating).toBeUndefined();
-      expect(result!.genre).toBeUndefined();
-      expect(result!.media.boxArt2d).toBeUndefined();
+      expect(assertDefined(result).title).toBe('Super Mario Bros.');
+      expect(assertDefined(result).synopsis).toBeUndefined();
+      expect(assertDefined(result).developer).toBeUndefined();
+      expect(assertDefined(result).publisher).toBeUndefined();
+      expect(assertDefined(result).players).toBeUndefined();
+      expect(assertDefined(result).rating).toBeUndefined();
+      expect(assertDefined(result).genre).toBeUndefined();
+      expect(assertDefined(result).media.boxArt2d).toBeUndefined();
     });
 
-    it("normalizes rating from 0-20 scale to 0-1", () => {
+    it('normalizes rating from 0-20 scale to 0-1', () => {
       const client = new ScreenScraperClient(dummyCredentials);
-      const fixture = makeGameResponseFixture({ note: { text: "10" } });
+      const fixture = makeGameResponseFixture({ note: { text: '10' } });
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.rating).toBeCloseTo(0.5);
+      expect(assertDefined(result).rating).toBeCloseTo(0.5);
     });
 
-    it("handles non-numeric players text", () => {
+    it('handles non-numeric players text', () => {
       const client = new ScreenScraperClient(dummyCredentials);
-      const fixture = makeGameResponseFixture({ joueurs: { text: "N/A" } });
+      const fixture = makeGameResponseFixture({ joueurs: { text: 'N/A' } });
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.players).toBeUndefined();
+      expect(assertDefined(result).players).toBeUndefined();
     });
   });
 
-  describe("parseSearchResponse", () => {
-    it("returns the first game from search results", () => {
+  describe('parseSearchResponse', () => {
+    it('returns the first game from search results', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeSearchResponseFixture();
       const result = client.parseSearchResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(result!.title).toBe("Super Mario Bros.");
-      expect(result!.media.boxArt2d).toBe("https://screenscraper.fr/medias/box2d-us.png");
+      expect(assertDefined(result).title).toBe('Super Mario Bros.');
+      expect(assertDefined(result).media.boxArt2d).toBe('https://screenscraper.fr/medias/box2d-us.png');
     });
 
-    it("returns null for empty search results", () => {
+    it('returns null for empty search results', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseSearchResponse({
-        header: { APIversion: "2", success: "true" },
+        header: { APIversion: '2', success: 'true' },
         response: { jeux: [] },
       });
       expect(result).toBeNull();
     });
 
-    it("returns null when search response has no jeux", () => {
+    it('returns null when search response has no jeux', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseSearchResponse({ response: {} });
       expect(result).toBeNull();
     });
   });
 
-  describe("region preference", () => {
-    it("prefers US over EU over JP for titles", () => {
+  describe('region preference', () => {
+    it('prefers US over EU over JP for titles', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: "jp", text: "JP Title" },
-          { region: "eu", text: "EU Title" },
-          { region: "us", text: "US Title" },
+          { region: 'jp', text: 'JP Title' },
+          { region: 'eu', text: 'EU Title' },
+          { region: 'us', text: 'US Title' },
         ],
       });
       const result = client.parseGameResponse(fixture);
-      expect(result!.title).toBe("US Title");
+      expect(assertDefined(result).title).toBe('US Title');
     });
 
-    it("falls back through region priority when preferred region is missing", () => {
+    it('falls back through region priority when preferred region is missing', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: "jp", text: "JP Title" },
-          { region: "eu", text: "EU Title" },
+          { region: 'jp', text: 'JP Title' },
+          { region: 'eu', text: 'EU Title' },
         ],
       });
       const result = client.parseGameResponse(fixture);
       // 'wor' is second priority, not present, then 'eu' is third
-      expect(result!.title).toBe("EU Title");
+      expect(assertDefined(result).title).toBe('EU Title');
     });
 
-    it("falls back to first available entry when no preferred region matches", () => {
+    it('falls back to first available entry when no preferred region matches', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        noms: [{ region: "br", text: "BR Title" }],
+        noms: [{ region: 'br', text: 'BR Title' }],
       });
       const result = client.parseGameResponse(fixture);
-      expect(result!.title).toBe("BR Title");
-      expect(result!.region).toBe("br");
+      expect(assertDefined(result).title).toBe('BR Title');
+      expect(assertDefined(result).region).toBe('br');
     });
 
-    it("returns jp region when only Japanese title is available", () => {
+    it('returns jp region when only Japanese title is available', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        noms: [{ region: "jp", text: "スーパーマリオブラザーズ" }],
+        noms: [{ region: 'jp', text: 'スーパーマリオブラザーズ' }],
       });
       const result = client.parseGameResponse(fixture);
-      expect(result!.title).toBe("スーパーマリオブラザーズ");
-      expect(result!.region).toBe("jp");
+      expect(assertDefined(result).title).toBe('スーパーマリオブラザーズ');
+      expect(assertDefined(result).region).toBe('jp');
     });
 
-    it("returns eu region when EU is the best match", () => {
+    it('returns eu region when EU is the best match', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: "jp", text: "JP Title" },
-          { region: "eu", text: "EU Title" },
+          { region: 'jp', text: 'JP Title' },
+          { region: 'eu', text: 'EU Title' },
         ],
       });
       const result = client.parseGameResponse(fixture);
-      expect(result!.title).toBe("EU Title");
-      expect(result!.region).toBe("eu");
+      expect(assertDefined(result).title).toBe('EU Title');
+      expect(assertDefined(result).region).toBe('eu');
     });
   });
 
-  describe("media selection", () => {
-    it("returns undefined when no media of requested type exists", () => {
+  describe('media selection', () => {
+    it('returns undefined when no media of requested type exists', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        medias: [{ region: "us", type: "box-2D", url: "https://example.com/box.png" }],
+        medias: [
+          { type: 'box-2D', region: 'us', url: 'https://example.com/box.png' },
+        ],
       });
       const result = client.parseGameResponse(fixture);
 
-      expect(result!.media.boxArt2d).toBe("https://example.com/box.png");
-      expect(result!.media.fanart).toBeUndefined();
+      expect(assertDefined(result).media.boxArt2d).toBe('https://example.com/box.png');
+      expect(assertDefined(result).media.fanart).toBeUndefined();
     });
 
-    it("selects media with region fallback", () => {
+    it('selects media with region fallback', () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        medias: [{ region: "eu", type: "box-2D", url: "https://example.com/box-eu.png" }],
+        medias: [
+          { type: 'box-2D', region: 'eu', url: 'https://example.com/box-eu.png' },
+        ],
       });
       const result = client.parseGameResponse(fixture);
-      expect(result!.media.boxArt2d).toBe("https://example.com/box-eu.png");
+      expect(assertDefined(result).media.boxArt2d).toBe('https://example.com/box-eu.png');
     });
   });
 
-  describe("ScreenScraperError", () => {
-    it("carries errorCode and statusCode", () => {
-      const error = new ScreenScraperError("Auth failed", 401, "auth-failed");
+  describe('ScreenScraperError', () => {
+    it('carries errorCode and statusCode', () => {
+      const error = new ScreenScraperError('Auth failed', 401, 'auth-failed');
 
-      expect(error.message).toBe("Auth failed");
+      expect(error.message).toBe('Auth failed');
       expect(error.statusCode).toBe(401);
-      expect(error.errorCode).toBe("auth-failed");
-      expect(error.name).toBe("ScreenScraperError");
+      expect(error.errorCode).toBe('auth-failed');
+      expect(error.name).toBe('ScreenScraperError');
       expect(error).toBeInstanceOf(Error);
     });
 
-    it("defaults errorCode to network-error", () => {
-      const error = new ScreenScraperError("Something broke", 500);
+    it('defaults errorCode to network-error', () => {
+      const error = new ScreenScraperError('Something broke', 500);
 
-      expect(error.errorCode).toBe("network-error");
+      expect(error.errorCode).toBe('network-error');
     });
 
-    it("supports all defined error codes", () => {
-      const codes = [
-        "timeout",
-        "auth-failed",
-        "rate-limited",
-        "network-error",
-        "parse-error",
-      ] as const;
+    it('supports all defined error codes', () => {
+      const codes = ['timeout', 'auth-failed', 'rate-limited', 'network-error', 'parse-error'] as const;
       for (const code of codes) {
         const error = new ScreenScraperError(`Error: ${code}`, 0, code);
         expect(error.errorCode).toBe(code);

--- a/apps/desktop/src/main/services/ScreenScraperClient.test.ts
+++ b/apps/desktop/src/main/services/ScreenScraperClient.test.ts
@@ -1,61 +1,91 @@
 // @vitest-environment node
-import { describe, it, expect } from 'vitest';
-import { ScreenScraperClient, ScreenScraperError } from './ScreenScraperClient';
+import { describe, it, expect } from "vitest";
+import { ScreenScraperClient, ScreenScraperError } from "./ScreenScraperClient";
 
 const dummyCredentials = {
-  devId: 'testdev',
-  devPassword: 'testpass',
-  userId: 'testuser',
-  userPassword: 'testuserpass',
+  devId: "testdev",
+  devPassword: "testpass",
+  userId: "testuser",
+  userPassword: "testuserpass",
 };
 
 /** Realistic fixture based on actual ScreenScraper jeuInfos responses. */
 function makeGameResponseFixture(overrides?: Record<string, unknown>) {
   return {
-    header: { APIversion: '2', success: 'true' },
+    header: { APIversion: "2", success: "true" },
     response: {
       jeu: {
-        id: '12345',
+        id: "12345",
         noms: [
-          { region: 'jp', text: 'Super Mario Bros.' },
-          { region: 'us', text: 'Super Mario Bros.' },
-          { region: 'eu', text: 'Super Mario Bros.' },
+          { region: "jp", text: "Super Mario Bros." },
+          { region: "us", text: "Super Mario Bros." },
+          { region: "eu", text: "Super Mario Bros." },
         ],
         synopsis: [
-          { langue: 'fr', text: 'Un jeu de plateforme classique.' },
-          { langue: 'en', text: 'A classic platform game featuring Mario.' },
-          { langue: 'de', text: 'Ein klassisches Plattformspiel.' },
+          { langue: "fr", text: "Un jeu de plateforme classique." },
+          { langue: "en", text: "A classic platform game featuring Mario." },
+          { langue: "de", text: "Ein klassisches Plattformspiel." },
         ],
-        developpeur: { text: 'Nintendo R&D4' },
-        editeur: { text: 'Nintendo' },
-        joueurs: { text: '2' },
-        note: { text: '18' },
+        developpeur: { text: "Nintendo R&D4" },
+        editeur: { text: "Nintendo" },
+        joueurs: { text: "2" },
+        note: { text: "18" },
         dates: [
-          { region: 'jp', text: '1985-09-13' },
-          { region: 'us', text: '1985-10-18' },
-          { region: 'eu', text: '1987-05-15' },
+          { region: "jp", text: "1985-09-13" },
+          { region: "us", text: "1985-10-18" },
+          { region: "eu", text: "1987-05-15" },
         ],
         genres: [
           {
             noms: [
-              { langue: 'en', text: 'Platform' },
-              { langue: 'fr', text: 'Plateforme' },
+              { langue: "en", text: "Platform" },
+              { langue: "fr", text: "Plateforme" },
             ],
           },
           {
             noms: [
-              { langue: 'en', text: 'Action' },
-              { langue: 'fr', text: 'Action' },
+              { langue: "en", text: "Action" },
+              { langue: "fr", text: "Action" },
             ],
           },
         ],
         medias: [
-          { type: 'box-2D', region: 'us', url: 'https://screenscraper.fr/medias/box2d-us.png', format: 'png' },
-          { type: 'box-2D', region: 'jp', url: 'https://screenscraper.fr/medias/box2d-jp.png', format: 'png' },
-          { type: 'box-2D', region: 'eu', url: 'https://screenscraper.fr/medias/box2d-eu.png', format: 'png' },
-          { type: 'box-3D', region: 'us', url: 'https://screenscraper.fr/medias/box3d-us.png', format: 'png' },
-          { type: 'ss', region: 'us', url: 'https://screenscraper.fr/medias/ss-us.png', format: 'png' },
-          { type: 'fanart', region: 'wor', url: 'https://screenscraper.fr/medias/fanart-wor.png', format: 'png' },
+          {
+            type: "box-2D",
+            region: "us",
+            url: "https://screenscraper.fr/medias/box2d-us.png",
+            format: "png",
+          },
+          {
+            type: "box-2D",
+            region: "jp",
+            url: "https://screenscraper.fr/medias/box2d-jp.png",
+            format: "png",
+          },
+          {
+            type: "box-2D",
+            region: "eu",
+            url: "https://screenscraper.fr/medias/box2d-eu.png",
+            format: "png",
+          },
+          {
+            type: "box-3D",
+            region: "us",
+            url: "https://screenscraper.fr/medias/box3d-us.png",
+            format: "png",
+          },
+          {
+            type: "ss",
+            region: "us",
+            url: "https://screenscraper.fr/medias/ss-us.png",
+            format: "png",
+          },
+          {
+            type: "fanart",
+            region: "wor",
+            url: "https://screenscraper.fr/medias/fanart-wor.png",
+            format: "png",
+          },
         ],
         ...overrides,
       },
@@ -65,21 +95,26 @@ function makeGameResponseFixture(overrides?: Record<string, unknown>) {
 
 function makeSearchResponseFixture() {
   return {
-    header: { APIversion: '2', success: 'true' },
+    header: { APIversion: "2", success: "true" },
     response: {
       jeux: [
         {
-          id: '12345',
-          noms: [{ region: 'us', text: 'Super Mario Bros.' }],
-          developpeur: { text: 'Nintendo R&D4' },
-          editeur: { text: 'Nintendo' },
-          joueurs: { text: '2' },
-          note: { text: '18' },
-          dates: [{ region: 'us', text: '1985-10-18' }],
-          genres: [{ noms: [{ langue: 'en', text: 'Platform' }] }],
-          synopsis: [{ langue: 'en', text: 'A classic platformer.' }],
+          id: "12345",
+          noms: [{ region: "us", text: "Super Mario Bros." }],
+          developpeur: { text: "Nintendo R&D4" },
+          editeur: { text: "Nintendo" },
+          joueurs: { text: "2" },
+          note: { text: "18" },
+          dates: [{ region: "us", text: "1985-10-18" }],
+          genres: [{ noms: [{ langue: "en", text: "Platform" }] }],
+          synopsis: [{ langue: "en", text: "A classic platformer." }],
           medias: [
-            { type: 'box-2D', region: 'us', url: 'https://screenscraper.fr/medias/box2d-us.png', format: 'png' },
+            {
+              type: "box-2D",
+              region: "us",
+              url: "https://screenscraper.fr/medias/box2d-us.png",
+              format: "png",
+            },
           ],
         },
       ],
@@ -88,83 +123,96 @@ function makeSearchResponseFixture() {
 }
 
 /** Assert a value is non-null and return it with narrowed type. */
-function assertDefined<T>(value: T | null | undefined, message = 'Expected value to be defined'): T {
-  if (value === null || value === undefined) throw new Error(message);
+function assertDefined<T>(
+  value: T | null | undefined,
+  message = "Expected value to be defined",
+): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
   return value;
 }
 
-describe('ScreenScraperClient', () => {
-  describe('parseGameResponse', () => {
-    it('parses a full game response with all fields', () => {
+describe("ScreenScraperClient", () => {
+  describe("parseGameResponse", () => {
+    it("parses a full game response with all fields", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(assertDefined(result).title).toBe('Super Mario Bros.');
-      expect(assertDefined(result).region).toBe('us');
-      expect(assertDefined(result).developer).toBe('Nintendo R&D4');
-      expect(assertDefined(result).publisher).toBe('Nintendo');
-      expect(assertDefined(result).genre).toBe('Platform');
-      expect(assertDefined(result).synopsis).toBe('A classic platform game featuring Mario.');
+      expect(assertDefined(result).title).toBe("Super Mario Bros.");
+      expect(assertDefined(result).region).toBe("us");
+      expect(assertDefined(result).developer).toBe("Nintendo R&D4");
+      expect(assertDefined(result).publisher).toBe("Nintendo");
+      expect(assertDefined(result).genre).toBe("Platform");
+      expect(assertDefined(result).synopsis).toBe("A classic platform game featuring Mario.");
       expect(assertDefined(result).players).toBe(2);
       expect(assertDefined(result).rating).toBeCloseTo(0.9); // 18/20
-      expect(assertDefined(result).releaseDate).toBe('1985-10-18'); // US preferred
+      expect(assertDefined(result).releaseDate).toBe("1985-10-18"); // US preferred
     });
 
-    it('selects US region for box art and screenshots', () => {
+    it("selects US region for box art and screenshots", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
-      expect(assertDefined(result).media.boxArt2d).toBe('https://screenscraper.fr/medias/box2d-us.png');
-      expect(assertDefined(result).media.boxArt3d).toBe('https://screenscraper.fr/medias/box3d-us.png');
-      expect(assertDefined(result).media.screenshot).toBe('https://screenscraper.fr/medias/ss-us.png');
+      expect(assertDefined(result).media.boxArt2d).toBe(
+        "https://screenscraper.fr/medias/box2d-us.png",
+      );
+      expect(assertDefined(result).media.boxArt3d).toBe(
+        "https://screenscraper.fr/medias/box3d-us.png",
+      );
+      expect(assertDefined(result).media.screenshot).toBe(
+        "https://screenscraper.fr/medias/ss-us.png",
+      );
     });
 
-    it('falls back to world region when US is not available', () => {
+    it("falls back to world region when US is not available", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
       // fanart only has 'wor' region in fixture
-      expect(assertDefined(result).media.fanart).toBe('https://screenscraper.fr/medias/fanart-wor.png');
+      expect(assertDefined(result).media.fanart).toBe(
+        "https://screenscraper.fr/medias/fanart-wor.png",
+      );
     });
 
-    it('prefers English synopsis over other languages', () => {
+    it("prefers English synopsis over other languages", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture();
       const result = client.parseGameResponse(fixture);
 
-      expect(assertDefined(result).synopsis).toBe('A classic platform game featuring Mario.');
+      expect(assertDefined(result).synopsis).toBe("A classic platform game featuring Mario.");
     });
 
-    it('falls back to French synopsis when English is unavailable', () => {
+    it("falls back to French synopsis when English is unavailable", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         synopsis: [
-          { langue: 'fr', text: 'Un jeu de plateforme.' },
-          { langue: 'de', text: 'Ein Plattformspiel.' },
+          { langue: "fr", text: "Un jeu de plateforme." },
+          { langue: "de", text: "Ein Plattformspiel." },
         ],
       });
       const result = client.parseGameResponse(fixture);
 
-      expect(assertDefined(result).synopsis).toBe('Un jeu de plateforme.');
+      expect(assertDefined(result).synopsis).toBe("Un jeu de plateforme.");
     });
 
-    it('returns null for empty response', () => {
+    it("returns null for empty response", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseGameResponse({});
       expect(result).toBeNull();
     });
 
-    it('returns null when response has no jeu', () => {
+    it("returns null when response has no jeu", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseGameResponse({ response: {} });
       expect(result).toBeNull();
     });
 
-    it('handles missing optional fields gracefully', () => {
+    it("handles missing optional fields gracefully", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         synopsis: undefined,
@@ -178,7 +226,7 @@ describe('ScreenScraperClient', () => {
       const result = client.parseGameResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(assertDefined(result).title).toBe('Super Mario Bros.');
+      expect(assertDefined(result).title).toBe("Super Mario Bros.");
       expect(assertDefined(result).synopsis).toBeUndefined();
       expect(assertDefined(result).developer).toBeUndefined();
       expect(assertDefined(result).publisher).toBeUndefined();
@@ -188,156 +236,160 @@ describe('ScreenScraperClient', () => {
       expect(assertDefined(result).media.boxArt2d).toBeUndefined();
     });
 
-    it('normalizes rating from 0-20 scale to 0-1', () => {
+    it("normalizes rating from 0-20 scale to 0-1", () => {
       const client = new ScreenScraperClient(dummyCredentials);
-      const fixture = makeGameResponseFixture({ note: { text: '10' } });
+      const fixture = makeGameResponseFixture({ note: { text: "10" } });
       const result = client.parseGameResponse(fixture);
 
       expect(assertDefined(result).rating).toBeCloseTo(0.5);
     });
 
-    it('handles non-numeric players text', () => {
+    it("handles non-numeric players text", () => {
       const client = new ScreenScraperClient(dummyCredentials);
-      const fixture = makeGameResponseFixture({ joueurs: { text: 'N/A' } });
+      const fixture = makeGameResponseFixture({ joueurs: { text: "N/A" } });
       const result = client.parseGameResponse(fixture);
 
       expect(assertDefined(result).players).toBeUndefined();
     });
   });
 
-  describe('parseSearchResponse', () => {
-    it('returns the first game from search results', () => {
+  describe("parseSearchResponse", () => {
+    it("returns the first game from search results", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeSearchResponseFixture();
       const result = client.parseSearchResponse(fixture);
 
       expect(result).not.toBeNull();
-      expect(assertDefined(result).title).toBe('Super Mario Bros.');
-      expect(assertDefined(result).media.boxArt2d).toBe('https://screenscraper.fr/medias/box2d-us.png');
+      expect(assertDefined(result).title).toBe("Super Mario Bros.");
+      expect(assertDefined(result).media.boxArt2d).toBe(
+        "https://screenscraper.fr/medias/box2d-us.png",
+      );
     });
 
-    it('returns null for empty search results', () => {
+    it("returns null for empty search results", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseSearchResponse({
-        header: { APIversion: '2', success: 'true' },
+        header: { APIversion: "2", success: "true" },
         response: { jeux: [] },
       });
       expect(result).toBeNull();
     });
 
-    it('returns null when search response has no jeux', () => {
+    it("returns null when search response has no jeux", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const result = client.parseSearchResponse({ response: {} });
       expect(result).toBeNull();
     });
   });
 
-  describe('region preference', () => {
-    it('prefers US over EU over JP for titles', () => {
+  describe("region preference", () => {
+    it("prefers US over EU over JP for titles", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: 'jp', text: 'JP Title' },
-          { region: 'eu', text: 'EU Title' },
-          { region: 'us', text: 'US Title' },
+          { region: "jp", text: "JP Title" },
+          { region: "eu", text: "EU Title" },
+          { region: "us", text: "US Title" },
         ],
       });
       const result = client.parseGameResponse(fixture);
-      expect(assertDefined(result).title).toBe('US Title');
+      expect(assertDefined(result).title).toBe("US Title");
     });
 
-    it('falls back through region priority when preferred region is missing', () => {
+    it("falls back through region priority when preferred region is missing", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: 'jp', text: 'JP Title' },
-          { region: 'eu', text: 'EU Title' },
+          { region: "jp", text: "JP Title" },
+          { region: "eu", text: "EU Title" },
         ],
       });
       const result = client.parseGameResponse(fixture);
       // 'wor' is second priority, not present, then 'eu' is third
-      expect(assertDefined(result).title).toBe('EU Title');
+      expect(assertDefined(result).title).toBe("EU Title");
     });
 
-    it('falls back to first available entry when no preferred region matches', () => {
+    it("falls back to first available entry when no preferred region matches", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        noms: [{ region: 'br', text: 'BR Title' }],
+        noms: [{ region: "br", text: "BR Title" }],
       });
       const result = client.parseGameResponse(fixture);
-      expect(assertDefined(result).title).toBe('BR Title');
-      expect(assertDefined(result).region).toBe('br');
+      expect(assertDefined(result).title).toBe("BR Title");
+      expect(assertDefined(result).region).toBe("br");
     });
 
-    it('returns jp region when only Japanese title is available', () => {
+    it("returns jp region when only Japanese title is available", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        noms: [{ region: 'jp', text: 'スーパーマリオブラザーズ' }],
+        noms: [{ region: "jp", text: "スーパーマリオブラザーズ" }],
       });
       const result = client.parseGameResponse(fixture);
-      expect(assertDefined(result).title).toBe('スーパーマリオブラザーズ');
-      expect(assertDefined(result).region).toBe('jp');
+      expect(assertDefined(result).title).toBe("スーパーマリオブラザーズ");
+      expect(assertDefined(result).region).toBe("jp");
     });
 
-    it('returns eu region when EU is the best match', () => {
+    it("returns eu region when EU is the best match", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
         noms: [
-          { region: 'jp', text: 'JP Title' },
-          { region: 'eu', text: 'EU Title' },
+          { region: "jp", text: "JP Title" },
+          { region: "eu", text: "EU Title" },
         ],
       });
       const result = client.parseGameResponse(fixture);
-      expect(assertDefined(result).title).toBe('EU Title');
-      expect(assertDefined(result).region).toBe('eu');
+      expect(assertDefined(result).title).toBe("EU Title");
+      expect(assertDefined(result).region).toBe("eu");
     });
   });
 
-  describe('media selection', () => {
-    it('returns undefined when no media of requested type exists', () => {
+  describe("media selection", () => {
+    it("returns undefined when no media of requested type exists", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        medias: [
-          { type: 'box-2D', region: 'us', url: 'https://example.com/box.png' },
-        ],
+        medias: [{ type: "box-2D", region: "us", url: "https://example.com/box.png" }],
       });
       const result = client.parseGameResponse(fixture);
 
-      expect(assertDefined(result).media.boxArt2d).toBe('https://example.com/box.png');
+      expect(assertDefined(result).media.boxArt2d).toBe("https://example.com/box.png");
       expect(assertDefined(result).media.fanart).toBeUndefined();
     });
 
-    it('selects media with region fallback', () => {
+    it("selects media with region fallback", () => {
       const client = new ScreenScraperClient(dummyCredentials);
       const fixture = makeGameResponseFixture({
-        medias: [
-          { type: 'box-2D', region: 'eu', url: 'https://example.com/box-eu.png' },
-        ],
+        medias: [{ type: "box-2D", region: "eu", url: "https://example.com/box-eu.png" }],
       });
       const result = client.parseGameResponse(fixture);
-      expect(assertDefined(result).media.boxArt2d).toBe('https://example.com/box-eu.png');
+      expect(assertDefined(result).media.boxArt2d).toBe("https://example.com/box-eu.png");
     });
   });
 
-  describe('ScreenScraperError', () => {
-    it('carries errorCode and statusCode', () => {
-      const error = new ScreenScraperError('Auth failed', 401, 'auth-failed');
+  describe("ScreenScraperError", () => {
+    it("carries errorCode and statusCode", () => {
+      const error = new ScreenScraperError("Auth failed", 401, "auth-failed");
 
-      expect(error.message).toBe('Auth failed');
+      expect(error.message).toBe("Auth failed");
       expect(error.statusCode).toBe(401);
-      expect(error.errorCode).toBe('auth-failed');
-      expect(error.name).toBe('ScreenScraperError');
+      expect(error.errorCode).toBe("auth-failed");
+      expect(error.name).toBe("ScreenScraperError");
       expect(error).toBeInstanceOf(Error);
     });
 
-    it('defaults errorCode to network-error', () => {
-      const error = new ScreenScraperError('Something broke', 500);
+    it("defaults errorCode to network-error", () => {
+      const error = new ScreenScraperError("Something broke", 500);
 
-      expect(error.errorCode).toBe('network-error');
+      expect(error.errorCode).toBe("network-error");
     });
 
-    it('supports all defined error codes', () => {
-      const codes = ['timeout', 'auth-failed', 'rate-limited', 'network-error', 'parse-error'] as const;
+    it("supports all defined error codes", () => {
+      const codes = [
+        "timeout",
+        "auth-failed",
+        "rate-limited",
+        "network-error",
+        "parse-error",
+      ] as const;
       for (const code of codes) {
         const error = new ScreenScraperError(`Error: ${code}`, 0, code);
         expect(error.errorCode).toBe(code);

--- a/apps/desktop/src/main/utils/windowState.test.ts
+++ b/apps/desktop/src/main/utils/windowState.test.ts
@@ -166,7 +166,7 @@ describe('getSavedWindowBounds', () => {
     // Verify it reads from the custom state file
     expect(mockReadFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
-      'utf-8'
+      'utf8'
     )
   })
 
@@ -348,7 +348,7 @@ describe('manageWindowState', () => {
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"width": 1024'),
-      'utf-8'
+      'utf8'
     )
   })
 
@@ -369,7 +369,7 @@ describe('manageWindowState', () => {
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"isMaximized": true'),
-      'utf-8'
+      'utf8'
     )
   })
 
@@ -455,7 +455,7 @@ describe('saveWindowStateNow', () => {
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
       expect.stringContaining('"width": 1024'),
-      'utf-8'
+      'utf8'
     )
     const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
     expect(savedState.isFullScreen).toBe(false)

--- a/apps/desktop/src/main/utils/windowState.test.ts
+++ b/apps/desktop/src/main/utils/windowState.test.ts
@@ -1,83 +1,77 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const MOCK_USER_DATA = "/tmp/gamelord-window-test";
+const MOCK_USER_DATA = '/tmp/gamelord-window-test'
 
 // Hoisted mocks for use in vi.mock factories
 const { mockReadFileSync, mockWriteFileSync } = vi.hoisted(() => ({
   mockReadFileSync: vi.fn(),
   mockWriteFileSync: vi.fn(),
-}));
+}))
 
-const mockGetBounds = vi.fn().mockReturnValue({ height: 768, width: 1024, x: 100, y: 200 });
-const mockSetBounds = vi.fn();
-const mockSetSize = vi.fn();
-const mockCenter = vi.fn();
-const mockMaximize = vi.fn();
-const mockSetFullScreen = vi.fn();
-const mockIsMaximized = vi.fn().mockReturnValue(false);
-const mockIsFullScreen = vi.fn().mockReturnValue(false);
-const mockIsDestroyed = vi.fn().mockReturnValue(false);
-const mockOn = vi.fn();
+const mockGetBounds = vi.fn().mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 })
+const mockSetBounds = vi.fn()
+const mockSetSize = vi.fn()
+const mockCenter = vi.fn()
+const mockMaximize = vi.fn()
+const mockSetFullScreen = vi.fn()
+const mockIsMaximized = vi.fn().mockReturnValue(false)
+const mockIsFullScreen = vi.fn().mockReturnValue(false)
+const mockIsDestroyed = vi.fn().mockReturnValue(false)
+const mockOn = vi.fn()
 
 const mockGetDisplayMatching = vi.fn().mockReturnValue({
-  workArea: { height: 1080, width: 1920, x: 0, y: 0 },
-});
+  workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+})
 
-vi.mock("electron", () => ({
+vi.mock('electron', () => ({
   app: {
     getPath: (name: string) => {
-      if (name === "userData") {
-        return MOCK_USER_DATA;
-      }
-      return "/tmp";
+      if (name === 'userData') return MOCK_USER_DATA
+      return '/tmp'
     },
   },
   BrowserWindow: vi.fn(),
   screen: {
     getAllDisplays: () => [
       {
-        workArea: { height: 1080, width: 1920, x: 0, y: 0 },
+        workArea: { x: 0, y: 0, width: 1920, height: 1080 },
       },
     ],
-    getDisplayMatching: (...args: Array<unknown>) => mockGetDisplayMatching(...args),
+    getDisplayMatching: (...args: unknown[]) => mockGetDisplayMatching(...args),
   },
-}));
+}))
 
-vi.mock("node:fs", () => ({
+vi.mock('node:fs', () => ({
   default: {
     readFileSync: mockReadFileSync,
     writeFileSync: mockWriteFileSync,
   },
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
-}));
+}))
 
 // Import after mocks are set up
-import {
-  getSavedWindowBounds,
-  manageWindowState,
-  saveWindowStateNow,
-  type WindowStateConfig,
-} from "./windowState";
-import type { BrowserWindow } from "electron";
+import { getSavedWindowBounds, manageWindowState, saveWindowStateNow, type WindowStateConfig } from './windowState'
+import type { BrowserWindow } from 'electron'
 
 function createMockWindow(): BrowserWindow {
   return {
-    center: mockCenter,
     getBounds: mockGetBounds,
-    isDestroyed: mockIsDestroyed,
-    isFullScreen: mockIsFullScreen,
-    isMaximized: mockIsMaximized,
-    maximize: mockMaximize,
-    on: mockOn,
     setBounds: mockSetBounds,
-    setFullScreen: mockSetFullScreen,
     setSize: mockSetSize,
-  } as unknown as BrowserWindow;
+    center: mockCenter,
+    maximize: mockMaximize,
+    setFullScreen: mockSetFullScreen,
+    isMaximized: mockIsMaximized,
+    isFullScreen: mockIsFullScreen,
+    isDestroyed: mockIsDestroyed,
+    on: mockOn,
+  } as unknown as BrowserWindow
 }
 
 const GAME_WINDOW_CONFIG: WindowStateConfig = {
+  stateFile: 'game-window-state.json',
   defaults: {
     x: -1,
     y: -1,
@@ -86,429 +80,410 @@ const GAME_WINDOW_CONFIG: WindowStateConfig = {
     isMaximized: false,
     isFullScreen: false,
   },
-  manualCloseSave: true,
-  stateFile: "game-window-state.json",
   trackFullScreen: true,
-};
+  manualCloseSave: true,
+}
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  mockReadFileSync.mockReset();
-  mockWriteFileSync.mockReset();
-  mockIsMaximized.mockReturnValue(false);
-  mockIsFullScreen.mockReturnValue(false);
-  mockIsDestroyed.mockReturnValue(false);
-  mockGetBounds.mockReturnValue({ height: 768, width: 1024, x: 100, y: 200 });
+  vi.clearAllMocks()
+  mockReadFileSync.mockReset()
+  mockWriteFileSync.mockReset()
+  mockIsMaximized.mockReturnValue(false)
+  mockIsFullScreen.mockReturnValue(false)
+  mockIsDestroyed.mockReturnValue(false)
+  mockGetBounds.mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 })
   mockGetDisplayMatching.mockReturnValue({
-    workArea: { height: 1080, width: 1920, x: 0, y: 0 },
-  });
-});
+    workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+  })
+})
 
-describe("getSavedWindowBounds", () => {
-  it("returns default dimensions when no saved state exists", () => {
+describe('getSavedWindowBounds', () => {
+  it('returns default dimensions when no saved state exists', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
+      throw new Error('ENOENT')
+    })
 
-    const bounds = getSavedWindowBounds();
-    expect(bounds).toEqual({ height: 800, width: 1280 });
-    expect(bounds).not.toHaveProperty("x");
-    expect(bounds).not.toHaveProperty("y");
-  });
+    const bounds = getSavedWindowBounds()
+    expect(bounds).toEqual({ width: 1280, height: 800 })
+    expect(bounds).not.toHaveProperty('x')
+    expect(bounds).not.toHaveProperty('y')
+  })
 
-  it("returns saved position and dimensions from disk", () => {
+  it('returns saved position and dimensions from disk', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 900, isMaximized: false, width: 1400, x: 50, y: 75 }),
-    );
+      JSON.stringify({ x: 50, y: 75, width: 1400, height: 900, isMaximized: false })
+    )
 
-    const bounds = getSavedWindowBounds();
-    expect(bounds).toEqual({ height: 900, width: 1400, x: 50, y: 75 });
-  });
+    const bounds = getSavedWindowBounds()
+    expect(bounds).toEqual({ x: 50, y: 75, width: 1400, height: 900 })
+  })
 
-  it("returns only width/height when saved position is default (-1)", () => {
+  it('returns only width/height when saved position is default (-1)', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 700, isMaximized: false, width: 1000, x: -1, y: -1 }),
-    );
+      JSON.stringify({ x: -1, y: -1, width: 1000, height: 700, isMaximized: false })
+    )
 
-    const bounds = getSavedWindowBounds();
-    expect(bounds).toEqual({ height: 700, width: 1000 });
-    expect(bounds).not.toHaveProperty("x");
-    expect(bounds).not.toHaveProperty("y");
-  });
+    const bounds = getSavedWindowBounds()
+    expect(bounds).toEqual({ width: 1000, height: 700 })
+    expect(bounds).not.toHaveProperty('x')
+    expect(bounds).not.toHaveProperty('y')
+  })
 
-  it("returns defaults when saved state has invalid JSON", () => {
-    mockReadFileSync.mockReturnValue("not json!!!");
+  it('returns defaults when saved state has invalid JSON', () => {
+    mockReadFileSync.mockReturnValue('not json!!!')
 
-    const bounds = getSavedWindowBounds();
-    expect(bounds).toEqual({ height: 800, width: 1280 });
-  });
+    const bounds = getSavedWindowBounds()
+    expect(bounds).toEqual({ width: 1280, height: 800 })
+  })
 
-  it("uses default values for missing fields in saved state", () => {
-    mockReadFileSync.mockReturnValue(JSON.stringify({ width: 900 }));
+  it('uses default values for missing fields in saved state', () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ width: 900 }))
 
-    const bounds = getSavedWindowBounds();
+    const bounds = getSavedWindowBounds()
     // x and y default to -1, so no position returned
-    expect(bounds).toEqual({ height: 800, width: 900 });
-  });
+    expect(bounds).toEqual({ width: 900, height: 800 })
+  })
 
-  it("clamps position when saved window is off-screen", () => {
+  it('clamps position when saved window is off-screen', () => {
     // Position far off-screen — getDisplayMatching returns nearest display
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 768, isMaximized: false, width: 1024, x: 5000, y: 5000 }),
-    );
+      JSON.stringify({ x: 5000, y: 5000, width: 1024, height: 768, isMaximized: false })
+    )
 
-    const bounds = getSavedWindowBounds();
+    const bounds = getSavedWindowBounds()
     // Position should be clamped to fit within the 1920x1080 display
-    expect(bounds).toEqual({ height: 768, width: 1024, x: 896, y: 312 });
-  });
+    expect(bounds).toEqual({ x: 896, y: 312, width: 1024, height: 768 })
+  })
 
-  it("uses custom config defaults and file path", () => {
+  it('uses custom config defaults and file path', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
+      throw new Error('ENOENT')
+    })
 
-    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG);
-    expect(bounds).toEqual({ height: 720, width: 960 });
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
+    expect(bounds).toEqual({ width: 960, height: 720 })
 
     // Verify it reads from the custom state file
     expect(mockReadFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
-      "utf8",
-    );
-  });
+      'utf-8'
+    )
+  })
 
-  it("reads saved state from custom config file", () => {
+  it('reads saved state from custom config file', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({
-        height: 600,
-        isFullScreen: true,
-        isMaximized: false,
-        width: 800,
-        x: 300,
-        y: 400,
-      }),
-    );
+      JSON.stringify({ x: 300, y: 400, width: 800, height: 600, isMaximized: false, isFullScreen: true })
+    )
 
-    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG);
-    expect(bounds).toEqual({ height: 600, width: 800, x: 300, y: 400 });
-  });
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
+    expect(bounds).toEqual({ x: 300, y: 400, width: 800, height: 600 })
+  })
 
-  describe("display clamping", () => {
-    it("does not change position when window fits within display", () => {
+  describe('display clamping', () => {
+    it('does not change position when window fits within display', () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 800, x: 100, y: 100 }),
-      );
+        JSON.stringify({ x: 100, y: 100, width: 800, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
-      expect(bounds).toEqual({ height: 600, width: 800, x: 100, y: 100 });
-    });
+      const bounds = getSavedWindowBounds()
+      expect(bounds).toEqual({ x: 100, y: 100, width: 800, height: 600 })
+    })
 
-    it("shifts window left when it extends past right edge", () => {
+    it('shifts window left when it extends past right edge', () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 800, x: 1500, y: 100 }),
-      );
+        JSON.stringify({ x: 1500, y: 100, width: 800, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
+      const bounds = getSavedWindowBounds()
       // x should be clamped to 1920 - 800 = 1120
-      expect(bounds).toEqual({ height: 600, width: 800, x: 1120, y: 100 });
-    });
+      expect(bounds).toEqual({ x: 1120, y: 100, width: 800, height: 600 })
+    })
 
-    it("shifts window up when it extends past bottom edge", () => {
+    it('shifts window up when it extends past bottom edge', () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 800, x: 100, y: 800 }),
-      );
+        JSON.stringify({ x: 100, y: 800, width: 800, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
+      const bounds = getSavedWindowBounds()
       // y should be clamped to 1080 - 600 = 480
-      expect(bounds).toEqual({ height: 600, width: 800, x: 100, y: 480 });
-    });
+      expect(bounds).toEqual({ x: 100, y: 480, width: 800, height: 600 })
+    })
 
-    it("shifts window right when x is before display left edge", () => {
+    it('shifts window right when x is before display left edge', () => {
       // Simulate a secondary display at negative x offset
       mockGetDisplayMatching.mockReturnValue({
-        workArea: { height: 1080, width: 1920, x: 0, y: 0 },
-      });
+        workArea: { x: 0, y: 0, width: 1920, height: 1080 },
+      })
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 800, x: -100, y: 100 }),
-      );
+        JSON.stringify({ x: -100, y: 100, width: 800, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
-      expect(bounds).toEqual({ height: 600, width: 800, x: 0, y: 100 });
-    });
+      const bounds = getSavedWindowBounds()
+      expect(bounds).toEqual({ x: 0, y: 100, width: 800, height: 600 })
+    })
 
-    it("shrinks width when window is wider than display", () => {
+    it('shrinks width when window is wider than display', () => {
       // Simulate a small laptop display
       mockGetDisplayMatching.mockReturnValue({
-        workArea: { height: 768, width: 1366, x: 0, y: 0 },
-      });
+        workArea: { x: 0, y: 0, width: 1366, height: 768 },
+      })
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 2560, x: 100, y: 100 }),
-      );
+        JSON.stringify({ x: 100, y: 100, width: 2560, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
-      expect(bounds).toEqual({ height: 600, width: 1366, x: 0, y: 100 });
-    });
+      const bounds = getSavedWindowBounds()
+      expect(bounds).toEqual({ x: 0, y: 100, width: 1366, height: 600 })
+    })
 
-    it("shrinks height when window is taller than display", () => {
+    it('shrinks height when window is taller than display', () => {
       mockGetDisplayMatching.mockReturnValue({
-        workArea: { height: 768, width: 1920, x: 0, y: 0 },
-      });
+        workArea: { x: 0, y: 0, width: 1920, height: 768 },
+      })
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 1200, isMaximized: false, width: 800, x: 100, y: 100 }),
-      );
+        JSON.stringify({ x: 100, y: 100, width: 800, height: 1200, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
-      expect(bounds).toEqual({ height: 768, width: 800, x: 100, y: 0 });
-    });
+      const bounds = getSavedWindowBounds()
+      expect(bounds).toEqual({ x: 100, y: 0, width: 800, height: 768 })
+    })
 
-    it("shrinks both dimensions and clamps position for oversized window", () => {
+    it('shrinks both dimensions and clamps position for oversized window', () => {
       // Saved from a 4K display, now on a 720p laptop
       mockGetDisplayMatching.mockReturnValue({
-        workArea: { height: 720, width: 1280, x: 0, y: 0 },
-      });
+        workArea: { x: 0, y: 0, width: 1280, height: 720 },
+      })
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 1440, isMaximized: false, width: 2560, x: 500, y: 300 }),
-      );
+        JSON.stringify({ x: 500, y: 300, width: 2560, height: 1440, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
-      expect(bounds).toEqual({ height: 720, width: 1280, x: 0, y: 0 });
-    });
+      const bounds = getSavedWindowBounds()
+      expect(bounds).toEqual({ x: 0, y: 0, width: 1280, height: 720 })
+    })
 
-    it("clamps to secondary display work area with offset", () => {
+    it('clamps to secondary display work area with offset', () => {
       // Secondary display positioned to the right at x=1920
       mockGetDisplayMatching.mockReturnValue({
-        workArea: { height: 900, width: 1440, x: 1920, y: 0 },
-      });
+        workArea: { x: 1920, y: 0, width: 1440, height: 900 },
+      })
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 600, isMaximized: false, width: 800, x: 3000, y: 500 }),
-      );
+        JSON.stringify({ x: 3000, y: 500, width: 800, height: 600, isMaximized: false })
+      )
 
-      const bounds = getSavedWindowBounds();
+      const bounds = getSavedWindowBounds()
       // x clamped to 1920 + 1440 - 800 = 2560; y clamped to 0 + 900 - 600 = 300
-      expect(bounds).toEqual({ height: 600, width: 800, x: 2560, y: 300 });
-    });
-  });
-});
+      expect(bounds).toEqual({ x: 2560, y: 300, width: 800, height: 600 })
+    })
+  })
+})
 
-describe("manageWindowState", () => {
-  it("restores saved position and size to the window", () => {
+describe('manageWindowState', () => {
+  it('restores saved position and size to the window', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 850, isMaximized: false, width: 1100, x: 200, y: 100 }),
-    );
+      JSON.stringify({ x: 200, y: 100, width: 1100, height: 850, isMaximized: false })
+    )
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    expect(mockSetBounds).toHaveBeenCalledWith({ height: 850, width: 1100, x: 200, y: 100 });
-    expect(mockCenter).not.toHaveBeenCalled();
-  });
+    expect(mockSetBounds).toHaveBeenCalledWith({ x: 200, y: 100, width: 1100, height: 850 })
+    expect(mockCenter).not.toHaveBeenCalled()
+  })
 
-  it("centers the window when no saved position exists", () => {
+  it('centers the window when no saved position exists', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 800, isMaximized: false, width: 1280, x: -1, y: -1 }),
-    );
+      JSON.stringify({ x: -1, y: -1, width: 1280, height: 800, isMaximized: false })
+    )
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    expect(mockSetBounds).not.toHaveBeenCalled();
-    expect(mockSetSize).toHaveBeenCalledWith(1280, 800);
-    expect(mockCenter).toHaveBeenCalled();
-  });
+    expect(mockSetBounds).not.toHaveBeenCalled()
+    expect(mockSetSize).toHaveBeenCalledWith(1280, 800)
+    expect(mockCenter).toHaveBeenCalled()
+  })
 
-  it("maximizes the window when saved state was maximized", () => {
+  it('maximizes the window when saved state was maximized', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 768, isMaximized: true, width: 1024, x: 100, y: 100 }),
-    );
+      JSON.stringify({ x: 100, y: 100, width: 1024, height: 768, isMaximized: true })
+    )
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    expect(mockMaximize).toHaveBeenCalled();
-  });
+    expect(mockMaximize).toHaveBeenCalled()
+  })
 
-  it("registers event listeners for resize, move, maximize, unmaximize, and close", () => {
+  it('registers event listeners for resize, move, maximize, unmaximize, and close', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
+      throw new Error('ENOENT')
+    })
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
-    expect(registeredEvents).toContain("resize");
-    expect(registeredEvents).toContain("move");
-    expect(registeredEvents).toContain("maximize");
-    expect(registeredEvents).toContain("unmaximize");
-    expect(registeredEvents).toContain("close");
-  });
+    const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
+    expect(registeredEvents).toContain('resize')
+    expect(registeredEvents).toContain('move')
+    expect(registeredEvents).toContain('maximize')
+    expect(registeredEvents).toContain('unmaximize')
+    expect(registeredEvents).toContain('close')
+  })
 
-  it("saves normal bounds on close when not maximized", () => {
+  it('saves normal bounds on close when not maximized', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
+      throw new Error('ENOENT')
+    })
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
     // Get the 'close' handler
-    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
-    expect(closeCall).toBeDefined();
+    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
+    expect(closeCall).toBeDefined()
 
-    const closeHandler = closeCall![1] as () => void;
-    closeHandler();
+    if (!closeCall) throw new Error('Expected close handler to be registered')
+    const closeHandler = closeCall[1] as () => void
+    closeHandler()
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"width": 1024'),
-      "utf8",
-    );
-  });
+      'utf-8'
+    )
+  })
 
-  it("saves maximized flag on close when maximized", () => {
+  it('saves maximized flag on close when maximized', () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ height: 768, isMaximized: false, width: 1024, x: 100, y: 200 }),
-    );
-    mockIsMaximized.mockReturnValue(true);
+      JSON.stringify({ x: 100, y: 200, width: 1024, height: 768, isMaximized: false })
+    )
+    mockIsMaximized.mockReturnValue(true)
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
-    const closeHandler = closeCall![1] as () => void;
-    closeHandler();
+    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
+    if (!closeCall) throw new Error('Expected close handler to be registered')
+    const closeHandler = closeCall[1] as () => void
+    closeHandler()
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"isMaximized": true'),
-      "utf8",
-    );
-  });
+      'utf-8'
+    )
+  })
 
-  it("does not save on close when window is destroyed", () => {
+  it('does not save on close when window is destroyed', () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    mockIsDestroyed.mockReturnValue(true);
+      throw new Error('ENOENT')
+    })
+    mockIsDestroyed.mockReturnValue(true)
 
-    const window = createMockWindow();
-    manageWindowState(window);
+    const window = createMockWindow()
+    manageWindowState(window)
 
-    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
-    const closeHandler = closeCall![1] as () => void;
-    closeHandler();
+    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
+    if (!closeCall) throw new Error('Expected close handler to be registered')
+    const closeHandler = closeCall[1] as () => void
+    closeHandler()
 
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-  });
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
 
-  describe("with trackFullScreen config", () => {
-    it("restores fullscreen state when saved", () => {
+  describe('with trackFullScreen config', () => {
+    it('restores fullscreen state when saved', () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          height: 720,
-          isFullScreen: true,
-          isMaximized: false,
-          width: 960,
-          x: 100,
-          y: 100,
-        }),
-      );
+        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false, isFullScreen: true })
+      )
 
-      const window = createMockWindow();
-      manageWindowState(window, GAME_WINDOW_CONFIG);
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
 
-      expect(mockSetFullScreen).toHaveBeenCalledWith(true);
-      expect(mockMaximize).not.toHaveBeenCalled();
-    });
+      expect(mockSetFullScreen).toHaveBeenCalledWith(true)
+      expect(mockMaximize).not.toHaveBeenCalled()
+    })
 
-    it("registers fullscreen events instead of maximize events", () => {
+    it('registers fullscreen events instead of maximize events', () => {
       mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
+        throw new Error('ENOENT')
+      })
 
-      const window = createMockWindow();
-      manageWindowState(window, GAME_WINDOW_CONFIG);
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
 
-      const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
-      expect(registeredEvents).toContain("resize");
-      expect(registeredEvents).toContain("move");
-      expect(registeredEvents).toContain("enter-full-screen");
-      expect(registeredEvents).toContain("leave-full-screen");
-      expect(registeredEvents).not.toContain("maximize");
-      expect(registeredEvents).not.toContain("unmaximize");
-    });
+      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
+      expect(registeredEvents).toContain('resize')
+      expect(registeredEvents).toContain('move')
+      expect(registeredEvents).toContain('enter-full-screen')
+      expect(registeredEvents).toContain('leave-full-screen')
+      expect(registeredEvents).not.toContain('maximize')
+      expect(registeredEvents).not.toContain('unmaximize')
+    })
 
-    it("defaults isFullScreen to false when missing from saved state", () => {
+    it('defaults isFullScreen to false when missing from saved state', () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ height: 720, isMaximized: false, width: 960, x: 100, y: 100 }),
-      );
+        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false })
+      )
 
-      const window = createMockWindow();
-      manageWindowState(window, GAME_WINDOW_CONFIG);
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
 
-      expect(mockSetFullScreen).not.toHaveBeenCalled();
-    });
-  });
+      expect(mockSetFullScreen).not.toHaveBeenCalled()
+    })
+  })
 
-  describe("with manualCloseSave config", () => {
-    it("does not attach a close handler", () => {
+  describe('with manualCloseSave config', () => {
+    it('does not attach a close handler', () => {
       mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
+        throw new Error('ENOENT')
+      })
 
-      const window = createMockWindow();
-      manageWindowState(window, GAME_WINDOW_CONFIG);
+      const window = createMockWindow()
+      manageWindowState(window, GAME_WINDOW_CONFIG)
 
-      const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
-      expect(registeredEvents).not.toContain("close");
-    });
-  });
-});
+      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
+      expect(registeredEvents).not.toContain('close')
+    })
+  })
+})
 
-describe("saveWindowStateNow", () => {
-  it("saves current bounds when not fullscreen or maximized", () => {
-    const window = createMockWindow();
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
+describe('saveWindowStateNow', () => {
+  it('saves current bounds when not fullscreen or maximized', () => {
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
       expect.stringContaining('"width": 1024'),
-      "utf8",
-    );
-    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(savedState.isFullScreen).toBe(false);
-    expect(savedState.isMaximized).toBe(false);
-  });
+      'utf-8'
+    )
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
+    expect(savedState.isFullScreen).toBe(false)
+    expect(savedState.isMaximized).toBe(false)
+  })
 
-  it("preserves pre-fullscreen bounds when fullscreen", () => {
-    mockIsFullScreen.mockReturnValue(true);
+  it('preserves pre-fullscreen bounds when fullscreen', () => {
+    mockIsFullScreen.mockReturnValue(true)
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({
-        height: 720,
-        isFullScreen: false,
-        isMaximized: false,
-        width: 960,
-        x: 300,
-        y: 400,
-      }),
-    );
+      JSON.stringify({ x: 300, y: 400, width: 960, height: 720, isMaximized: false, isFullScreen: false })
+    )
 
-    const window = createMockWindow();
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
 
-    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(savedState.isFullScreen).toBe(true);
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
+    expect(savedState.isFullScreen).toBe(true)
     // Should preserve the pre-fullscreen bounds, not the current fullscreen bounds
-    expect(savedState.width).toBe(960);
-    expect(savedState.height).toBe(720);
-  });
+    expect(savedState.width).toBe(960)
+    expect(savedState.height).toBe(720)
+  })
 
-  it("does nothing when window is destroyed", () => {
-    mockIsDestroyed.mockReturnValue(true);
+  it('does nothing when window is destroyed', () => {
+    mockIsDestroyed.mockReturnValue(true)
 
-    const window = createMockWindow();
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
+    const window = createMockWindow()
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
 
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-  });
-});
+    expect(mockWriteFileSync).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/utils/windowState.test.ts
+++ b/apps/desktop/src/main/utils/windowState.test.ts
@@ -1,34 +1,36 @@
 // @vitest-environment node
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const MOCK_USER_DATA = '/tmp/gamelord-window-test'
+const MOCK_USER_DATA = "/tmp/gamelord-window-test";
 
 // Hoisted mocks for use in vi.mock factories
 const { mockReadFileSync, mockWriteFileSync } = vi.hoisted(() => ({
   mockReadFileSync: vi.fn(),
   mockWriteFileSync: vi.fn(),
-}))
+}));
 
-const mockGetBounds = vi.fn().mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 })
-const mockSetBounds = vi.fn()
-const mockSetSize = vi.fn()
-const mockCenter = vi.fn()
-const mockMaximize = vi.fn()
-const mockSetFullScreen = vi.fn()
-const mockIsMaximized = vi.fn().mockReturnValue(false)
-const mockIsFullScreen = vi.fn().mockReturnValue(false)
-const mockIsDestroyed = vi.fn().mockReturnValue(false)
-const mockOn = vi.fn()
+const mockGetBounds = vi.fn().mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 });
+const mockSetBounds = vi.fn();
+const mockSetSize = vi.fn();
+const mockCenter = vi.fn();
+const mockMaximize = vi.fn();
+const mockSetFullScreen = vi.fn();
+const mockIsMaximized = vi.fn().mockReturnValue(false);
+const mockIsFullScreen = vi.fn().mockReturnValue(false);
+const mockIsDestroyed = vi.fn().mockReturnValue(false);
+const mockOn = vi.fn();
 
 const mockGetDisplayMatching = vi.fn().mockReturnValue({
   workArea: { x: 0, y: 0, width: 1920, height: 1080 },
-})
+});
 
-vi.mock('electron', () => ({
+vi.mock("electron", () => ({
   app: {
     getPath: (name: string) => {
-      if (name === 'userData') return MOCK_USER_DATA
-      return '/tmp'
+      if (name === "userData") {
+        return MOCK_USER_DATA;
+      }
+      return "/tmp";
     },
   },
   BrowserWindow: vi.fn(),
@@ -38,22 +40,27 @@ vi.mock('electron', () => ({
         workArea: { x: 0, y: 0, width: 1920, height: 1080 },
       },
     ],
-    getDisplayMatching: (...args: unknown[]) => mockGetDisplayMatching(...args),
+    getDisplayMatching: (...args: Array<unknown>) => mockGetDisplayMatching(...args),
   },
-}))
+}));
 
-vi.mock('node:fs', () => ({
+vi.mock("node:fs", () => ({
   default: {
     readFileSync: mockReadFileSync,
     writeFileSync: mockWriteFileSync,
   },
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
-}))
+}));
 
 // Import after mocks are set up
-import { getSavedWindowBounds, manageWindowState, saveWindowStateNow, type WindowStateConfig } from './windowState'
-import type { BrowserWindow } from 'electron'
+import {
+  getSavedWindowBounds,
+  manageWindowState,
+  saveWindowStateNow,
+  type WindowStateConfig,
+} from "./windowState";
+import type { BrowserWindow } from "electron";
 
 function createMockWindow(): BrowserWindow {
   return {
@@ -67,11 +74,11 @@ function createMockWindow(): BrowserWindow {
     isFullScreen: mockIsFullScreen,
     isDestroyed: mockIsDestroyed,
     on: mockOn,
-  } as unknown as BrowserWindow
+  } as unknown as BrowserWindow;
 }
 
 const GAME_WINDOW_CONFIG: WindowStateConfig = {
-  stateFile: 'game-window-state.json',
+  stateFile: "game-window-state.json",
   defaults: {
     x: -1,
     y: -1,
@@ -82,408 +89,435 @@ const GAME_WINDOW_CONFIG: WindowStateConfig = {
   },
   trackFullScreen: true,
   manualCloseSave: true,
-}
+};
 
 beforeEach(() => {
-  vi.clearAllMocks()
-  mockReadFileSync.mockReset()
-  mockWriteFileSync.mockReset()
-  mockIsMaximized.mockReturnValue(false)
-  mockIsFullScreen.mockReturnValue(false)
-  mockIsDestroyed.mockReturnValue(false)
-  mockGetBounds.mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 })
+  vi.clearAllMocks();
+  mockReadFileSync.mockReset();
+  mockWriteFileSync.mockReset();
+  mockIsMaximized.mockReturnValue(false);
+  mockIsFullScreen.mockReturnValue(false);
+  mockIsDestroyed.mockReturnValue(false);
+  mockGetBounds.mockReturnValue({ x: 100, y: 200, width: 1024, height: 768 });
   mockGetDisplayMatching.mockReturnValue({
     workArea: { x: 0, y: 0, width: 1920, height: 1080 },
-  })
-})
+  });
+});
 
-describe('getSavedWindowBounds', () => {
-  it('returns default dimensions when no saved state exists', () => {
+describe("getSavedWindowBounds", () => {
+  it("returns default dimensions when no saved state exists", () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
+      throw new Error("ENOENT");
+    });
 
-    const bounds = getSavedWindowBounds()
-    expect(bounds).toEqual({ width: 1280, height: 800 })
-    expect(bounds).not.toHaveProperty('x')
-    expect(bounds).not.toHaveProperty('y')
-  })
+    const bounds = getSavedWindowBounds();
+    expect(bounds).toEqual({ width: 1280, height: 800 });
+    expect(bounds).not.toHaveProperty("x");
+    expect(bounds).not.toHaveProperty("y");
+  });
 
-  it('returns saved position and dimensions from disk', () => {
+  it("returns saved position and dimensions from disk", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 50, y: 75, width: 1400, height: 900, isMaximized: false })
-    )
+      JSON.stringify({ x: 50, y: 75, width: 1400, height: 900, isMaximized: false }),
+    );
 
-    const bounds = getSavedWindowBounds()
-    expect(bounds).toEqual({ x: 50, y: 75, width: 1400, height: 900 })
-  })
+    const bounds = getSavedWindowBounds();
+    expect(bounds).toEqual({ x: 50, y: 75, width: 1400, height: 900 });
+  });
 
-  it('returns only width/height when saved position is default (-1)', () => {
+  it("returns only width/height when saved position is default (-1)", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: -1, y: -1, width: 1000, height: 700, isMaximized: false })
-    )
+      JSON.stringify({ x: -1, y: -1, width: 1000, height: 700, isMaximized: false }),
+    );
 
-    const bounds = getSavedWindowBounds()
-    expect(bounds).toEqual({ width: 1000, height: 700 })
-    expect(bounds).not.toHaveProperty('x')
-    expect(bounds).not.toHaveProperty('y')
-  })
+    const bounds = getSavedWindowBounds();
+    expect(bounds).toEqual({ width: 1000, height: 700 });
+    expect(bounds).not.toHaveProperty("x");
+    expect(bounds).not.toHaveProperty("y");
+  });
 
-  it('returns defaults when saved state has invalid JSON', () => {
-    mockReadFileSync.mockReturnValue('not json!!!')
+  it("returns defaults when saved state has invalid JSON", () => {
+    mockReadFileSync.mockReturnValue("not json!!!");
 
-    const bounds = getSavedWindowBounds()
-    expect(bounds).toEqual({ width: 1280, height: 800 })
-  })
+    const bounds = getSavedWindowBounds();
+    expect(bounds).toEqual({ width: 1280, height: 800 });
+  });
 
-  it('uses default values for missing fields in saved state', () => {
-    mockReadFileSync.mockReturnValue(JSON.stringify({ width: 900 }))
+  it("uses default values for missing fields in saved state", () => {
+    mockReadFileSync.mockReturnValue(JSON.stringify({ width: 900 }));
 
-    const bounds = getSavedWindowBounds()
+    const bounds = getSavedWindowBounds();
     // x and y default to -1, so no position returned
-    expect(bounds).toEqual({ width: 900, height: 800 })
-  })
+    expect(bounds).toEqual({ width: 900, height: 800 });
+  });
 
-  it('clamps position when saved window is off-screen', () => {
+  it("clamps position when saved window is off-screen", () => {
     // Position far off-screen — getDisplayMatching returns nearest display
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 5000, y: 5000, width: 1024, height: 768, isMaximized: false })
-    )
+      JSON.stringify({ x: 5000, y: 5000, width: 1024, height: 768, isMaximized: false }),
+    );
 
-    const bounds = getSavedWindowBounds()
+    const bounds = getSavedWindowBounds();
     // Position should be clamped to fit within the 1920x1080 display
-    expect(bounds).toEqual({ x: 896, y: 312, width: 1024, height: 768 })
-  })
+    expect(bounds).toEqual({ x: 896, y: 312, width: 1024, height: 768 });
+  });
 
-  it('uses custom config defaults and file path', () => {
+  it("uses custom config defaults and file path", () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
+      throw new Error("ENOENT");
+    });
 
-    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
-    expect(bounds).toEqual({ width: 960, height: 720 })
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG);
+    expect(bounds).toEqual({ width: 960, height: 720 });
 
     // Verify it reads from the custom state file
     expect(mockReadFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
-      'utf8'
-    )
-  })
+      "utf8",
+    );
+  });
 
-  it('reads saved state from custom config file', () => {
+  it("reads saved state from custom config file", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 300, y: 400, width: 800, height: 600, isMaximized: false, isFullScreen: true })
-    )
+      JSON.stringify({
+        x: 300,
+        y: 400,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        isFullScreen: true,
+      }),
+    );
 
-    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG)
-    expect(bounds).toEqual({ x: 300, y: 400, width: 800, height: 600 })
-  })
+    const bounds = getSavedWindowBounds(GAME_WINDOW_CONFIG);
+    expect(bounds).toEqual({ x: 300, y: 400, width: 800, height: 600 });
+  });
 
-  describe('display clamping', () => {
-    it('does not change position when window fits within display', () => {
+  describe("display clamping", () => {
+    it("does not change position when window fits within display", () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 100, width: 800, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: 100, y: 100, width: 800, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
-      expect(bounds).toEqual({ x: 100, y: 100, width: 800, height: 600 })
-    })
+      const bounds = getSavedWindowBounds();
+      expect(bounds).toEqual({ x: 100, y: 100, width: 800, height: 600 });
+    });
 
-    it('shifts window left when it extends past right edge', () => {
+    it("shifts window left when it extends past right edge", () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 1500, y: 100, width: 800, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: 1500, y: 100, width: 800, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
+      const bounds = getSavedWindowBounds();
       // x should be clamped to 1920 - 800 = 1120
-      expect(bounds).toEqual({ x: 1120, y: 100, width: 800, height: 600 })
-    })
+      expect(bounds).toEqual({ x: 1120, y: 100, width: 800, height: 600 });
+    });
 
-    it('shifts window up when it extends past bottom edge', () => {
+    it("shifts window up when it extends past bottom edge", () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 800, width: 800, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: 100, y: 800, width: 800, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
+      const bounds = getSavedWindowBounds();
       // y should be clamped to 1080 - 600 = 480
-      expect(bounds).toEqual({ x: 100, y: 480, width: 800, height: 600 })
-    })
+      expect(bounds).toEqual({ x: 100, y: 480, width: 800, height: 600 });
+    });
 
-    it('shifts window right when x is before display left edge', () => {
+    it("shifts window right when x is before display left edge", () => {
       // Simulate a secondary display at negative x offset
       mockGetDisplayMatching.mockReturnValue({
         workArea: { x: 0, y: 0, width: 1920, height: 1080 },
-      })
+      });
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: -100, y: 100, width: 800, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: -100, y: 100, width: 800, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
-      expect(bounds).toEqual({ x: 0, y: 100, width: 800, height: 600 })
-    })
+      const bounds = getSavedWindowBounds();
+      expect(bounds).toEqual({ x: 0, y: 100, width: 800, height: 600 });
+    });
 
-    it('shrinks width when window is wider than display', () => {
+    it("shrinks width when window is wider than display", () => {
       // Simulate a small laptop display
       mockGetDisplayMatching.mockReturnValue({
         workArea: { x: 0, y: 0, width: 1366, height: 768 },
-      })
+      });
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 100, width: 2560, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: 100, y: 100, width: 2560, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
-      expect(bounds).toEqual({ x: 0, y: 100, width: 1366, height: 600 })
-    })
+      const bounds = getSavedWindowBounds();
+      expect(bounds).toEqual({ x: 0, y: 100, width: 1366, height: 600 });
+    });
 
-    it('shrinks height when window is taller than display', () => {
+    it("shrinks height when window is taller than display", () => {
       mockGetDisplayMatching.mockReturnValue({
         workArea: { x: 0, y: 0, width: 1920, height: 768 },
-      })
+      });
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 100, width: 800, height: 1200, isMaximized: false })
-      )
+        JSON.stringify({ x: 100, y: 100, width: 800, height: 1200, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
-      expect(bounds).toEqual({ x: 100, y: 0, width: 800, height: 768 })
-    })
+      const bounds = getSavedWindowBounds();
+      expect(bounds).toEqual({ x: 100, y: 0, width: 800, height: 768 });
+    });
 
-    it('shrinks both dimensions and clamps position for oversized window', () => {
+    it("shrinks both dimensions and clamps position for oversized window", () => {
       // Saved from a 4K display, now on a 720p laptop
       mockGetDisplayMatching.mockReturnValue({
         workArea: { x: 0, y: 0, width: 1280, height: 720 },
-      })
+      });
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 500, y: 300, width: 2560, height: 1440, isMaximized: false })
-      )
+        JSON.stringify({ x: 500, y: 300, width: 2560, height: 1440, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
-      expect(bounds).toEqual({ x: 0, y: 0, width: 1280, height: 720 })
-    })
+      const bounds = getSavedWindowBounds();
+      expect(bounds).toEqual({ x: 0, y: 0, width: 1280, height: 720 });
+    });
 
-    it('clamps to secondary display work area with offset', () => {
+    it("clamps to secondary display work area with offset", () => {
       // Secondary display positioned to the right at x=1920
       mockGetDisplayMatching.mockReturnValue({
         workArea: { x: 1920, y: 0, width: 1440, height: 900 },
-      })
+      });
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 3000, y: 500, width: 800, height: 600, isMaximized: false })
-      )
+        JSON.stringify({ x: 3000, y: 500, width: 800, height: 600, isMaximized: false }),
+      );
 
-      const bounds = getSavedWindowBounds()
+      const bounds = getSavedWindowBounds();
       // x clamped to 1920 + 1440 - 800 = 2560; y clamped to 0 + 900 - 600 = 300
-      expect(bounds).toEqual({ x: 2560, y: 300, width: 800, height: 600 })
-    })
-  })
-})
+      expect(bounds).toEqual({ x: 2560, y: 300, width: 800, height: 600 });
+    });
+  });
+});
 
-describe('manageWindowState', () => {
-  it('restores saved position and size to the window', () => {
+describe("manageWindowState", () => {
+  it("restores saved position and size to the window", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 200, y: 100, width: 1100, height: 850, isMaximized: false })
-    )
+      JSON.stringify({ x: 200, y: 100, width: 1100, height: 850, isMaximized: false }),
+    );
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    expect(mockSetBounds).toHaveBeenCalledWith({ x: 200, y: 100, width: 1100, height: 850 })
-    expect(mockCenter).not.toHaveBeenCalled()
-  })
+    expect(mockSetBounds).toHaveBeenCalledWith({ x: 200, y: 100, width: 1100, height: 850 });
+    expect(mockCenter).not.toHaveBeenCalled();
+  });
 
-  it('centers the window when no saved position exists', () => {
+  it("centers the window when no saved position exists", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: -1, y: -1, width: 1280, height: 800, isMaximized: false })
-    )
+      JSON.stringify({ x: -1, y: -1, width: 1280, height: 800, isMaximized: false }),
+    );
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    expect(mockSetBounds).not.toHaveBeenCalled()
-    expect(mockSetSize).toHaveBeenCalledWith(1280, 800)
-    expect(mockCenter).toHaveBeenCalled()
-  })
+    expect(mockSetBounds).not.toHaveBeenCalled();
+    expect(mockSetSize).toHaveBeenCalledWith(1280, 800);
+    expect(mockCenter).toHaveBeenCalled();
+  });
 
-  it('maximizes the window when saved state was maximized', () => {
+  it("maximizes the window when saved state was maximized", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 100, y: 100, width: 1024, height: 768, isMaximized: true })
-    )
+      JSON.stringify({ x: 100, y: 100, width: 1024, height: 768, isMaximized: true }),
+    );
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    expect(mockMaximize).toHaveBeenCalled()
-  })
+    expect(mockMaximize).toHaveBeenCalled();
+  });
 
-  it('registers event listeners for resize, move, maximize, unmaximize, and close', () => {
+  it("registers event listeners for resize, move, maximize, unmaximize, and close", () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
+      throw new Error("ENOENT");
+    });
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
-    expect(registeredEvents).toContain('resize')
-    expect(registeredEvents).toContain('move')
-    expect(registeredEvents).toContain('maximize')
-    expect(registeredEvents).toContain('unmaximize')
-    expect(registeredEvents).toContain('close')
-  })
+    const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
+    expect(registeredEvents).toContain("resize");
+    expect(registeredEvents).toContain("move");
+    expect(registeredEvents).toContain("maximize");
+    expect(registeredEvents).toContain("unmaximize");
+    expect(registeredEvents).toContain("close");
+  });
 
-  it('saves normal bounds on close when not maximized', () => {
+  it("saves normal bounds on close when not maximized", () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
+      throw new Error("ENOENT");
+    });
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
     // Get the 'close' handler
-    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
-    expect(closeCall).toBeDefined()
+    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
+    expect(closeCall).toBeDefined();
 
-    if (!closeCall) throw new Error('Expected close handler to be registered')
-    const closeHandler = closeCall[1] as () => void
-    closeHandler()
+    if (!closeCall) {
+      throw new Error("Expected close handler to be registered");
+    }
+    const closeHandler = closeCall[1] as () => void;
+    closeHandler();
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"width": 1024'),
-      'utf8'
-    )
-  })
+      "utf8",
+    );
+  });
 
-  it('saves maximized flag on close when maximized', () => {
+  it("saves maximized flag on close when maximized", () => {
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 100, y: 200, width: 1024, height: 768, isMaximized: false })
-    )
-    mockIsMaximized.mockReturnValue(true)
+      JSON.stringify({ x: 100, y: 200, width: 1024, height: 768, isMaximized: false }),
+    );
+    mockIsMaximized.mockReturnValue(true);
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
-    if (!closeCall) throw new Error('Expected close handler to be registered')
-    const closeHandler = closeCall[1] as () => void
-    closeHandler()
+    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
+    if (!closeCall) {
+      throw new Error("Expected close handler to be registered");
+    }
+    const closeHandler = closeCall[1] as () => void;
+    closeHandler();
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/window-state.json`,
       expect.stringContaining('"isMaximized": true'),
-      'utf8'
-    )
-  })
+      "utf8",
+    );
+  });
 
-  it('does not save on close when window is destroyed', () => {
+  it("does not save on close when window is destroyed", () => {
     mockReadFileSync.mockImplementation(() => {
-      throw new Error('ENOENT')
-    })
-    mockIsDestroyed.mockReturnValue(true)
+      throw new Error("ENOENT");
+    });
+    mockIsDestroyed.mockReturnValue(true);
 
-    const window = createMockWindow()
-    manageWindowState(window)
+    const window = createMockWindow();
+    manageWindowState(window);
 
-    const closeCall = mockOn.mock.calls.find((call: unknown[]) => call[0] === 'close')
-    if (!closeCall) throw new Error('Expected close handler to be registered')
-    const closeHandler = closeCall[1] as () => void
-    closeHandler()
+    const closeCall = mockOn.mock.calls.find((call: Array<unknown>) => call[0] === "close");
+    if (!closeCall) {
+      throw new Error("Expected close handler to be registered");
+    }
+    const closeHandler = closeCall[1] as () => void;
+    closeHandler();
 
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
-  })
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
 
-  describe('with trackFullScreen config', () => {
-    it('restores fullscreen state when saved', () => {
+  describe("with trackFullScreen config", () => {
+    it("restores fullscreen state when saved", () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false, isFullScreen: true })
-      )
+        JSON.stringify({
+          x: 100,
+          y: 100,
+          width: 960,
+          height: 720,
+          isMaximized: false,
+          isFullScreen: true,
+        }),
+      );
 
-      const window = createMockWindow()
-      manageWindowState(window, GAME_WINDOW_CONFIG)
+      const window = createMockWindow();
+      manageWindowState(window, GAME_WINDOW_CONFIG);
 
-      expect(mockSetFullScreen).toHaveBeenCalledWith(true)
-      expect(mockMaximize).not.toHaveBeenCalled()
-    })
+      expect(mockSetFullScreen).toHaveBeenCalledWith(true);
+      expect(mockMaximize).not.toHaveBeenCalled();
+    });
 
-    it('registers fullscreen events instead of maximize events', () => {
+    it("registers fullscreen events instead of maximize events", () => {
       mockReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT')
-      })
+        throw new Error("ENOENT");
+      });
 
-      const window = createMockWindow()
-      manageWindowState(window, GAME_WINDOW_CONFIG)
+      const window = createMockWindow();
+      manageWindowState(window, GAME_WINDOW_CONFIG);
 
-      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
-      expect(registeredEvents).toContain('resize')
-      expect(registeredEvents).toContain('move')
-      expect(registeredEvents).toContain('enter-full-screen')
-      expect(registeredEvents).toContain('leave-full-screen')
-      expect(registeredEvents).not.toContain('maximize')
-      expect(registeredEvents).not.toContain('unmaximize')
-    })
+      const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
+      expect(registeredEvents).toContain("resize");
+      expect(registeredEvents).toContain("move");
+      expect(registeredEvents).toContain("enter-full-screen");
+      expect(registeredEvents).toContain("leave-full-screen");
+      expect(registeredEvents).not.toContain("maximize");
+      expect(registeredEvents).not.toContain("unmaximize");
+    });
 
-    it('defaults isFullScreen to false when missing from saved state', () => {
+    it("defaults isFullScreen to false when missing from saved state", () => {
       mockReadFileSync.mockReturnValue(
-        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false })
-      )
+        JSON.stringify({ x: 100, y: 100, width: 960, height: 720, isMaximized: false }),
+      );
 
-      const window = createMockWindow()
-      manageWindowState(window, GAME_WINDOW_CONFIG)
+      const window = createMockWindow();
+      manageWindowState(window, GAME_WINDOW_CONFIG);
 
-      expect(mockSetFullScreen).not.toHaveBeenCalled()
-    })
-  })
+      expect(mockSetFullScreen).not.toHaveBeenCalled();
+    });
+  });
 
-  describe('with manualCloseSave config', () => {
-    it('does not attach a close handler', () => {
+  describe("with manualCloseSave config", () => {
+    it("does not attach a close handler", () => {
       mockReadFileSync.mockImplementation(() => {
-        throw new Error('ENOENT')
-      })
+        throw new Error("ENOENT");
+      });
 
-      const window = createMockWindow()
-      manageWindowState(window, GAME_WINDOW_CONFIG)
+      const window = createMockWindow();
+      manageWindowState(window, GAME_WINDOW_CONFIG);
 
-      const registeredEvents = mockOn.mock.calls.map((call: unknown[]) => call[0])
-      expect(registeredEvents).not.toContain('close')
-    })
-  })
-})
+      const registeredEvents = mockOn.mock.calls.map((call: Array<unknown>) => call[0]);
+      expect(registeredEvents).not.toContain("close");
+    });
+  });
+});
 
-describe('saveWindowStateNow', () => {
-  it('saves current bounds when not fullscreen or maximized', () => {
-    const window = createMockWindow()
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
+describe("saveWindowStateNow", () => {
+  it("saves current bounds when not fullscreen or maximized", () => {
+    const window = createMockWindow();
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
 
     expect(mockWriteFileSync).toHaveBeenCalledWith(
       `${MOCK_USER_DATA}/game-window-state.json`,
       expect.stringContaining('"width": 1024'),
-      'utf8'
-    )
-    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
-    expect(savedState.isFullScreen).toBe(false)
-    expect(savedState.isMaximized).toBe(false)
-  })
+      "utf8",
+    );
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(savedState.isFullScreen).toBe(false);
+    expect(savedState.isMaximized).toBe(false);
+  });
 
-  it('preserves pre-fullscreen bounds when fullscreen', () => {
-    mockIsFullScreen.mockReturnValue(true)
+  it("preserves pre-fullscreen bounds when fullscreen", () => {
+    mockIsFullScreen.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(
-      JSON.stringify({ x: 300, y: 400, width: 960, height: 720, isMaximized: false, isFullScreen: false })
-    )
+      JSON.stringify({
+        x: 300,
+        y: 400,
+        width: 960,
+        height: 720,
+        isMaximized: false,
+        isFullScreen: false,
+      }),
+    );
 
-    const window = createMockWindow()
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
+    const window = createMockWindow();
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
 
-    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string)
-    expect(savedState.isFullScreen).toBe(true)
+    const savedState = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+    expect(savedState.isFullScreen).toBe(true);
     // Should preserve the pre-fullscreen bounds, not the current fullscreen bounds
-    expect(savedState.width).toBe(960)
-    expect(savedState.height).toBe(720)
-  })
+    expect(savedState.width).toBe(960);
+    expect(savedState.height).toBe(720);
+  });
 
-  it('does nothing when window is destroyed', () => {
-    mockIsDestroyed.mockReturnValue(true)
+  it("does nothing when window is destroyed", () => {
+    mockIsDestroyed.mockReturnValue(true);
 
-    const window = createMockWindow()
-    saveWindowStateNow(window, GAME_WINDOW_CONFIG)
+    const window = createMockWindow();
+    saveWindowStateNow(window, GAME_WINDOW_CONFIG);
 
-    expect(mockWriteFileSync).not.toHaveBeenCalled()
-  })
-})
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/utils/zipExtraction.test.ts
+++ b/apps/desktop/src/main/utils/zipExtraction.test.ts
@@ -1,156 +1,173 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
-import { listZipContents, findRomInZip, extractFileFromZip } from './zipExtraction'
-import fs from 'fs'
-import path from 'path'
-import os from 'os'
-import { execFileSync } from 'child_process'
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { listZipContents, findRomInZip, extractFileFromZip } from "./zipExtraction";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
 
-const TEST_DIR = path.join(os.tmpdir(), 'gamelord-zip-extraction-test')
-const ZIPS_DIR = path.join(TEST_DIR, 'zips')
-const ROMS_DIR = path.join(TEST_DIR, 'roms')
-const EXTRACT_DIR = path.join(TEST_DIR, 'extract')
+const TEST_DIR = path.join(os.tmpdir(), "gamelord-zip-extraction-test");
+const ZIPS_DIR = path.join(TEST_DIR, "zips");
+const ROMS_DIR = path.join(TEST_DIR, "roms");
+const EXTRACT_DIR = path.join(TEST_DIR, "extract");
 
 beforeAll(() => {
-  fs.mkdirSync(ZIPS_DIR, { recursive: true })
-  fs.mkdirSync(ROMS_DIR, { recursive: true })
-  fs.mkdirSync(EXTRACT_DIR, { recursive: true })
+  fs.mkdirSync(ZIPS_DIR, { recursive: true });
+  fs.mkdirSync(ROMS_DIR, { recursive: true });
+  fs.mkdirSync(EXTRACT_DIR, { recursive: true });
 
   // Create fake ROM files to zip
-  fs.writeFileSync(path.join(ROMS_DIR, 'game.gb'), 'fake gb rom data')
-  fs.writeFileSync(path.join(ROMS_DIR, 'game.nes'), 'fake nes rom data')
-  fs.writeFileSync(path.join(ROMS_DIR, 'readme.txt'), 'not a rom')
-  fs.writeFileSync(path.join(ROMS_DIR, 'game.GBC'), 'fake gbc rom uppercase')
+  fs.writeFileSync(path.join(ROMS_DIR, "game.gb"), "fake gb rom data");
+  fs.writeFileSync(path.join(ROMS_DIR, "game.nes"), "fake nes rom data");
+  fs.writeFileSync(path.join(ROMS_DIR, "readme.txt"), "not a rom");
+  fs.writeFileSync(path.join(ROMS_DIR, "game.GBC"), "fake gbc rom uppercase");
 
   // Create a subdirectory with a ROM (to test nested entries)
-  fs.mkdirSync(path.join(ROMS_DIR, 'subdir'), { recursive: true })
-  fs.writeFileSync(path.join(ROMS_DIR, 'subdir', 'nested.sfc'), 'fake snes rom')
+  fs.mkdirSync(path.join(ROMS_DIR, "subdir"), { recursive: true });
+  fs.writeFileSync(path.join(ROMS_DIR, "subdir", "nested.sfc"), "fake snes rom");
 
   // Create __MACOSX junk
-  fs.mkdirSync(path.join(ROMS_DIR, '__MACOSX'), { recursive: true })
-  fs.writeFileSync(path.join(ROMS_DIR, '__MACOSX', '._game.gb'), 'macos resource fork')
+  fs.mkdirSync(path.join(ROMS_DIR, "__MACOSX"), { recursive: true });
+  fs.writeFileSync(path.join(ROMS_DIR, "__MACOSX", "._game.gb"), "macos resource fork");
 
   // zip containing a single .gb ROM
-  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'single-gb.zip'), path.join(ROMS_DIR, 'game.gb')])
+  execFileSync("zip", ["-j", path.join(ZIPS_DIR, "single-gb.zip"), path.join(ROMS_DIR, "game.gb")]);
 
   // zip containing a .nes ROM and a .txt (non-ROM)
-  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'nes-with-txt.zip'),
-    path.join(ROMS_DIR, 'game.nes'), path.join(ROMS_DIR, 'readme.txt')])
+  execFileSync("zip", [
+    "-j",
+    path.join(ZIPS_DIR, "nes-with-txt.zip"),
+    path.join(ROMS_DIR, "game.nes"),
+    path.join(ROMS_DIR, "readme.txt"),
+  ]);
 
   // zip containing only a .txt (no ROM)
-  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'no-rom.zip'), path.join(ROMS_DIR, 'readme.txt')])
+  execFileSync("zip", ["-j", path.join(ZIPS_DIR, "no-rom.zip"), path.join(ROMS_DIR, "readme.txt")]);
 
   // zip with uppercase extension ROM
-  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'uppercase-ext.zip'), path.join(ROMS_DIR, 'game.GBC')])
+  execFileSync("zip", [
+    "-j",
+    path.join(ZIPS_DIR, "uppercase-ext.zip"),
+    path.join(ROMS_DIR, "game.GBC"),
+  ]);
 
   // zip with __MACOSX junk and a real ROM
-  execFileSync('zip', ['-r', path.join(ZIPS_DIR, 'macosx-junk.zip'), 'game.gb', '__MACOSX'], { cwd: ROMS_DIR })
+  execFileSync("zip", ["-r", path.join(ZIPS_DIR, "macosx-junk.zip"), "game.gb", "__MACOSX"], {
+    cwd: ROMS_DIR,
+  });
 
   // zip with nested directory structure
-  execFileSync('zip', ['-r', path.join(ZIPS_DIR, 'nested.zip'), 'subdir/nested.sfc'], { cwd: ROMS_DIR })
-})
+  execFileSync("zip", ["-r", path.join(ZIPS_DIR, "nested.zip"), "subdir/nested.sfc"], {
+    cwd: ROMS_DIR,
+  });
+});
 
 afterAll(() => {
-  fs.rmSync(TEST_DIR, { recursive: true, force: true })
-})
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
 
-describe('listZipContents', () => {
-  it('lists all files in a valid zip', async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, 'nes-with-txt.zip'))
-    expect(contents).toContain('game.nes')
-    expect(contents).toContain('readme.txt')
-    expect(contents).toHaveLength(2)
-  })
+describe("listZipContents", () => {
+  it("lists all files in a valid zip", async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, "nes-with-txt.zip"));
+    expect(contents).toContain("game.nes");
+    expect(contents).toContain("readme.txt");
+    expect(contents).toHaveLength(2);
+  });
 
-  it('filters out __MACOSX/ resource fork entries', async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, 'macosx-junk.zip'))
-    expect(contents).toContain('game.gb')
-    expect(contents.some(e => e.includes('__MACOSX'))).toBe(false)
-  })
+  it("filters out __MACOSX/ resource fork entries", async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, "macosx-junk.zip"));
+    expect(contents).toContain("game.gb");
+    expect(contents.some((e) => e.includes("__MACOSX"))).toBe(false);
+  });
 
-  it('includes files from nested directories', async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, 'nested.zip'))
-    expect(contents).toContain('subdir/nested.sfc')
-  })
+  it("includes files from nested directories", async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, "nested.zip"));
+    expect(contents).toContain("subdir/nested.sfc");
+  });
 
-  it('throws for non-existent zip path', async () => {
-    await expect(listZipContents('/nonexistent/file.zip')).rejects.toThrow()
-  })
-})
+  it("throws for non-existent zip path", async () => {
+    await expect(listZipContents("/nonexistent/file.zip")).rejects.toThrow();
+  });
+});
 
 /** Assert a value is non-null and return it with narrowed type. */
-function assertDefined<T>(value: T | null | undefined, message = 'Expected value to be defined'): T {
-  if (value === null || value === undefined) throw new Error(message);
+function assertDefined<T>(
+  value: T | null | undefined,
+  message = "Expected value to be defined",
+): T {
+  if (value === null || value === undefined) {
+    throw new Error(message);
+  }
   return value;
 }
 
-describe('findRomInZip', () => {
-  it('finds .gb file when matching extensions are provided', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'single-gb.zip'), ['.gb', '.gbc'])
-    expect(result).not.toBeNull()
-    expect(assertDefined(result).entryName).toBe('game.gb')
-    expect(assertDefined(result).extension).toBe('.gb')
-  })
+describe("findRomInZip", () => {
+  it("finds .gb file when matching extensions are provided", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "single-gb.zip"), [".gb", ".gbc"]);
+    expect(result).not.toBeNull();
+    expect(assertDefined(result).entryName).toBe("game.gb");
+    expect(assertDefined(result).extension).toBe(".gb");
+  });
 
-  it('finds .nes file and ignores non-matching .txt', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'nes-with-txt.zip'), ['.nes'])
-    expect(result).not.toBeNull()
-    expect(assertDefined(result).entryName).toBe('game.nes')
-    expect(assertDefined(result).extension).toBe('.nes')
-  })
+  it("finds .nes file and ignores non-matching .txt", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "nes-with-txt.zip"), [".nes"]);
+    expect(result).not.toBeNull();
+    expect(assertDefined(result).entryName).toBe("game.nes");
+    expect(assertDefined(result).extension).toBe(".nes");
+  });
 
-  it('returns null when no matching extension exists', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'no-rom.zip'), ['.gb', '.nes'])
-    expect(result).toBeNull()
-  })
+  it("returns null when no matching extension exists", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "no-rom.zip"), [".gb", ".nes"]);
+    expect(result).toBeNull();
+  });
 
-  it('ignores __MACOSX/ resource fork entries', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'macosx-junk.zip'), ['.gb'])
-    expect(result).not.toBeNull()
-    expect(assertDefined(result).entryName).toBe('game.gb')
-  })
+  it("ignores __MACOSX/ resource fork entries", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "macosx-junk.zip"), [".gb"]);
+    expect(result).not.toBeNull();
+    expect(assertDefined(result).entryName).toBe("game.gb");
+  });
 
-  it('matches extensions case-insensitively', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'uppercase-ext.zip'), ['.gbc'])
-    expect(result).not.toBeNull()
-    expect(assertDefined(result).entryName).toBe('game.GBC')
-    expect(assertDefined(result).extension).toBe('.gbc')
-  })
+  it("matches extensions case-insensitively", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "uppercase-ext.zip"), [".gbc"]);
+    expect(result).not.toBeNull();
+    expect(assertDefined(result).entryName).toBe("game.GBC");
+    expect(assertDefined(result).extension).toBe(".gbc");
+  });
 
-  it('finds ROM in nested directory inside zip', async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, 'nested.zip'), ['.sfc'])
-    expect(result).not.toBeNull()
-    expect(assertDefined(result).entryName).toBe('subdir/nested.sfc')
-    expect(assertDefined(result).extension).toBe('.sfc')
-  })
-})
+  it("finds ROM in nested directory inside zip", async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, "nested.zip"), [".sfc"]);
+    expect(result).not.toBeNull();
+    expect(assertDefined(result).entryName).toBe("subdir/nested.sfc");
+    expect(assertDefined(result).extension).toBe(".sfc");
+  });
+});
 
-describe('extractFileFromZip', () => {
-  it('extracts a specific file to the destination directory', async () => {
+describe("extractFileFromZip", () => {
+  it("extracts a specific file to the destination directory", async () => {
     const extractedPath = await extractFileFromZip(
-      path.join(ZIPS_DIR, 'single-gb.zip'),
-      'game.gb',
+      path.join(ZIPS_DIR, "single-gb.zip"),
+      "game.gb",
       EXTRACT_DIR,
-    )
-    expect(extractedPath).toBe(path.join(EXTRACT_DIR, 'game.gb'))
-    expect(fs.existsSync(extractedPath)).toBe(true)
-    expect(fs.readFileSync(extractedPath, 'utf-8')).toBe('fake gb rom data')
-  })
+    );
+    expect(extractedPath).toBe(path.join(EXTRACT_DIR, "game.gb"));
+    expect(fs.existsSync(extractedPath)).toBe(true);
+    expect(fs.readFileSync(extractedPath, "utf8")).toBe("fake gb rom data");
+  });
 
-  it('extracts flat, stripping internal directory paths', async () => {
+  it("extracts flat, stripping internal directory paths", async () => {
     const extractedPath = await extractFileFromZip(
-      path.join(ZIPS_DIR, 'nested.zip'),
-      'subdir/nested.sfc',
+      path.join(ZIPS_DIR, "nested.zip"),
+      "subdir/nested.sfc",
       EXTRACT_DIR,
-    )
+    );
     // Should be flat in EXTRACT_DIR, not in EXTRACT_DIR/subdir/
-    expect(extractedPath).toBe(path.join(EXTRACT_DIR, 'nested.sfc'))
-    expect(fs.existsSync(extractedPath)).toBe(true)
-    expect(fs.readFileSync(extractedPath, 'utf-8')).toBe('fake snes rom')
-  })
+    expect(extractedPath).toBe(path.join(EXTRACT_DIR, "nested.sfc"));
+    expect(fs.existsSync(extractedPath)).toBe(true);
+    expect(fs.readFileSync(extractedPath, "utf8")).toBe("fake snes rom");
+  });
 
-  it('throws when entry does not exist in the zip', async () => {
+  it("throws when entry does not exist in the zip", async () => {
     await expect(
-      extractFileFromZip(path.join(ZIPS_DIR, 'single-gb.zip'), 'nonexistent.nes', EXTRACT_DIR),
-    ).rejects.toThrow()
-  })
-})
+      extractFileFromZip(path.join(ZIPS_DIR, "single-gb.zip"), "nonexistent.nes", EXTRACT_DIR),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/desktop/src/main/utils/zipExtraction.test.ts
+++ b/apps/desktop/src/main/utils/zipExtraction.test.ts
@@ -1,162 +1,156 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { listZipContents, findRomInZip, extractFileFromZip } from "./zipExtraction";
-import fs from "node:fs";
-import path from "node:path";
-import os from "node:os";
-import { execFileSync } from "node:child_process";
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { listZipContents, findRomInZip, extractFileFromZip } from './zipExtraction'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+import { execFileSync } from 'child_process'
 
-const TEST_DIR = path.join(os.tmpdir(), "gamelord-zip-extraction-test");
-const ZIPS_DIR = path.join(TEST_DIR, "zips");
-const ROMS_DIR = path.join(TEST_DIR, "roms");
-const EXTRACT_DIR = path.join(TEST_DIR, "extract");
+const TEST_DIR = path.join(os.tmpdir(), 'gamelord-zip-extraction-test')
+const ZIPS_DIR = path.join(TEST_DIR, 'zips')
+const ROMS_DIR = path.join(TEST_DIR, 'roms')
+const EXTRACT_DIR = path.join(TEST_DIR, 'extract')
 
 beforeAll(() => {
-  fs.mkdirSync(ZIPS_DIR, { recursive: true });
-  fs.mkdirSync(ROMS_DIR, { recursive: true });
-  fs.mkdirSync(EXTRACT_DIR, { recursive: true });
+  fs.mkdirSync(ZIPS_DIR, { recursive: true })
+  fs.mkdirSync(ROMS_DIR, { recursive: true })
+  fs.mkdirSync(EXTRACT_DIR, { recursive: true })
 
   // Create fake ROM files to zip
-  fs.writeFileSync(path.join(ROMS_DIR, "game.gb"), "fake gb rom data");
-  fs.writeFileSync(path.join(ROMS_DIR, "game.nes"), "fake nes rom data");
-  fs.writeFileSync(path.join(ROMS_DIR, "readme.txt"), "not a rom");
-  fs.writeFileSync(path.join(ROMS_DIR, "game.GBC"), "fake gbc rom uppercase");
+  fs.writeFileSync(path.join(ROMS_DIR, 'game.gb'), 'fake gb rom data')
+  fs.writeFileSync(path.join(ROMS_DIR, 'game.nes'), 'fake nes rom data')
+  fs.writeFileSync(path.join(ROMS_DIR, 'readme.txt'), 'not a rom')
+  fs.writeFileSync(path.join(ROMS_DIR, 'game.GBC'), 'fake gbc rom uppercase')
 
   // Create a subdirectory with a ROM (to test nested entries)
-  fs.mkdirSync(path.join(ROMS_DIR, "subdir"), { recursive: true });
-  fs.writeFileSync(path.join(ROMS_DIR, "subdir", "nested.sfc"), "fake snes rom");
+  fs.mkdirSync(path.join(ROMS_DIR, 'subdir'), { recursive: true })
+  fs.writeFileSync(path.join(ROMS_DIR, 'subdir', 'nested.sfc'), 'fake snes rom')
 
   // Create __MACOSX junk
-  fs.mkdirSync(path.join(ROMS_DIR, "__MACOSX"), { recursive: true });
-  fs.writeFileSync(path.join(ROMS_DIR, "__MACOSX", "._game.gb"), "macos resource fork");
+  fs.mkdirSync(path.join(ROMS_DIR, '__MACOSX'), { recursive: true })
+  fs.writeFileSync(path.join(ROMS_DIR, '__MACOSX', '._game.gb'), 'macos resource fork')
 
   // zip containing a single .gb ROM
-  execFileSync("zip", ["-j", path.join(ZIPS_DIR, "single-gb.zip"), path.join(ROMS_DIR, "game.gb")]);
+  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'single-gb.zip'), path.join(ROMS_DIR, 'game.gb')])
 
   // zip containing a .nes ROM and a .txt (non-ROM)
-  execFileSync("zip", [
-    "-j",
-    path.join(ZIPS_DIR, "nes-with-txt.zip"),
-    path.join(ROMS_DIR, "game.nes"),
-    path.join(ROMS_DIR, "readme.txt"),
-  ]);
+  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'nes-with-txt.zip'),
+    path.join(ROMS_DIR, 'game.nes'), path.join(ROMS_DIR, 'readme.txt')])
 
   // zip containing only a .txt (no ROM)
-  execFileSync("zip", ["-j", path.join(ZIPS_DIR, "no-rom.zip"), path.join(ROMS_DIR, "readme.txt")]);
+  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'no-rom.zip'), path.join(ROMS_DIR, 'readme.txt')])
 
   // zip with uppercase extension ROM
-  execFileSync("zip", [
-    "-j",
-    path.join(ZIPS_DIR, "uppercase-ext.zip"),
-    path.join(ROMS_DIR, "game.GBC"),
-  ]);
+  execFileSync('zip', ['-j', path.join(ZIPS_DIR, 'uppercase-ext.zip'), path.join(ROMS_DIR, 'game.GBC')])
 
   // zip with __MACOSX junk and a real ROM
-  execFileSync("zip", ["-r", path.join(ZIPS_DIR, "macosx-junk.zip"), "game.gb", "__MACOSX"], {
-    cwd: ROMS_DIR,
-  });
+  execFileSync('zip', ['-r', path.join(ZIPS_DIR, 'macosx-junk.zip'), 'game.gb', '__MACOSX'], { cwd: ROMS_DIR })
 
   // zip with nested directory structure
-  execFileSync("zip", ["-r", path.join(ZIPS_DIR, "nested.zip"), "subdir/nested.sfc"], {
-    cwd: ROMS_DIR,
-  });
-});
+  execFileSync('zip', ['-r', path.join(ZIPS_DIR, 'nested.zip'), 'subdir/nested.sfc'], { cwd: ROMS_DIR })
+})
 
 afterAll(() => {
-  fs.rmSync(TEST_DIR, { force: true, recursive: true });
-});
+  fs.rmSync(TEST_DIR, { recursive: true, force: true })
+})
 
-describe("listZipContents", () => {
-  it("lists all files in a valid zip", async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, "nes-with-txt.zip"));
-    expect(contents).toContain("game.nes");
-    expect(contents).toContain("readme.txt");
-    expect(contents).toHaveLength(2);
-  });
+describe('listZipContents', () => {
+  it('lists all files in a valid zip', async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, 'nes-with-txt.zip'))
+    expect(contents).toContain('game.nes')
+    expect(contents).toContain('readme.txt')
+    expect(contents).toHaveLength(2)
+  })
 
-  it("filters out __MACOSX/ resource fork entries", async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, "macosx-junk.zip"));
-    expect(contents).toContain("game.gb");
-    expect(contents.some((e) => e.includes("__MACOSX"))).toBe(false);
-  });
+  it('filters out __MACOSX/ resource fork entries', async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, 'macosx-junk.zip'))
+    expect(contents).toContain('game.gb')
+    expect(contents.some(e => e.includes('__MACOSX'))).toBe(false)
+  })
 
-  it("includes files from nested directories", async () => {
-    const contents = await listZipContents(path.join(ZIPS_DIR, "nested.zip"));
-    expect(contents).toContain("subdir/nested.sfc");
-  });
+  it('includes files from nested directories', async () => {
+    const contents = await listZipContents(path.join(ZIPS_DIR, 'nested.zip'))
+    expect(contents).toContain('subdir/nested.sfc')
+  })
 
-  it("throws for non-existent zip path", async () => {
-    await expect(listZipContents("/nonexistent/file.zip")).rejects.toThrow();
-  });
-});
+  it('throws for non-existent zip path', async () => {
+    await expect(listZipContents('/nonexistent/file.zip')).rejects.toThrow()
+  })
+})
 
-describe("findRomInZip", () => {
-  it("finds .gb file when matching extensions are provided", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "single-gb.zip"), [".gb", ".gbc"]);
-    expect(result).not.toBeNull();
-    expect(result!.entryName).toBe("game.gb");
-    expect(result!.extension).toBe(".gb");
-  });
+/** Assert a value is non-null and return it with narrowed type. */
+function assertDefined<T>(value: T | null | undefined, message = 'Expected value to be defined'): T {
+  if (value === null || value === undefined) throw new Error(message);
+  return value;
+}
 
-  it("finds .nes file and ignores non-matching .txt", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "nes-with-txt.zip"), [".nes"]);
-    expect(result).not.toBeNull();
-    expect(result!.entryName).toBe("game.nes");
-    expect(result!.extension).toBe(".nes");
-  });
+describe('findRomInZip', () => {
+  it('finds .gb file when matching extensions are provided', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'single-gb.zip'), ['.gb', '.gbc'])
+    expect(result).not.toBeNull()
+    expect(assertDefined(result).entryName).toBe('game.gb')
+    expect(assertDefined(result).extension).toBe('.gb')
+  })
 
-  it("returns null when no matching extension exists", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "no-rom.zip"), [".gb", ".nes"]);
-    expect(result).toBeNull();
-  });
+  it('finds .nes file and ignores non-matching .txt', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'nes-with-txt.zip'), ['.nes'])
+    expect(result).not.toBeNull()
+    expect(assertDefined(result).entryName).toBe('game.nes')
+    expect(assertDefined(result).extension).toBe('.nes')
+  })
 
-  it("ignores __MACOSX/ resource fork entries", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "macosx-junk.zip"), [".gb"]);
-    expect(result).not.toBeNull();
-    expect(result!.entryName).toBe("game.gb");
-  });
+  it('returns null when no matching extension exists', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'no-rom.zip'), ['.gb', '.nes'])
+    expect(result).toBeNull()
+  })
 
-  it("matches extensions case-insensitively", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "uppercase-ext.zip"), [".gbc"]);
-    expect(result).not.toBeNull();
-    expect(result!.entryName).toBe("game.GBC");
-    expect(result!.extension).toBe(".gbc");
-  });
+  it('ignores __MACOSX/ resource fork entries', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'macosx-junk.zip'), ['.gb'])
+    expect(result).not.toBeNull()
+    expect(assertDefined(result).entryName).toBe('game.gb')
+  })
 
-  it("finds ROM in nested directory inside zip", async () => {
-    const result = await findRomInZip(path.join(ZIPS_DIR, "nested.zip"), [".sfc"]);
-    expect(result).not.toBeNull();
-    expect(result!.entryName).toBe("subdir/nested.sfc");
-    expect(result!.extension).toBe(".sfc");
-  });
-});
+  it('matches extensions case-insensitively', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'uppercase-ext.zip'), ['.gbc'])
+    expect(result).not.toBeNull()
+    expect(assertDefined(result).entryName).toBe('game.GBC')
+    expect(assertDefined(result).extension).toBe('.gbc')
+  })
 
-describe("extractFileFromZip", () => {
-  it("extracts a specific file to the destination directory", async () => {
+  it('finds ROM in nested directory inside zip', async () => {
+    const result = await findRomInZip(path.join(ZIPS_DIR, 'nested.zip'), ['.sfc'])
+    expect(result).not.toBeNull()
+    expect(assertDefined(result).entryName).toBe('subdir/nested.sfc')
+    expect(assertDefined(result).extension).toBe('.sfc')
+  })
+})
+
+describe('extractFileFromZip', () => {
+  it('extracts a specific file to the destination directory', async () => {
     const extractedPath = await extractFileFromZip(
-      path.join(ZIPS_DIR, "single-gb.zip"),
-      "game.gb",
+      path.join(ZIPS_DIR, 'single-gb.zip'),
+      'game.gb',
       EXTRACT_DIR,
-    );
-    expect(extractedPath).toBe(path.join(EXTRACT_DIR, "game.gb"));
-    expect(fs.existsSync(extractedPath)).toBe(true);
-    expect(fs.readFileSync(extractedPath, "utf8")).toBe("fake gb rom data");
-  });
+    )
+    expect(extractedPath).toBe(path.join(EXTRACT_DIR, 'game.gb'))
+    expect(fs.existsSync(extractedPath)).toBe(true)
+    expect(fs.readFileSync(extractedPath, 'utf-8')).toBe('fake gb rom data')
+  })
 
-  it("extracts flat, stripping internal directory paths", async () => {
+  it('extracts flat, stripping internal directory paths', async () => {
     const extractedPath = await extractFileFromZip(
-      path.join(ZIPS_DIR, "nested.zip"),
-      "subdir/nested.sfc",
+      path.join(ZIPS_DIR, 'nested.zip'),
+      'subdir/nested.sfc',
       EXTRACT_DIR,
-    );
+    )
     // Should be flat in EXTRACT_DIR, not in EXTRACT_DIR/subdir/
-    expect(extractedPath).toBe(path.join(EXTRACT_DIR, "nested.sfc"));
-    expect(fs.existsSync(extractedPath)).toBe(true);
-    expect(fs.readFileSync(extractedPath, "utf8")).toBe("fake snes rom");
-  });
+    expect(extractedPath).toBe(path.join(EXTRACT_DIR, 'nested.sfc'))
+    expect(fs.existsSync(extractedPath)).toBe(true)
+    expect(fs.readFileSync(extractedPath, 'utf-8')).toBe('fake snes rom')
+  })
 
-  it("throws when entry does not exist in the zip", async () => {
+  it('throws when entry does not exist in the zip', async () => {
     await expect(
-      extractFileFromZip(path.join(ZIPS_DIR, "single-gb.zip"), "nonexistent.nes", EXTRACT_DIR),
-    ).rejects.toThrow();
-  });
-});
+      extractFileFromZip(path.join(ZIPS_DIR, 'single-gb.zip'), 'nonexistent.nes', EXTRACT_DIR),
+    ).rejects.toThrow()
+  })
+})

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -247,7 +247,9 @@ function initialize(command: Extract<WorkerCommand, { action: "init" }>): void {
 
 /** Write a video frame into the inactive double-buffer and swap the active flag. */
 function writeVideoToSAB(frame: { data: Uint8Array; width: number; height: number }): void {
-  if (!controlView || !videoView) return;
+  if (!controlView || !videoView) {
+    return;
+  }
   const ctrl = controlView;
   const video = videoView;
 
@@ -272,7 +274,9 @@ function writeVideoToSAB(frame: { data: Uint8Array; width: number; height: numbe
 
 /** Write audio samples into the SPSC ring buffer. */
 function writeAudioToSAB(samples: Int16Array): void {
-  if (!controlView || !audioView) return;
+  if (!controlView || !audioView) {
+    return;
+  }
   const ctrl = controlView;
   const ring = audioView;
   const ringLen = ring.length;

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -247,8 +247,9 @@ function initialize(command: Extract<WorkerCommand, { action: "init" }>): void {
 
 /** Write a video frame into the inactive double-buffer and swap the active flag. */
 function writeVideoToSAB(frame: { data: Uint8Array; width: number; height: number }): void {
-  const ctrl = controlView!;
-  const video = videoView!;
+  if (!controlView || !videoView) return;
+  const ctrl = controlView;
+  const video = videoView;
 
   // Write to the opposite buffer from the one the renderer is reading
   const currentActive = Atomics.load(ctrl, CTRL_ACTIVE_BUFFER);
@@ -271,8 +272,9 @@ function writeVideoToSAB(frame: { data: Uint8Array; width: number; height: numbe
 
 /** Write audio samples into the SPSC ring buffer. */
 function writeAudioToSAB(samples: Int16Array): void {
-  const ctrl = controlView!;
-  const ring = audioView!;
+  if (!controlView || !audioView) return;
+  const ctrl = controlView;
+  const ring = audioView;
   const ringLen = ring.length;
 
   let writePos = Atomics.load(ctrl, CTRL_AUDIO_WRITE_POS);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -66,7 +66,7 @@ contextBridge.exposeInMainWorld("gamelord", {
     ipcRenderer.send("game:input", port, id, pressed),
 
   // Event listeners
-  on: (channel: string, callback: (...args: Array<any>) => void) => {
+  on: (channel: string, callback: (...args: Array<unknown>) => void) => {
     const validChannels = [
       "emulator:launched",
       "emulator:exited",
@@ -128,7 +128,7 @@ contextBridge.exposeInMainWorld("gamelord", {
   // Library management
   library: {
     getSystems: () => ipcRenderer.invoke("library:getSystems"),
-    addSystem: (system: any) => ipcRenderer.invoke("library:addSystem", system),
+    addSystem: (system: unknown) => ipcRenderer.invoke("library:addSystem", system),
     removeSystem: (systemId: string) => ipcRenderer.invoke("library:removeSystem", systemId),
     updateSystemPath: (systemId: string, romsPath: string) =>
       ipcRenderer.invoke("library:updateSystemPath", systemId, romsPath),
@@ -137,7 +137,7 @@ contextBridge.exposeInMainWorld("gamelord", {
     addGame: (romPath: string, systemId: string) =>
       ipcRenderer.invoke("library:addGame", romPath, systemId),
     removeGame: (gameId: string) => ipcRenderer.invoke("library:removeGame", gameId),
-    updateGame: (gameId: string, updates: any) =>
+    updateGame: (gameId: string, updates: unknown) =>
       ipcRenderer.invoke("library:updateGame", gameId, updates),
 
     scanDirectory: (directoryPath: string, systemId?: string) =>

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -113,7 +113,8 @@ function App() {
 
   // Listen for resume game dialog requests from main process
   useEffect(() => {
-    const handleShowResumeDialog = (data: { requestId: string; gameTitle: string }) => {
+    const handleShowResumeDialog = (raw: unknown) => {
+      const data = raw as { requestId: string; gameTitle: string };
       playSfxRef.current("dialogOpen");
       setResumeDialog({
         open: true,
@@ -157,8 +158,8 @@ function App() {
       return;
     }
 
-    const handleSystemThemeChange = (isDark: boolean) => {
-      applyDarkClass(isDark);
+    const handleSystemThemeChange = (raw: unknown) => {
+      applyDarkClass(raw as boolean);
     };
 
     api.on("theme:systemChanged", handleSystemThemeChange);

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -17,7 +17,8 @@ import {
   ChevronDown,
 } from "lucide-react";
 import type { Game } from "../../types/library";
-import type { GamelordAPI } from "../types/global";
+import type { GamelordAPI, VideoFrame } from "../types/global";
+import type { AVInfo } from "../../main/workers/core-worker-protocol";
 import {
   CTRL_ACTIVE_BUFFER,
   CTRL_FRAME_SEQUENCE,
@@ -114,7 +115,7 @@ export const GameWindow: React.FC = () => {
   const audioContextRef = useRef<AudioContext | null>(null);
   const audioNextTimeRef = useRef(0);
   const gainNodeRef = useRef<GainNode | null>(null);
-  const pendingFrameRef = useRef<any>(null);
+  const pendingFrameRef = useRef<VideoFrame | null>(null);
   /** Gate: don't render frames until the boot animation overlay is in place. */
   const bootReadyRef = useRef(false);
   const rafIdRef = useRef<number>(0);
@@ -225,7 +226,9 @@ export const GameWindow: React.FC = () => {
 
     const source = ctx.createBufferSource();
     source.buffer = buffer;
-    source.connect(gainNodeRef.current!);
+    const gainNode = gainNodeRef.current;
+    if (!gainNode) return;
+    source.connect(gainNode);
 
     const PRE_BUFFER_S = 0.06;
     const MAX_LOOKAHEAD_S = 0.12;
@@ -313,7 +316,8 @@ export const GameWindow: React.FC = () => {
       }
     });
 
-    api.on("game:loaded", (gameData: Game) => {
+    api.on("game:loaded", (raw: unknown) => {
+      const gameData = raw as Game;
       setGame(gameData);
 
       // Load per-system shader preference (e.g. CRT for NES, LCD for GBA)
@@ -337,22 +341,23 @@ export const GameWindow: React.FC = () => {
       playSfxRef.current("powerOn");
     });
 
-    api.on("game:mode", (m: string) => {
-      setMode(m as "overlay" | "native");
+    api.on("game:mode", (raw: unknown) => {
+      setMode(raw as "overlay" | "native");
       // Controls start hidden; user reveals them by moving mouse
     });
 
-    api.on("overlay:show-controls", (visible: boolean) => {
-      setShowControls(visible);
+    api.on("overlay:show-controls", (raw: unknown) => {
+      setShowControls(raw as boolean);
     });
 
     api.on("emulator:paused", () => setIsPaused(true));
     api.on("emulator:resumed", () => setIsPaused(false));
-    api.on("emulator:speedChanged", (data: { multiplier: number }) => {
-      setSpeedMultiplier(data.multiplier);
+    api.on("emulator:speedChanged", (raw: unknown) => {
+      setSpeedMultiplier((raw as { multiplier: number }).multiplier);
     });
 
-    api.on("game:emulation-error", (data: { message: string }) => {
+    api.on("game:emulation-error", (raw: unknown) => {
+      const data = raw as { message: string };
       setEmulationError(data.message || "An unknown error occurred");
     });
 
@@ -365,7 +370,8 @@ export const GameWindow: React.FC = () => {
       playSfxRef.current("powerOff");
     });
 
-    api.on("game:av-info", (avInfo: any) => {
+    api.on("game:av-info", (raw: unknown) => {
+      const avInfo = raw as AVInfo;
       const canvas = canvasRef.current;
       if (canvas) {
         canvas.width = avInfo.geometry.baseWidth;
@@ -379,7 +385,8 @@ export const GameWindow: React.FC = () => {
       setGameAspectRatio(aspectRatio);
     });
 
-    api.on("game:video-frame", (frameData: any) => {
+    api.on("game:video-frame", (raw: unknown) => {
+      const frameData = raw as VideoFrame;
       // Buffer the frame immediately so the latest state is always available,
       // but don't initialize the renderer or draw until the boot animation
       // overlay is in place. This prevents the game content from flashing
@@ -476,13 +483,14 @@ export const GameWindow: React.FC = () => {
     // IPC fallback audio path — used when SharedArrayBuffer is unavailable.
     // When SAB mode is active, audio is drained from the ring buffer in the
     // rAF loop instead (see drainAudioRing).
-    api.on("game:audio-samples", (audioData: any) => {
+    api.on("game:audio-samples", (audioDataRaw: unknown) => {
       if (useSharedBuffersRef.current) {
         return;
       }
 
       // audioData.samples arrives as Uint8Array after Electron IPC.
       // Interpret the raw bytes as interleaved stereo Int16 samples.
+      const audioData = audioDataRaw as { samples: Uint8Array; sampleRate: number };
       const raw: Uint8Array = audioData.samples;
       const samples = new Int16Array(raw.buffer, raw.byteOffset, raw.byteLength / 2);
       scheduleAudioChunk(samples, audioData.sampleRate);

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -227,7 +227,9 @@ export const GameWindow: React.FC = () => {
     const source = ctx.createBufferSource();
     source.buffer = buffer;
     const gainNode = gainNodeRef.current;
-    if (!gainNode) return;
+    if (!gainNode) {
+      return;
+    }
     source.connect(gainNode);
 
     const PRE_BUFFER_S = 0.06;

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -166,13 +166,14 @@ export const LibraryView: React.FC<{
 
     api.on(
       "library:scanProgress",
-      (progress: {
-        game: AppGame;
-        isNew: boolean;
-        processed: number;
-        total: number;
-        skipped: number;
-      }) => {
+      (raw: unknown) => {
+        const progress = raw as {
+          game: AppGame;
+          isNew: boolean;
+          processed: number;
+          total: number;
+          skipped: number;
+        };
         setScanProgress({
           processed: progress.processed,
           total: progress.total,
@@ -192,7 +193,8 @@ export const LibraryView: React.FC<{
       },
     );
 
-    api.on("core:downloadProgress", (progress: CoreDownloadProgress) => {
+    api.on("core:downloadProgress", (raw: unknown) => {
+      const progress = raw as CoreDownloadProgress;
       if (progress.phase === "done") {
         setDownloadProgress(progress);
         setTimeout(() => setDownloadProgress(null), 2000);
@@ -201,7 +203,8 @@ export const LibraryView: React.FC<{
       }
     });
 
-    api.on("artwork:progress", (progress: ArtworkProgress) => {
+    api.on("artwork:progress", (raw: unknown) => {
+      const progress = raw as ArtworkProgress;
       // Update per-card sync phase
       setCardPhase(progress.gameId, progress.phase as ArtworkSyncPhase);
 
@@ -295,7 +298,8 @@ export const LibraryView: React.FC<{
       syncResults.current = { found: 0, notFound: 0, errors: 0 };
     });
 
-    api.on("artwork:syncError", (data: { error: string; errorCode?: string }) => {
+    api.on("artwork:syncError", (raw: unknown) => {
+      const data = raw as { error: string; errorCode?: string };
       setSyncCounter(null);
       artworkSyncStore.clear();
       syncResults.current = { found: 0, notFound: 0, errors: 0 };

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -164,34 +164,31 @@ export const LibraryView: React.FC<{
       loadLibrary();
     });
 
-    api.on(
-      "library:scanProgress",
-      (raw: unknown) => {
-        const progress = raw as {
-          game: AppGame;
-          isNew: boolean;
-          processed: number;
-          total: number;
-          skipped: number;
-        };
-        setScanProgress({
-          processed: progress.processed,
-          total: progress.total,
-          skipped: progress.skipped,
-        });
+    api.on("library:scanProgress", (raw: unknown) => {
+      const progress = raw as {
+        game: AppGame;
+        isNew: boolean;
+        processed: number;
+        total: number;
+        skipped: number;
+      };
+      setScanProgress({
+        processed: progress.processed,
+        total: progress.total,
+        skipped: progress.skipped,
+      });
 
-        if (progress.isNew) {
-          // Incrementally add the new game to the list without waiting for the full scan
-          setGames((prev) => {
-            // Avoid duplicates — the scan may re-emit known games
-            if (prev.some((g) => g.id === progress.game.id)) {
-              return prev;
-            }
-            return [...prev, progress.game];
-          });
-        }
-      },
-    );
+      if (progress.isNew) {
+        // Incrementally add the new game to the list without waiting for the full scan
+        setGames((prev) => {
+          // Avoid duplicates — the scan may re-emit known games
+          if (prev.some((g) => g.id === progress.game.id)) {
+            return prev;
+          }
+          return [...prev, progress.game];
+        });
+      }
+    });
 
     api.on("core:downloadProgress", (raw: unknown) => {
       const progress = raw as CoreDownloadProgress;

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -14,7 +14,9 @@ const shouldBeDark = savedTheme === "dark" || (savedTheme !== "light" && prefers
 document.documentElement.classList.toggle("dark", shouldBeDark);
 
 const rootElement = document.getElementById("root");
-if (!rootElement) throw new Error("Root element #root not found");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
 
 ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -13,7 +13,10 @@ const shouldBeDark = savedTheme === "dark" || (savedTheme !== "light" && prefers
 
 document.documentElement.classList.toggle("dark", shouldBeDark);
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("Root element #root not found");
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <ErrorBoundary>
       <App />

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -18,7 +18,7 @@ export interface GamelordAPI {
       cardBounds?: { x: number; y: number; width: number; height: number },
     ) => Promise<{ success: boolean; error?: string }>;
     stop: () => Promise<{ success: boolean; error?: string }>;
-    getAvailable: () => Promise<any>;
+    getAvailable: () => Promise<Array<unknown>>;
     isRunning: () => Promise<boolean>;
     getCoresForSystem: (systemId: string) => Promise<Array<CoreInfo>>;
     downloadCore: (
@@ -43,20 +43,20 @@ export interface GamelordAPI {
   // Library management (matches preload API)
   library: {
     getSystems: () => Promise<Array<GameSystem>>;
-    addSystem: (system: GameSystem) => Promise<any>;
-    removeSystem: (systemId: string) => Promise<any>;
-    updateSystemPath: (systemId: string, romsPath: string) => Promise<any>;
+    addSystem: (system: GameSystem) => Promise<{ success: boolean }>;
+    removeSystem: (systemId: string) => Promise<{ success: boolean }>;
+    updateSystemPath: (systemId: string, romsPath: string) => Promise<{ success: boolean }>;
 
     getGames: (systemId?: string) => Promise<Array<Game>>;
     addGame: (romPath: string, systemId: string) => Promise<Game | null>;
-    removeGame: (gameId: string) => Promise<any>;
-    updateGame: (gameId: string, updates: Partial<Game>) => Promise<any>;
+    removeGame: (gameId: string) => Promise<{ success: boolean }>;
+    updateGame: (gameId: string, updates: Partial<Game>) => Promise<{ success: boolean }>;
 
     scanDirectory: (directoryPath: string, systemId?: string) => Promise<Array<Game>>;
-    scanSystemFolders: () => Promise<any>;
+    scanSystemFolders: () => Promise<Array<Game>>;
 
     getConfig: () => Promise<LibraryConfig>;
-    setRomsBasePath: (basePath: string) => Promise<any>;
+    setRomsBasePath: (basePath: string) => Promise<{ success: boolean }>;
   };
 
   // Artwork & metadata
@@ -103,7 +103,7 @@ export interface GamelordAPI {
   // Signal to the main process that the renderer has loaded and is ready to show.
   contentReady: () => void;
 
-  on: (channel: string, callback: (...args: Array<any>) => void) => void;
+  on: (channel: string, callback: (...args: Array<unknown>) => void) => void;
   removeAllListeners: (channel: string) => void;
 }
 


### PR DESCRIPTION
## Summary

Closes #173

- Eliminated all ~204 `!` non-null assertions and `as any` casts across the codebase
- Source files: replaced with guard clauses, null coalescing (`?? undefined`, `?? ''`), proper type imports, and typed helper functions (`errorMessage()`)
- Test files: introduced `assertDefined()` helpers (throw on null instead of `!`), typed mock interfaces, `as unknown as SpecificType` for mock constructors
- Zero eslint warnings remain (was ~204)

## Changes by file

**Source files (first commit):**
- `preload.ts` — `any` → `unknown` in callback/param types
- `GameWindow.tsx` — typed `pendingFrameRef`, IPC callbacks use `(raw: unknown)` + cast pattern
- `ArtworkService.ts` — null coalescing for `coverArt` and `artworkUrl`
- `handlers.ts` — `errorMessage()` helper, typed `forwardEvent` and `updateGame` params
- `EmulatorManager.ts` — typed options, null-to-undefined conversions
- `core-worker.ts` — guard clauses for SharedArrayBuffer views
- `SfxEngine.ts` — guard clause for AudioContext/GainNode
- `main.tsx` — guard clause for root element
- `global.d.ts` — all 9 `any` types replaced with proper types

**Test files (second commit):**
- `handlers.test.ts` — typed mock interfaces, throwing `getHandler()`/`getOnListener()` helpers, `IpcMainInvokeEvent` stub
- `LibraryService.test.ts` — `assertDefined()` helper for 35+ find/addGame results
- `ScreenScraperClient.test.ts` — `assertDefined()` helper for parse results
- `ArtworkService.test.ts` — typed private method spies, `vi.mocked()` for mock calls
- `EmulationWorkerClient.test.ts` — `instanceof` checks, guard clauses for SAB/setup calls
- `windowState.test.ts` — guard clauses for close handler
- `zipExtraction.test.ts` — `assertDefined()` helper for findRomInZip results
- `EmulatorManager.test.ts` — typed `fs.PathLike` parameter

## Test plan

- [x] `pnpm --filter desktop lint` — zero warnings
- [x] `pnpm --filter desktop typecheck` — passes clean
- [x] `pnpm --filter desktop test` — all 511 tests pass (23 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)