### PR TITLE
fix: add clean step to build script to prevent stale artifact packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,8 @@
   "main": "./out/main/index.js",
   "scripts": {
     "build:native": "cd native && node-gyp rebuild",
-    "build": "npm run build:native && electron-vite build",
+    "clean": "rm -rf out dist",
+    "build": "npm run clean && npm run build:native && electron-vite build",
     "dev": "electron-vite dev",
     "start": "electron-vite preview",
     "package": "npm run build && electron-builder --dir",


### PR DESCRIPTION
## Summary
- Adds a `clean` script (`rm -rf out dist`) to the desktop package
- Chains it at the start of `build` so every production build starts from a clean state
- Prevents stale artifacts (e.g. leftover Electron Forge output in `out/`) from being bundled into the asar by electron-builder, which caused codesign failures

## Context
`pnpm package` was failing with `ENOENT` errors during `@electron/rebuild` (broken pnpm symlinks) and then codesign failures (stale `.app` bundle from a previous Forge-era build sitting in `out/`). The symlinks were a local `node_modules` issue fixed by a clean install. The stale build artifacts are prevented by this change.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm format` passes
- [x] `pnpm package` succeeds on main repo after manual cleanup (verified the clean step logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)