### PR TITLE
fix: drop debug-level libretro logs before IPC to prevent UI throttle

### DIFF
--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -4,6 +4,12 @@ import * as path from "node:path";
 import * as crypto from "node:crypto";
 import type { WorkerCommand, WorkerEvent, AVInfo } from "../workers/core-worker-protocol";
 import {
+  RETRO_LOG_DEBUG,
+  RETRO_LOG_INFO,
+  RETRO_LOG_WARN,
+  RETRO_LOG_ERROR,
+} from "../workers/core-worker-protocol";
+import {
   computeVideoBufferSize,
   CTRL_SAB_BYTE_LENGTH,
   CTRL_AUDIO_SAMPLE_RATE,
@@ -356,18 +362,17 @@ export class EmulationWorkerClient extends EventEmitter {
 
       case "log":
         // Route native addon log messages through electron-log.
-        // Libretro log levels: 0=debug, 1=info, 2=warn, 3=error
         switch (event.level) {
-          case 0:
+          case RETRO_LOG_DEBUG:
             libretroLog.debug(event.message);
             break;
-          case 1:
+          case RETRO_LOG_INFO:
             libretroLog.info(event.message);
             break;
-          case 2:
+          case RETRO_LOG_WARN:
             libretroLog.warn(event.message);
             break;
-          case 3:
+          case RETRO_LOG_ERROR:
             libretroLog.error(event.message);
             break;
           default:

--- a/apps/desktop/src/main/workers/core-worker-protocol.test.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterForwardableLogs,
+  RETRO_LOG_DEBUG,
+  RETRO_LOG_INFO,
+  RETRO_LOG_WARN,
+  RETRO_LOG_ERROR,
+  MIN_FORWARD_LOG_LEVEL,
+} from "./core-worker-protocol";
+
+describe("filterForwardableLogs", () => {
+  it("drops debug-level messages", () => {
+    const entries = [
+      { level: RETRO_LOG_DEBUG, message: "GBA DMA: Starting DMA 3 0x03006204 -> 0x0600F1C0" },
+      { level: RETRO_LOG_DEBUG, message: "GBA DMA: Starting DMA 3 0x030068C4 -> 0x0600E1C0" },
+    ];
+
+    expect(filterForwardableLogs(entries)).toEqual([]);
+  });
+
+  it("keeps info, warn, and error messages", () => {
+    const entries = [
+      { level: RETRO_LOG_INFO, message: "Core loaded successfully" },
+      { level: RETRO_LOG_WARN, message: "Save file not found" },
+      { level: RETRO_LOG_ERROR, message: "Failed to open ROM" },
+    ];
+
+    const result = filterForwardableLogs(entries);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(entries);
+  });
+
+  it("filters a mixed batch, keeping only non-debug entries", () => {
+    const entries = [
+      { level: RETRO_LOG_DEBUG, message: "DMA trace 1" },
+      { level: RETRO_LOG_INFO, message: "Loaded BIOS" },
+      { level: RETRO_LOG_DEBUG, message: "DMA trace 2" },
+      { level: RETRO_LOG_DEBUG, message: "DMA trace 3" },
+      { level: RETRO_LOG_ERROR, message: "Audio buffer underrun" },
+      { level: RETRO_LOG_DEBUG, message: "DMA trace 4" },
+    ];
+
+    const result = filterForwardableLogs(entries);
+    expect(result).toEqual([
+      { level: RETRO_LOG_INFO, message: "Loaded BIOS" },
+      { level: RETRO_LOG_ERROR, message: "Audio buffer underrun" },
+    ]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(filterForwardableLogs([])).toEqual([]);
+  });
+
+  it("handles a high-volume debug flood (simulating real-world mGBA output)", () => {
+    // Simulate what mGBA does: hundreds of debug messages per frame drain
+    const entries = Array.from({ length: 500 }, (_, i) => ({
+      level: RETRO_LOG_DEBUG,
+      message: `GBA DMA: Starting DMA 3 0x${i.toString(16).padStart(8, "0")} -> 0x0600F1C0 (8000:001F)`,
+    }));
+    // Sprinkle in one real message
+    entries.push({ level: RETRO_LOG_WARN, message: "Battery save loaded" });
+
+    const result = filterForwardableLogs(entries);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe("Battery save loaded");
+  });
+
+  it("minimum forward level is info (level 1)", () => {
+    expect(MIN_FORWARD_LOG_LEVEL).toBe(1);
+  });
+});

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -99,6 +99,33 @@ export type WorkerCommand =
     };
 
 // ---------------------------------------------------------------------------
+// Libretro log levels (from libretro.h RETRO_LOG_*)
+// ---------------------------------------------------------------------------
+
+export const RETRO_LOG_DEBUG = 0;
+export const RETRO_LOG_INFO = 1;
+export const RETRO_LOG_WARN = 2;
+export const RETRO_LOG_ERROR = 3;
+
+/**
+ * Minimum log level to forward over IPC. Debug-level messages are dropped
+ * because cores like mGBA emit thousands of DMA/IRQ trace messages per
+ * second at that level, which saturates the IPC channel and throttles the
+ * main process event loop.
+ */
+export const MIN_FORWARD_LOG_LEVEL = RETRO_LOG_INFO;
+
+/**
+ * Filter native log entries to only those worth forwarding over IPC.
+ * Returns a new array (empty if nothing passes the filter).
+ */
+export function filterForwardableLogs(
+  entries: ReadonlyArray<{ level: number; message: string }>,
+): Array<{ level: number; message: string }> {
+  return entries.filter((entry) => entry.level >= MIN_FORWARD_LOG_LEVEL);
+}
+
+// ---------------------------------------------------------------------------
 // Worker → Main events
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -427,10 +427,15 @@ function startEmulationLoop(): void {
       }
     }
 
-    // Drain buffered log messages from the native addon
+    // Drain buffered log messages from the native addon.
+    // Skip debug-level (0) messages — cores like mGBA emit thousands of
+    // DMA/IRQ trace messages per second at debug level, which flood IPC
+    // and throttle the main process.
     const logs = native.getLogMessages();
     for (const entry of logs) {
-      send({ type: "log", level: entry.level, message: entry.message });
+      if (entry.level > 0) {
+        send({ type: "log", level: entry.level, message: entry.message });
+      }
     }
 
     scheduleNext();
@@ -498,10 +503,13 @@ function startEmulationLoop(): void {
         }
       }
 
