### PR TITLE
fix: hoist @electron/* packages for workspace resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=@electron/*


### PR DESCRIPTION
## Summary

- Add root `.npmrc` with `public-hoist-pattern[]=@electron/*` so `@electron/fuses` is resolvable from `apps/desktop/` during electron-builder's `afterPack` hook

Closes #199

## Context

pnpm's strict hoisting keeps `@electron/fuses` in the root `node_modules/` but doesn't symlink it into `apps/desktop/node_modules/`. The `afterPack.js` script calls `require("@electron/fuses")` which failed to resolve from the workspace package context. The `public-hoist-pattern` ensures all `@electron/*` packages are hoisted to the root where Node's module resolution can find them from any workspace package.

## Test plan

- [x] `pnpm install` completes without errors
- [x] `node -e "require.resolve('@electron/fuses')"` resolves from `apps/desktop/`
- [x] `pnpm package` builds the `.app` bundle successfully (afterPack fuses script runs without errors)
- [x] `pnpm lint && pnpm typecheck && pnpm format` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)