### PR TITLE
fix: inject ScreenScraper and Sentry credentials at build time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,9 +129,12 @@ jobs:
         working-directory: apps/desktop
         run: npx electron-vite build
         env:
+          SCREENSCRAPER_DEV_ID: ${{ secrets.SCREENSCRAPER_DEV_ID }}
+          SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN || '' }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG || '' }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT || '' }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN || '' }}
 
       - name: Package, sign, and notarize
         working-directory: apps/desktop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,12 @@ jobs:
         working-directory: apps/desktop
         run: npx electron-vite build
         env:
+          SCREENSCRAPER_DEV_ID: ${{ secrets.SCREENSCRAPER_DEV_ID }}
+          SCREENSCRAPER_DEV_PASSWORD: ${{ secrets.SCREENSCRAPER_DEV_PASSWORD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Package, sign, notarize, and publish
         working-directory: apps/desktop

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,9 +1,14 @@
 import { resolve } from "node:path";
 import { execSync } from "node:child_process";
+import { config as loadDotenv } from "dotenv";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 import react from "@vitejs/plugin-react";
 import { sentryVitePlugin } from "@sentry/vite-plugin";
 import type { Plugin } from "vite";
+
+// Load .env at config time so values are available for build-time injection.
+// In CI, these come from GitHub Actions secrets instead.
+loadDotenv({ path: resolve(__dirname, ".env") });
 
 function getGitBranch(): string | null {
   try {
@@ -83,6 +88,13 @@ export default defineConfig({
         },
         external: [/\.node$/],
       },
+    },
+    define: {
+      "process.env.SCREENSCRAPER_DEV_ID": JSON.stringify(process.env.SCREENSCRAPER_DEV_ID ?? ""),
+      "process.env.SCREENSCRAPER_DEV_PASSWORD": JSON.stringify(
+        process.env.SCREENSCRAPER_DEV_PASSWORD ?? "",
+      ),
+      "process.env.SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN ?? ""),
     },
     plugins: [externalizeDepsPlugin(), ...sentryPlugins()],
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,11 +22,11 @@
   "dependencies": {
     "@sentry/electron": "^7.9.0",
     "@sentry/react": "^10.40.0",
-    "dotenv": "^17.2.4",
     "electron-log": "^5.4.3",
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {
+    "dotenv": "^17.2.4",
     "@electron/fuses": "^1.8.0",
     "@gamelord/ui": "workspace:*",
     "@sentry/vite-plugin": "^5.1.1",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,4 +1,3 @@
-import { config as loadDotenv } from "dotenv";
 import {
   app,
   BrowserWindow,
@@ -23,12 +22,8 @@ import {
 } from "./main/utils/windowState";
 import { animateWindowClose } from "./main/windowCloseAnimation";
 
-// Load .env from the desktop app root (apps/desktop/.env) before anything
-// reads process.env. This provides SCREENSCRAPER_DEV_ID / DEV_PASSWORD, etc.
-loadDotenv({ path: path.join(__dirname, "../../.env") });
-
-// Initialize Sentry crash reporting as early as possible (after dotenv so
-// SENTRY_DSN is available). No-op when DSN is not configured.
+// Initialize Sentry crash reporting as early as possible.
+// SENTRY_DSN is injected at build time via electron.vite.config.ts `define`.
 initSentryMain();
 
 // Set app name for macOS menu bar (must be called before app is ready)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@sentry/react':
         specifier: ^10.40.0
         version: 10.40.0(react@19.1.0)
-      dotenv:
-        specifier: ^17.2.4
-        version: 17.2.4
       electron-log:
         specifier: ^5.4.3
         version: 5.4.3
@@ -99,6 +96,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      dotenv:
+        specifier: ^17.2.4
+        version: 17.2.4
       electron:
         specifier: 37.3.1
         version: 37.3.1


### PR DESCRIPTION
## Summary

- **Root cause**: The runtime `loadDotenv()` in `main.ts` loaded `.env` relative to `__dirname`, which points inside the asar archive in packaged builds — so credentials were never found.
- **Fix**: Use Vite `define` in `electron.vite.config.ts` to inject `SCREENSCRAPER_DEV_ID`, `SCREENSCRAPER_DEV_PASSWORD`, and `SENTRY_DSN` as string literals at build time.
- **CI**: Added the ScreenScraper and Sentry DSN secrets to the nightly and release workflow build steps.
- **Cleanup**: Moved `dotenv` from `dependencies` to `devDependencies` since it's now only used at config/build time.

## Action required

You need to add these GitHub repository secrets before the next nightly build:
- `SCREENSCRAPER_DEV_ID`
- `SCREENSCRAPER_DEV_PASSWORD`
- `SENTRY_DSN` (if not already set)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (589/589)
- [x] Verify dev mode still loads credentials from `.env` and artwork sync works
- [ ] Verify nightly build has credentials baked in after adding GitHub secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)