-      // Drain buffered log messages from the native addon
+      // Drain buffered log messages from the native addon.
+      // Skip debug-level (0) — see fast-forward tick comment above.
       const logs = native.getLogMessages();
       for (const entry of logs) {
-        send({ type: "log", level: entry.level, message: entry.message });
+        if (entry.level > 0) {
+          send({ type: "log", level: entry.level, message: entry.message });
+        }
       }
     }
 

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -24,6 +24,7 @@ import {
   CTRL_AUDIO_WRITE_POS,
   CTRL_AUDIO_SAMPLE_RATE,
 } from "./shared-frame-protocol";
+import { filterForwardableLogs } from "./core-worker-protocol";
 
 // ---------------------------------------------------------------------------
 // State
@@ -427,15 +428,9 @@ function startEmulationLoop(): void {
       }
     }
 
-    // Drain buffered log messages from the native addon.
-    // Skip debug-level (0) messages — cores like mGBA emit thousands of
-    // DMA/IRQ trace messages per second at debug level, which flood IPC
-    // and throttle the main process.
-    const logs = native.getLogMessages();
-    for (const entry of logs) {
-      if (entry.level > 0) {
-        send({ type: "log", level: entry.level, message: entry.message });
-      }
+    // Drain buffered log messages, dropping debug-level noise.
+    for (const entry of filterForwardableLogs(native.getLogMessages())) {
+      send({ type: "log", level: entry.level, message: entry.message });
     }
 
     scheduleNext();
@@ -503,13 +498,9 @@ function startEmulationLoop(): void {
         }
       }
 
-      // Drain buffered log messages from the native addon.
-      // Skip debug-level (0) — see fast-forward tick comment above.
-      const logs = native.getLogMessages();
-      for (const entry of logs) {
-        if (entry.level > 0) {
-          send({ type: "log", level: entry.level, message: entry.message });
-        }
+      // Drain buffered log messages, dropping debug-level noise.
+      for (const entry of filterForwardableLogs(native.getLogMessages())) {
+        send({ type: "log", level: entry.level, message: entry.message });
       }
     }
 


### PR DESCRIPTION
## Summary

- Filter out libretro debug-level (0) log messages in the emulation worker's tick loops before they cross the IPC boundary
- Cores like mGBA emit thousands of DMA/IRQ trace messages per second at debug level, which flooded IPC → electron-log → Sentry breadcrumbs and caused severe UI throttling
- Info, warn, and error messages from cores are unaffected

## Context

The bug manifested when launching certain GBA ROMs — the mGBA core outputs verbose DMA transfer traces at debug level. Each frame tick drained all buffered log messages and forwarded every one over IPC to the main process, where each hit:
1. `electron-log` (console write + file write)
2. Sentry breadcrumb creation (via the log hook in `logger.ts`)

At 60fps with dozens of debug messages per frame, this created thousands of IPC roundtrips per second, starving the renderer of event loop time.

## Test plan

- [ ] Launch a GBA ROM that previously caused the log flood — UI should stay responsive
- [ ] Verify info/warn/error messages from cores still appear in logs
- [ ] Confirm no regression in emulation for other platforms (SNES, NES, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)