### PR TITLE
docs: add Linux support (#206) to development plan

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -292,6 +292,7 @@ Tracking issue for the first alpha release. All items below must be completed be
   - [ ] **Windows ARM64 support** — CoreDownloader already serves x86_64 cores; add `windows/arm64` buildbot path for `process.arch === "arm64"`, ensure native addon compiles for ARM64 target, add electron-builder `--arm64` target. High priority — Snapdragon is a primary dev device. — [#203](https://github.com/ryanmagoon/gamelord/issues/203)
   - [ ] **Windows code signing (Authenticode)** — EV or OV code signing certificate, `signtool.exe` integration in electron-builder, CI workflow with cert import and signing secrets (mirrors macOS notarization flow). — [#204](https://github.com/ryanmagoon/gamelord/issues/204)
   - [ ] **Windows release packaging + CI** — Windows runner in CI matrix, NSIS/zip build targets, GitHub Releases artifacts for Windows. — [#205](https://github.com/ryanmagoon/gamelord/issues/205)
+  - [ ] **Linux support** — Core downloading with XDG paths, titlebar behavior across DEs, electron-builder targets (AppImage/deb/rpm/snap), CI Linux matrix, app icon. — [#206](https://github.com/ryanmagoon/gamelord/issues/206)
 
 ### P10 — Web Presence (Vercel)
 


### PR DESCRIPTION
## Summary
- Adds Linux support tracking item to the cross-platform section of DEVELOPMENT_PLAN.md, linked to #206

Refs #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)