### PR TITLE
fix: auto-pause artwork sync during gameplay

### DIFF
--- a/.claude/rules/session-start.md
+++ b/.claude/rules/session-start.md
@@ -10,10 +10,10 @@ Before manually testing any emulator functionality, ensure the native addon is b
 
 ## Worktree Setup
 
-When working in a git worktree (`.claude/worktrees/`), dependencies and build artifacts are not shared with the main repo. After `pnpm install`, also run:
+When working in a git worktree (`.claude/worktrees/`), dependencies and build artifacts are not shared with the main repo. After `pnpm install`, run:
 
-1. **Build the native addon** (see above).
-2. **Symlink `.env`** — `ln -s /Users/ryanmagoon/code/gamelord/apps/desktop/.env apps/desktop/.env`. The worktree only has `.env.example`; the real credentials (ScreenScraper, etc.) live in the main repo.
+1. **`./scripts/setup-worktree.sh`** — Symlinks `.env` and any other shared files from the main repo. Safe to run multiple times. This replaces the manual symlink step.
+2. **Build the native addon** (see above).
 
 ### Rename auto-generated worktree branches
 

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -96,6 +96,7 @@ Items are grouped by priority. Work top-down within each tier.
 - [x] **Fix test environment** — Switch vitest config from jsdom to happy-dom (per project conventions)
 - [x] **Fix game ID hashing** — Replace `MD5(romPath)` in `LibraryService.ts` with `SHA-256(fileContent)` so IDs survive file moves
 - [x] **ROM checksum validation** — Compute CRC32/SHA-1/MD5 checksums on ROM files at scan time via single-pass streaming. Stored in required `romHashes` field on `Game`. Backfill on startup for existing libraries. ArtworkService simplified to use pre-computed MD5. — [#61](https://github.com/ryanmagoon/gamelord/issues/61)
+- [x] **Artwork sync auto-pause during gameplay** — Artwork sync now auto-pauses when a game launches and resumes when the emulator exits, preventing main process event loop contention. Also batches library.json writes (every 10 games instead of every game) to reduce I/O. Renderer shows a "Paused" badge. — [#246](https://github.com/ryanmagoon/gamelord/issues/246)
 
 ### P2 — Performance
 

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain, MessageChannelMain, nativeImage, screen } from "electron";
 import path from "node:path";
+import { EventEmitter } from "node:events";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { Game } from "../types/library";
@@ -20,7 +21,7 @@ export type GameWindowMode = "overlay" | "native";
 /** Max time to wait for the renderer's shutdown animation + OS window fade before force-closing. */
 const SHUTDOWN_ANIMATION_TIMEOUT = 2000;
 
-export class GameWindowManager {
+export class GameWindowManager extends EventEmitter {
   private gameWindows = new Map<string, BrowserWindow>();
   private trackingIntervals = new Map<string, ReturnType<typeof setInterval>>();
   private frameIntervals = new Map<string, ReturnType<typeof setInterval>>();
@@ -32,6 +33,7 @@ export class GameWindowManager {
   private shutdownTimeouts = new Map<number, ReturnType<typeof setTimeout>>();
 
   constructor(preloadPath: string) {
+    super();
     this.preloadPath = preloadPath;
     this.setupIpcHandlers();
   }
@@ -279,6 +281,8 @@ export class GameWindowManager {
       workerClient.shutdown().catch((error) => {
         gameWindowLog.warn("Worker shutdown after window close failed:", error);
       });
+
+      this.emit("gameWindowClosed", { gameId: game.id });
     });
 
     this.gameWindows.set(game.id, gameWindow);

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -311,7 +311,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(37);
+      expect(handleCalls).toHaveLength(39);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -330,8 +330,15 @@ export class IPCHandlers {
       });
     };
 
-    this.emulatorManager.on("gameLaunched", (data) => forwardEvent("emulator:launched", data));
-    this.emulatorManager.on("emulator:exited", (data) => forwardEvent("emulator:exited", data));
+    this.emulatorManager.on("gameLaunched", (data) => {
+      forwardEvent("emulator:launched", data);
+      // Auto-pause artwork sync during gameplay to avoid I/O contention
+      this.artworkService.pause();
+    });
+    this.emulatorManager.on("emulator:exited", (data) => {
+      forwardEvent("emulator:exited", data);
+      this.artworkService.resume();
+    });
     this.emulatorManager.on("emulator:error", (error) => forwardEvent("emulator:error", error));
     this.emulatorManager.on("emulator:stateSaved", (data) =>
       forwardEvent("emulator:stateSaved", data),
@@ -348,7 +355,10 @@ export class IPCHandlers {
     this.emulatorManager.on("emulator:speedChanged", (data) =>
       forwardEvent("emulator:speedChanged", data),
     );
-    this.emulatorManager.on("emulator:terminated", () => forwardEvent("emulator:terminated"));
+    this.emulatorManager.on("emulator:terminated", () => {
+      forwardEvent("emulator:terminated");
+      this.artworkService.resume();
+    });
     this.emulatorManager.on("core:downloadProgress", (data) =>
       forwardEvent("core:downloadProgress", data),
     );
@@ -544,6 +554,8 @@ export class IPCHandlers {
 
     this.artworkService.on("progress", (data) => forwardEvent("artwork:progress", data));
     this.artworkService.on("syncComplete", (data) => forwardEvent("artwork:syncComplete", data));
+    this.artworkService.on("paused", () => forwardEvent("artwork:syncPaused"));
+    this.artworkService.on("resumed", () => forwardEvent("artwork:syncResumed"));
 
     ipcMain.handle("artwork:syncGame", async (_event, gameId: string) => {
       try {
@@ -582,6 +594,16 @@ export class IPCHandlers {
 
     ipcMain.handle("artwork:cancelSync", () => {
       this.artworkService.cancelSync();
+      return { success: true };
+    });
+
+    ipcMain.handle("artwork:pause", () => {
+      this.artworkService.pause();
+      return { success: true };
+    });
+
+    ipcMain.handle("artwork:resume", () => {
+      this.artworkService.resume();
       return { success: true };
     });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -362,6 +362,12 @@ export class IPCHandlers {
     this.emulatorManager.on("core:downloadProgress", (data) =>
       forwardEvent("core:downloadProgress", data),
     );
+
+    // Native mode: game window close doesn't go through EmulatorManager events,
+    // so we listen on GameWindowManager directly to resume artwork sync.
+    this.gameWindowManager.on("gameWindowClosed", () => {
+      this.artworkService.resume();
+    });
   }
 
   private setupLibraryHandlers(): void {

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -708,6 +708,11 @@ export class IPCHandlers {
     // before the shutdown handshake completes.
     this.emulatorManager.prepareForQuit();
     await this.emulatorManager.stopEmulator();
+
+    // Stop any in-progress artwork sync and flush pending batched library
+    // writes so artwork downloaded during this session isn't lost on quit.
+    this.artworkService.cancelSync();
+    await this.libraryService.flushSave();
   }
 
   /**

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -91,6 +91,13 @@ function createMockLibraryService(games: Array<Game> = []): LibraryService {
         Object.assign(game, updates);
       }
     }),
+    updateGameBatched: vi.fn((id: string, updates: Partial<Game>) => {
+      const game = gameMap.get(id);
+      if (game) {
+        Object.assign(game, updates);
+      }
+    }),
+    flushSave: vi.fn(async () => {}),
   } as unknown as LibraryService;
 }
 
@@ -641,6 +648,190 @@ describe("ArtworkService", () => {
       const lastEvent = progressEvents.at(-1);
       expect(lastEvent).toBeDefined();
       expect(lastEvent?.phase).toBe("not-found");
+    });
+  });
+
+  describe("pause/resume", () => {
+    it("emits paused/resumed events", async () => {
+      const game = makeGame({
+        id: "g1",
+        title: "Game 1",
+        coverArt: undefined,
+      });
+      const lib = createMockLibraryService([game]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+
+      // Store config so createClient works
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      const events: Array<string> = [];
+      service.on("paused", () => events.push("paused"));
+      service.on("resumed", () => events.push("resumed"));
+
+      // Start sync — the sync loop will process game1 and complete
+      // We need to pause before it processes the game.
+      // Mock fetchByHash to stall so we can pause mid-sync.
+      const stallControl = { resolve: () => {} };
+      mockFetchByHash.mockImplementation(
+        () =>
+          new Promise<null>((resolve) => {
+            stallControl.resolve = () => resolve(null);
+          }),
+      );
+
+      const syncPromise = service.syncAllGames();
+
+      // Wait for the stall to be set up
+      await flushPromises();
+
+      service.pause();
+      expect(events).toContain("paused");
+      expect(service.isPaused()).toBe(true);
+
+      service.resume();
+      expect(events).toContain("resumed");
+      expect(service.isPaused()).toBe(false);
+
+      // Unblock the stalled request and let sync finish
+      stallControl.resolve();
+      await syncPromise;
+    });
+
+    it("blocks the sync loop when paused and resumes on resume()", async () => {
+      const games = [
+        makeGame({ id: "g1", title: "Game 1", coverArt: undefined }),
+        makeGame({ id: "g2", title: "Game 2", coverArt: undefined }),
+      ];
+      const lib = createMockLibraryService(games);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      let callCount = 0;
+      mockFetchByHash.mockImplementation(async () => {
+        callCount++;
+        return null;
+      });
+
+      // After processing game 1, pause
+      service.on("progress", (p: ArtworkProgress) => {
+        if (p.gameId === "g1" && p.phase === "not-found") {
+          service.pause();
+        }
+      });
+
+      const syncPromise = service.syncAllGames();
+      // Let game 1 finish
+      await flushPromises();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Only game 1 should have been queried (hash + name = 2 calls)
+      const callsBeforeResume = callCount;
+
+      // Resume and let sync finish
+      service.resume();
+      await syncPromise;
+
+      // Game 2 should now also have been queried
+      expect(callCount).toBeGreaterThan(callsBeforeResume);
+    });
+
+    it("cancel unblocks a paused sync", async () => {
+      const games = [
+        makeGame({ id: "g1", title: "Game 1", coverArt: undefined }),
+        makeGame({ id: "g2", title: "Game 2", coverArt: undefined }),
+      ];
+      const lib = createMockLibraryService(games);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      mockFetchByHash.mockResolvedValue(null);
+
+      // Pause after game 1 finishes
+      service.on("progress", (p: ArtworkProgress) => {
+        if (p.gameId === "g1" && p.phase === "not-found") {
+          service.pause();
+        }
+      });
+
+      const syncPromise = service.syncAllGames();
+      // Let game 1 process and trigger the pause
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(service.isPaused()).toBe(true);
+
+      // Cancel should unblock and finish the sync
+      service.cancelSync();
+      expect(service.isPaused()).toBe(false);
+
+      await syncPromise;
+    });
+
+    it("pause is a no-op when not syncing", () => {
+      const lib = createMockLibraryService([]);
+      const service = new ArtworkService(lib);
+
+      const events: Array<string> = [];
+      service.on("paused", () => events.push("paused"));
+
+      service.pause();
+      expect(events).toHaveLength(0);
+      expect(service.isPaused()).toBe(false);
+    });
+
+    it("getSyncStatus includes paused state", async () => {
+      const lib = createMockLibraryService([]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+
+      const status = service.getSyncStatus();
+      expect(status).toEqual({ inProgress: false, paused: false });
+    });
+  });
+
+  describe("batched saves during sync", () => {
+    it("uses updateGameBatched during sync instead of updateGame", async () => {
+      const game = makeGame({ id: "g1", coverArt: undefined });
+      const lib = createMockLibraryService([game]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      mockFetchByHash.mockResolvedValue({
+        title: "Test Game",
+        media: {},
+      });
+
+      await service.syncAllGames();
+
+      expect(lib.updateGameBatched).toHaveBeenCalled();
+      expect(lib.updateGame).not.toHaveBeenCalled();
+      expect(lib.flushSave).toHaveBeenCalled();
+    });
+
+    it("uses updateGame for single syncGame (not batch)", async () => {
+      const game = makeGame({ id: "g1", coverArt: undefined });
+      const lib = createMockLibraryService([game]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      mockFetchByHash.mockResolvedValue({
+        title: "Test Game",
+        media: {},
+      });
+
+      await service.syncGame("g1");
+
+      expect(lib.updateGame).toHaveBeenCalled();
+      expect(lib.updateGameBatched).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -59,6 +59,8 @@ export class ArtworkService extends EventEmitter {
   private config: ArtworkConfig = {};
   private cancelled = false;
   private syncing = false;
+  private paused = false;
+  private pauseResolve: (() => void) | null = null;
   private lastRequestTime = 0;
 
   constructor(libraryService: LibraryService) {
@@ -265,8 +267,10 @@ export class ArtworkService extends EventEmitter {
     }
 
     // Step 5: Update game record (including regional system name if applicable)
+    // Uses batched update when called from a sync batch to avoid rewriting
+    // library.json after every game. The batch loop calls flushSave() periodically.
     const regionalName = getRegionalSystemName(game.systemId, gameInfo.region);
-    await this.libraryService.updateGame(gameId, {
+    const updates: Partial<typeof game> = {
       ...(coverArtPath && artworkUrl
         ? { coverArt: `artwork://${gameId}${this.getImageExtension(artworkUrl)}` }
         : {}),
@@ -281,7 +285,13 @@ export class ArtworkService extends EventEmitter {
         players: gameInfo.players,
         rating: gameInfo.rating,
       },
-    });
+    };
+
+    if (this.syncing) {
+      this.libraryService.updateGameBatched(gameId, updates);
+    } else {
+      await this.libraryService.updateGame(gameId, updates);
+    }
 
     return !!coverArtPath;
   }
@@ -328,11 +338,47 @@ export class ArtworkService extends EventEmitter {
   /** Cancel an in-progress bulk sync. */
   cancelSync(): void {
     this.cancelled = true;
+    // If paused, unblock so the loop can exit
+    if (this.pauseResolve) {
+      this.pauseResolve();
+      this.pauseResolve = null;
+    }
+    this.paused = false;
+  }
+
+  /**
+   * Pause the sync loop after the current game finishes processing.
+   * The loop blocks at the next `waitIfPaused()` checkpoint until `resume()` is called.
+   */
+  pause(): void {
+    if (!this.syncing || this.paused) {
+      return;
+    }
+    this.paused = true;
+    this.emit("paused");
+  }
+
+  /** Resume a paused sync loop. */
+  resume(): void {
+    if (!this.paused) {
+      return;
+    }
+    this.paused = false;
+    if (this.pauseResolve) {
+      this.pauseResolve();
+      this.pauseResolve = null;
+    }
+    this.emit("resumed");
+  }
+
+  /** Returns whether the sync is currently paused. */
+  isPaused(): boolean {
+    return this.paused;
   }
 
   /** Get current sync status. */
-  getSyncStatus(): { inProgress: boolean } {
-    return { inProgress: this.syncing };
+  getSyncStatus(): { inProgress: boolean; paused: boolean } {
+    return { inProgress: this.syncing, paused: this.paused };
   }
 
   /**
@@ -447,6 +493,13 @@ export class ArtworkService extends EventEmitter {
         break;
       }
 
+      // If paused (e.g. during gameplay), block here until resumed
+      await this.waitIfPaused();
+
+      if (this.cancelled) {
+        break;
+      }
+
       const game = this.libraryService.getGame(gameId);
       if (!game) {
         processed++;
@@ -518,9 +571,19 @@ export class ArtworkService extends EventEmitter {
       }
 
       processed++;
+
+      // Flush batched saves to disk every 10 games to bound data loss on crash
+      if (processed % 10 === 0) {
+        await this.libraryService.flushSave();
+      }
     }
 
+    // Final flush for any remaining batched updates
+    await this.libraryService.flushSave();
+
     this.syncing = false;
+    this.paused = false;
+    this.pauseResolve = null;
     const status: ArtworkSyncStatus = {
       inProgress: false,
       processed,
@@ -531,6 +594,16 @@ export class ArtworkService extends EventEmitter {
     };
     this.emit("syncComplete", status);
     return status;
+  }
+
+  /** Block until the sync is unpaused. Returns immediately if not paused. */
+  private waitIfPaused(): Promise<void> {
+    if (!this.paused) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.pauseResolve = resolve;
+    });
   }
 
   /** Enforce rate limiting by waiting if needed since the last API request. */

--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -2131,4 +2131,68 @@ describe("LibraryService", () => {
       fs.unlinkSync(romPath);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // updateGameBatched / flushSave
+  // ---------------------------------------------------------------------------
+
+  describe("updateGameBatched", () => {
+    it("updates in-memory state without writing to disk", async () => {
+      const romPath = path.join(ROMS_DIR, "batched_test.nes");
+      fs.writeFileSync(romPath, "batched-data");
+
+      const service = await createService();
+      const game = await service.addGame(romPath, "nes");
+      expect(game).not.toBeNull();
+
+      // Read the library.json after the addGame write
+      const diskBefore = fs.readFileSync(path.join(USER_DATA_DIR, "library.json"), "utf8");
+
+      service.updateGameBatched(game!.id, { title: "New Title" });
+
+      // In-memory should be updated
+      const updated = service.getGame(game!.id);
+      expect(updated?.title).toBe("New Title");
+
+      // Disk should be unchanged
+      const diskAfter = fs.readFileSync(path.join(USER_DATA_DIR, "library.json"), "utf8");
+      expect(diskAfter).toBe(diskBefore);
+
+      fs.unlinkSync(romPath);
+    });
+
+    it("flushSave writes pending batched changes to disk", async () => {
+      const romPath = path.join(ROMS_DIR, "flush_test.nes");
+      fs.writeFileSync(romPath, "flush-data");
+
+      const service = await createService();
+      const game = await service.addGame(romPath, "nes");
+      expect(game).not.toBeNull();
+
+      service.updateGameBatched(game!.id, { title: "Flushed Title" });
+      await service.flushSave();
+
+      // Verify by loading from disk with a fresh service
+      const service2 = await createService();
+      const persisted = service2.getGame(game!.id);
+      expect(persisted?.title).toBe("Flushed Title");
+
+      fs.unlinkSync(romPath);
+    });
+
+    it("flushSave is a no-op when nothing is dirty", async () => {
+      const service = await createService();
+
+      // Spy on saveLibrary (private, accessed via prototype)
+      const saveSpy = vi.spyOn(
+        service as unknown as Record<string, () => Promise<void>>,
+        "saveLibrary",
+      );
+
+      await service.flushSave();
+      expect(saveSpy).not.toHaveBeenCalled();
+
+      saveSpy.mockRestore();
+    });
+  });
 });

--- a/apps/desktop/src/main/services/LibraryService.ts
+++ b/apps/desktop/src/main/services/LibraryService.ts
@@ -72,6 +72,8 @@ export class LibraryService extends EventEmitter {
   private configPath: string;
   private libraryPath: string;
   private romsCacheDir: string;
+  /** Tracks whether batched updates need flushing to disk. */
+  private dirty = false;
 
   constructor() {
     super();
@@ -935,6 +937,33 @@ export class LibraryService extends EventEmitter {
       }
       await this.saveLibrary();
     }
+  }
+
+  /**
+   * Update a game's in-memory state without immediately writing to disk.
+   * Call `flushSave()` when you're done with the batch to persist.
+   * Used during artwork sync to avoid rewriting library.json after every game.
+   */
+  public updateGameBatched(gameId: string, updates: Partial<Game>): void {
+    const game = this.games.get(gameId);
+    if (game) {
+      const oldRomPath = game.romPath;
+      Object.assign(game, updates);
+      if (updates.romPath && updates.romPath !== oldRomPath) {
+        this.romPathIndex.delete(oldRomPath);
+        this.romPathIndex.set(updates.romPath, gameId);
+      }
+      this.dirty = true;
+    }
+  }
+
+  /** Persist pending batched updates to disk. No-op if nothing changed. */
+  public async flushSave(): Promise<void> {
+    if (!this.dirty) {
+      return;
+    }
+    this.dirty = false;
+    await this.saveLibrary();
   }
 
   public getConfig(): LibraryConfig {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -92,6 +92,8 @@ contextBridge.exposeInMainWorld("gamelord", {
       "artwork:progress",
       "artwork:syncComplete",
       "artwork:syncError",
+      "artwork:syncPaused",
+      "artwork:syncResumed",
       "dialog:showResumeGame",
       "game:prepare-close",
       "game:emulation-error",
@@ -162,6 +164,8 @@ contextBridge.exposeInMainWorld("gamelord", {
     syncAll: () => ipcRenderer.invoke("artwork:syncAll"),
     syncGames: (gameIds: Array<string>) => ipcRenderer.invoke("artwork:syncGames", gameIds),
     cancelSync: () => ipcRenderer.invoke("artwork:cancelSync"),
+    pause: () => ipcRenderer.invoke("artwork:pause"),
+    resume: () => ipcRenderer.invoke("artwork:resume"),
     getSyncStatus: () => ipcRenderer.invoke("artwork:getSyncStatus"),
     getCredentials: () => ipcRenderer.invoke("artwork:getCredentials"),
     setCredentials: (userId: string, userPassword: string) =>

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -21,7 +21,7 @@ import {
   type ArtworkSyncPhase,
   type CommandAction,
 } from "@gamelord/ui";
-import { Plus, FolderOpen, RefreshCw, ImageDown, X } from "lucide-react";
+import { Plus, FolderOpen, RefreshCw, ImageDown, Pause, X } from "lucide-react";
 import type { Game as AppGame, GameSystem } from "../../types/library";
 import type { ArtworkProgress } from "../../types/artwork";
 import type { GamelordAPI } from "../types/global";
@@ -68,6 +68,7 @@ export const LibraryView: React.FC<{
   // Each GameCard subscribes to its own phase via useSyncExternalStore.
   const [artworkSyncStore] = useState(() => new ArtworkSyncStore());
   const [syncCounter, setSyncCounter] = useState<{ current: number; total: number } | null>(null);
+  const [syncPaused, setSyncPaused] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const phaseCleanupTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   /** Track sync results for the notification summary. */
@@ -243,6 +244,7 @@ export const LibraryView: React.FC<{
 
     api.on("artwork:syncComplete", () => {
       setSyncCounter(null);
+      setSyncPaused(false);
       loadLibrary();
 
       // Show summary notification
@@ -304,6 +306,7 @@ export const LibraryView: React.FC<{
     api.on("artwork:syncError", (raw: unknown) => {
       const data = raw as { error: string; errorCode?: string };
       setSyncCounter(null);
+      setSyncPaused(false);
       artworkSyncStore.clear();
       syncResults.current = { found: 0, notFound: 0, errors: 0 };
 
@@ -336,6 +339,9 @@ export const LibraryView: React.FC<{
       setSyncNotification({ message, variant: "error" });
     });
 
+    api.on("artwork:syncPaused", () => setSyncPaused(true));
+    api.on("artwork:syncResumed", () => setSyncPaused(false));
+
     return () => {
       api.removeAllListeners("library:scanProgress");
       api.removeAllListeners("library:homebrewImported");
@@ -343,6 +349,8 @@ export const LibraryView: React.FC<{
       api.removeAllListeners("artwork:progress");
       api.removeAllListeners("artwork:syncComplete");
       api.removeAllListeners("artwork:syncError");
+      api.removeAllListeners("artwork:syncPaused");
+      api.removeAllListeners("artwork:syncResumed");
       // Clear all cleanup timers
       phaseCleanupTimers.current.forEach((timer) => clearTimeout(timer));
       phaseCleanupTimers.current.clear();
@@ -802,8 +810,12 @@ export const LibraryView: React.FC<{
           {/* Sync progress badge — replaces the old purple banner */}
           {isSyncing && (
             <Badge variant="secondary" className="gap-1.5 text-xs font-normal">
-              <ImageDown className="h-3 w-3 animate-pulse" />
-              Syncing {syncCounter.current}/{syncCounter.total}
+              {syncPaused ? (
+                <Pause className="h-3 w-3" />
+              ) : (
+                <ImageDown className="h-3 w-3 animate-pulse" />
+              )}
+              {syncPaused ? "Paused" : "Syncing"} {syncCounter.current}/{syncCounter.total}
               <button
                 onClick={() => {
                   playSfx("click");

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -66,7 +66,9 @@ export interface GamelordAPI {
     syncAll: () => Promise<{ success: boolean; error?: string }>;
     syncGames: (gameIds: Array<string>) => Promise<{ success: boolean; error?: string }>;
     cancelSync: () => Promise<{ success: boolean }>;
-    getSyncStatus: () => Promise<{ inProgress: boolean }>;
+    pause: () => Promise<{ success: boolean }>;
+    resume: () => Promise<{ success: boolean }>;
+    getSyncStatus: () => Promise<{ inProgress: boolean; paused: boolean }>;
     getCredentials: () => Promise<{ hasCredentials: boolean }>;
     setCredentials: (
       userId: string,

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Setup script for git worktrees.
+# Symlinks shared files that aren't part of the git tree (credentials, env).
+# Safe to run multiple times — skips files that already exist.
+#
+# Usage: ./scripts/setup-worktree.sh
+#   Run from the worktree root after `pnpm install`.
+
+set -euo pipefail
+
+# Resolve the main repo root by walking up from this script's location
+# to find the nearest .git *file* (worktrees have a .git file, not a directory).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Find the main repo: read the gitdir pointer from the worktree's .git file
+GIT_FILE="$WORKTREE_ROOT/.git"
+if [ -f "$GIT_FILE" ]; then
+  # .git file contains: "gitdir: /path/to/main/.git/worktrees/<name>"
+  GITDIR=$(sed 's/^gitdir: //' "$GIT_FILE")
+  # Walk up from .git/worktrees/<name> to the main repo root
+  MAIN_REPO="$(cd "$GITDIR/../../.." && pwd)"
+else
+  echo "Not running inside a worktree (no .git file). Nothing to do."
+  exit 0
+fi
+
+echo "Worktree root: $WORKTREE_ROOT"
+echo "Main repo:     $MAIN_REPO"
+
+# --- Symlink .env ---
+ENV_SOURCE="$MAIN_REPO/apps/desktop/.env"
+ENV_TARGET="$WORKTREE_ROOT/apps/desktop/.env"
+
+if [ -f "$ENV_SOURCE" ]; then
+  if [ -e "$ENV_TARGET" ]; then
+    echo ".env already exists — skipping"
+  else
+    ln -s "$ENV_SOURCE" "$ENV_TARGET"
+    echo "Symlinked .env"
+  fi
+else
+  echo "Warning: $ENV_SOURCE not found — artwork sync credentials will be missing"
+fi
+
+echo "Worktree setup complete."


### PR DESCRIPTION
## Summary

Closes #246

- **Auto-pause artwork sync when a game launches** — the sync loop blocks at a promise-based gate between games, unblocking when the emulator exits or is terminated
- **Batched library saves during sync** — `updateGameBatched()` updates in-memory state without disk I/O, flushing to `library.json` every 10 games instead of after every single game (eliminates hundreds of redundant atomic writes)
- **"Paused" badge in the sync progress UI** — shows a Pause icon and "Paused N/M" when sync is paused, replacing the pulsing download icon

## Architecture

| Layer | Change |
|-------|--------|
| `ArtworkService` | `pause()` / `resume()` / `isPaused()` / `waitIfPaused()` — promise gate in sync loop, emits `paused` / `resumed` events |
| `LibraryService` | `updateGameBatched()` + `flushSave()` — deferred disk writes with dirty flag |
| IPC handlers | `gameLaunched` → pause, `emulator:exited` / `emulator:terminated` → resume; `artwork:pause` / `artwork:resume` for manual control |
| Preload | New `artwork:syncPaused` / `artwork:syncResumed` channels + `pause()` / `resume()` API methods |
| Renderer | `syncPaused` state, Pause icon badge, cleanup on sync complete/error |

## Test plan

- [x] 5 new ArtworkService tests: pause/resume events, sync loop blocking, cancel-unblocks-pause, no-op when not syncing, getSyncStatus includes paused
- [x] 2 new ArtworkService tests: batched saves during sync vs updateGame for single sync
- [x] 3 new LibraryService tests: batched update doesn't write to disk, flushSave persists, flushSave no-op when clean
- [x] Updated IPC handler count test (37 → 39)
- [x] All 605 tests pass
- [x] Lint, typecheck, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)