### PR TITLE
fix: always dismiss setup screen after homebrew check

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -43,19 +43,28 @@ export class IPCHandlers {
     this.setupDialogHandlers();
 
     // Import bundled homebrew ROMs on first launch (async, non-blocking).
-    // Notifies the renderer when done so it can reload the library.
+    // Always notifies the renderer when done — even if no import was needed —
+    // so the "Setting up your library" screen is dismissed. Without this the
+    // renderer can get stuck indefinitely when importIfNeeded() returns false
+    // (e.g. marker file exists but library is empty after a crash).
     this.homebrewService
       .importIfNeeded()
       .then((imported) => {
         if (imported) {
-          const windows = BrowserWindow.getAllWindows();
-          for (const window of windows) {
-            window.webContents.send("library:homebrewImported");
-          }
+          ipcLog.info("Homebrew ROMs imported, notifying renderer");
+        }
+        const windows = BrowserWindow.getAllWindows();
+        for (const window of windows) {
+          window.webContents.send("library:homebrewImported");
         }
       })
       .catch((error) => {
         ipcLog.error("Homebrew import failed:", error);
+        // Still dismiss the setup screen so the user isn't stuck
+        const windows = BrowserWindow.getAllWindows();
+        for (const window of windows) {
+          window.webContents.send("library:homebrewImported");
+        }
       });
   }
 


### PR DESCRIPTION
## Summary

- The `library:homebrewImported` IPC event was only sent when homebrew ROMs were actually imported (`importIfNeeded()` returned `true`). If the marker file already existed or the import errored, the event was never sent.
- The renderer defaults `isImportingHomebrew = true` and relies on either `loadLibrary()` returning games or this event to dismiss the "Setting up your library" screen.
- After a crash that corrupts `library.json` (e.g. file filled with null bytes), `loadLibrary()` returns `[]` and the event never fires — the UI is stuck forever on the setup screen even though no import is happening.
- Fix: always send the event after the homebrew check completes, regardless of whether import was needed or failed.

## Test plan

- [ ] Start app with a valid library — should load normally (no regression)
- [ ] Delete `.homebrew-imported` marker and `library.json`, start app — should show homebrew import, then transition to library
- [ ] With marker present and empty/corrupt `library.json`, start app — should show empty library UI (not stuck on "Setting up your library")

🤖 Generated with [Claude Code](https://claude.com/claude-code)