### PR TITLE
fix: suppress 'Cannot parse releases feed' error on nightly builds

### DIFF
--- a/apps/desktop/src/main/services/AutoUpdaterService.test.ts
+++ b/apps/desktop/src/main/services/AutoUpdaterService.test.ts
@@ -10,11 +10,13 @@ const {
   mockQuitAndInstall,
   mockWebContentsSend,
   mockGetAllWindows,
+  mockGetVersion,
 } = vi.hoisted(() => {
   const mockCheckForUpdates = vi.fn().mockResolvedValue(undefined);
   const mockQuitAndInstall = vi.fn();
   const mockWebContentsSend = vi.fn();
   const mockGetAllWindows = vi.fn();
+  const mockGetVersion = vi.fn().mockReturnValue("0.1.0");
 
   // Minimal EventEmitter implementation for the mock — avoids importing
   // node:events inside vi.hoisted() which isn't available at hoist time.
@@ -23,6 +25,7 @@ const {
   const fakeAutoUpdater = {
     autoDownload: false,
     autoInstallOnAppQuit: false,
+    allowPrerelease: false,
     logger: null as unknown,
     checkForUpdates: mockCheckForUpdates,
     quitAndInstall: mockQuitAndInstall,
@@ -58,6 +61,7 @@ const {
     mockQuitAndInstall,
     mockWebContentsSend,
     mockGetAllWindows,
+    mockGetVersion,
   };
 });
 
@@ -66,6 +70,9 @@ vi.mock("electron-updater", () => ({
 }));
 
 vi.mock("electron", () => ({
+  app: {
+    getVersion: () => mockGetVersion(),
+  },
   BrowserWindow: {
     getAllWindows: (...args: Array<unknown>) => mockGetAllWindows(...args),
   },
@@ -106,6 +113,30 @@ describe("AutoUpdaterService", () => {
       expect(fakeAutoUpdater.autoDownload).toBe(true);
       expect(fakeAutoUpdater.autoInstallOnAppQuit).toBe(true);
       expect(fakeAutoUpdater.logger).toBeDefined();
+    });
+
+    it("sets allowPrerelease=false for stable versions", () => {
+      expect(fakeAutoUpdater.allowPrerelease).toBe(false);
+    });
+
+    it("sets allowPrerelease=true for nightly versions", () => {
+      fakeAutoUpdater.removeAllListeners();
+      fakeAutoUpdater.allowPrerelease = false;
+      mockGetVersion.mockReturnValueOnce("0.1.0-nightly.20260328");
+
+      const nightlyService = new AutoUpdaterService();
+      expect(fakeAutoUpdater.allowPrerelease).toBe(true);
+      nightlyService.cleanup();
+    });
+
+    it("sets allowPrerelease=true for any pre-release version", () => {
+      fakeAutoUpdater.removeAllListeners();
+      fakeAutoUpdater.allowPrerelease = false;
+      mockGetVersion.mockReturnValueOnce("0.1.0-beta.1");
+
+      const preService = new AutoUpdaterService();
+      expect(fakeAutoUpdater.allowPrerelease).toBe(true);
+      preService.cleanup();
     });
 
     it("registers event listeners on autoUpdater", () => {
@@ -198,6 +229,16 @@ describe("AutoUpdaterService", () => {
       expect(mockWebContentsSend).toHaveBeenCalledWith("updates:error", {
         message: "Network timeout",
       });
+    });
+
+    it("suppresses 'Unable to find latest version' error from renderer", () => {
+      fakeAutoUpdater.emit(
+        "error",
+        new Error(
+          "Unable to find latest version on GitHub (https://github.com/ryanmagoon/gamelord/releases/latest), please ensure a production release exists: HttpError: 406",
+        ),
+      );
+      expect(mockWebContentsSend).not.toHaveBeenCalled();
     });
 
     it("broadcasts to all open windows", () => {

--- a/apps/desktop/src/main/services/AutoUpdaterService.ts
+++ b/apps/desktop/src/main/services/AutoUpdaterService.ts
@@ -1,9 +1,15 @@
-import { BrowserWindow } from "electron";
+import { app, BrowserWindow } from "electron";
 import { autoUpdater } from "electron-updater";
 import type { UpdateInfo, ProgressInfo } from "electron-updater";
 import { updaterLog } from "../logger";
 
 const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+/**
+ * Pattern matching the GitHub 406 error when no production release exists.
+ * This happens on nightly-only builds where all releases are pre-releases.
+ */
+const NO_LATEST_RELEASE_RE = /Unable to find latest version/i;
 
 /**
  * Manages automatic update checks and downloads via electron-updater.
@@ -15,9 +21,24 @@ export class AutoUpdaterService {
   constructor() {
     autoUpdater.autoDownload = true;
     autoUpdater.autoInstallOnAppQuit = true;
+    autoUpdater.allowPrerelease = this.isPrerelease();
     autoUpdater.logger = updaterLog;
 
     this.setupEventForwarding();
+  }
+
+  /**
+   * Detect if the current build is a pre-release (nightly).
+   * Nightly releases are tagged `nightly-YYYY-MM-DD` — electron-updater
+   * sets the app version from the release tag, which includes "nightly".
+   * Falls back to checking if no stable release exists by enabling
+   * prerelease for any version that contains a prerelease identifier.
+   */
+  private isPrerelease(): boolean {
+    const version = app.getVersion();
+    // Semver pre-release versions contain a hyphen (e.g. "0.1.0-nightly.20260328")
+    // Also match plain "nightly" substring for tagged builds
+    return version.includes("-") || version.includes("nightly");
   }
 
   /**
@@ -107,6 +128,17 @@ export class AutoUpdaterService {
     });
 
     autoUpdater.on("error", (error: Error) => {
+      // When no production release exists (nightly-only repo), GitHub returns
+      // 406 and electron-updater surfaces "Unable to find latest version".
+      // This is expected — log at info level and don't alarm the user.
+      if (NO_LATEST_RELEASE_RE.test(error.message)) {
+        updaterLog.info(
+          "No production release found (expected for nightly builds):",
+          error.message,
+        );
+        return;
+      }
+
       updaterLog.error("Auto-update error:", error.message);
       this.broadcast("updates:error", {
         message: error.message,


### PR DESCRIPTION
## Summary

- Set `allowPrerelease = true` on `electron-updater` when the app version contains a semver pre-release identifier or "nightly", so the updater can discover nightly releases instead of failing with a 406
- Suppress the specific "Unable to find latest version" error from being broadcast to renderer windows — log it at `info` level instead of `error`

## Test plan

- [x] Existing AutoUpdaterService tests pass (595 total)
- [x] New tests verify `allowPrerelease` is set correctly for stable, nightly, and beta versions
- [x] New test verifies the "Unable to find latest version" error is suppressed from the renderer
- [ ] Manual: run a nightly build and confirm no error toast on startup

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)