### PR TITLE
fix: pass GH_TOKEN to electron-builder in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -140,6 +140,7 @@ jobs:
         working-directory: apps/desktop
         run: npx electron-builder --mac
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_KEYCHAIN: ${{ runner.temp }}/signing.keychain-db
           APPLE_API_KEY: ~/.private_keys/AuthKey_${{ secrets.APPLE_API_KEY_ID }}.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}


### PR DESCRIPTION
## Summary

- The nightly workflow's `electron-builder --mac` step was missing `GH_TOKEN`, causing it to fail with "GitHub Personal Access Token is not set"
- The release workflow already passes this token correctly — this aligns the nightly workflow to match

Fixes the nightly build failure from https://github.com/ryanmagoon/gamelord/actions/runs/23097732574

## Test plan

- [ ] Merge this PR, then re-trigger the nightly workflow and confirm it passes the packaging step

🤖 Generated with [Claude Code](https://claude.com/claude-code)