### PR TITLE
feat: split Game Boy and Game Boy Color into separate systems

### DIFF
--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -1517,6 +1517,123 @@ describe("LibraryService", () => {
     });
   });
 
+  describe("migrateGbcSystem", () => {
+    it("reassigns .gbc games from gb to gbc system on load", async () => {
+      const gbRomPath = path.join(ROMS_DIR, "tetris.gb");
+      const gbcRomPath = path.join(ROMS_DIR, "pokemon_crystal.gbc");
+      fs.writeFileSync(gbRomPath, "gb-content");
+      fs.writeFileSync(gbcRomPath, "gbc-content");
+
+      const gbId = sha256File(gbRomPath);
+      const gbcId = sha256File(gbcRomPath);
+      const gbHashes = computeExpectedHashes("gb-content");
+      const gbcHashes = computeExpectedHashes("gbc-content");
+
+      const games = [
+        {
+          id: gbId,
+          romPath: gbRomPath,
+          romHashes: gbHashes,
+          system: "Game Boy",
+          systemId: "gb",
+          title: "Tetris",
+        },
+        {
+          id: gbcId,
+          romPath: gbcRomPath,
+          romHashes: gbcHashes,
+          system: "Game Boy",
+          systemId: "gb",
+          title: "Pokemon Crystal",
+        },
+      ];
+      fs.writeFileSync(path.join(USER_DATA_DIR, "library.json"), JSON.stringify(games, null, 2));
+
+      const service = await createService();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const loadedGames = service.getGames();
+      expect(loadedGames).toHaveLength(2);
+
+      const gbGame = loadedGames.find((g) => g.id === gbId);
+      const gbcGame = loadedGames.find((g) => g.id === gbcId);
+
+      expect(gbGame?.systemId).toBe("gb");
+      expect(gbGame?.system).toBe("Game Boy");
+
+      expect(gbcGame?.systemId).toBe("gbc");
+      expect(gbcGame?.system).toBe("Game Boy Color");
+
+      fs.unlinkSync(gbRomPath);
+      fs.unlinkSync(gbcRomPath);
+    });
+
+    it("removes .gbc extension from persisted gb system config", async () => {
+      // Write a config where gb still has .gbc in its extensions (pre-migration)
+      const legacyConfig = {
+        autoScan: false,
+        romsBasePath: ROMS_DIR,
+        scanRecursive: true,
+        systems: [
+          {
+            extensions: [".gb", ".gbc", ".sgb"],
+            id: "gb",
+            name: "Game Boy",
+            shortName: "GB",
+          },
+        ],
+      };
+      fs.writeFileSync(
+        path.join(USER_DATA_DIR, "library-config.json"),
+        JSON.stringify(legacyConfig, null, 2),
+      );
+
+      const service = await createService();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const config = service.getConfig();
+      const gbSystem = config.systems.find((s) => s.id === "gb");
+      expect(gbSystem?.extensions).not.toContain(".gbc");
+      expect(gbSystem?.extensions).toContain(".gb");
+      expect(gbSystem?.extensions).toContain(".sgb");
+
+      // GBC system should have been backfilled
+      const gbcSystem = config.systems.find((s) => s.id === "gbc");
+      expect(gbcSystem).toBeDefined();
+      expect(gbcSystem?.extensions).toEqual([".gbc"]);
+    });
+
+    it("is a no-op when no .gbc games exist", async () => {
+      const gbRomPath = path.join(ROMS_DIR, "tetris_noop.gb");
+      fs.writeFileSync(gbRomPath, "gb-only-content");
+
+      const gbId = sha256File(gbRomPath);
+      const gbHashes = computeExpectedHashes("gb-only-content");
+
+      const games = [
+        {
+          id: gbId,
+          romPath: gbRomPath,
+          romHashes: gbHashes,
+          system: "Game Boy",
+          systemId: "gb",
+          title: "Tetris",
+        },
+      ];
+      fs.writeFileSync(path.join(USER_DATA_DIR, "library.json"), JSON.stringify(games, null, 2));
+
+      const service = await createService();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      const loadedGames = service.getGames();
+      expect(loadedGames).toHaveLength(1);
+      expect(loadedGames[0].systemId).toBe("gb");
+      expect(loadedGames[0].system).toBe("Game Boy");
+
+      fs.unlinkSync(gbRomPath);
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // Zip extraction during scan
   // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/services/LibraryService.ts
+++ b/apps/desktop/src/main/services/LibraryService.ts
@@ -102,6 +102,7 @@ export class LibraryService extends EventEmitter {
       this.config = JSON.parse(data);
       await this.backfillNewSystems();
       await this.repairMissingRomsPaths();
+      await this.migrateGbcExtensions();
     } catch {
       // If no config exists, create default
       this.config = {
@@ -259,6 +260,7 @@ export class LibraryService extends EventEmitter {
     this.rebuildRomPathIndex();
     await this.migrateGameIds();
     await this.backfillRomHashes();
+    await this.migrateGbcGames();
   }
 
   /** Rebuild reverse indexes from the current games map. */
@@ -341,6 +343,41 @@ export class LibraryService extends EventEmitter {
     if (changed) {
       this.rebuildRomPathIndex();
       await this.saveLibrary();
+    }
+  }
+
+  /**
+   * Remove ".gbc" from the persisted "gb" system config if still present.
+   * Runs during config loading so new scans use the correct system assignment.
+   */
+  private async migrateGbcExtensions(): Promise<void> {
+    const gbSystem = this.config.systems.find((s) => s.id === "gb");
+    if (gbSystem && gbSystem.extensions.includes(".gbc")) {
+      gbSystem.extensions = gbSystem.extensions.filter((ext) => ext !== ".gbc");
+      await this.saveConfig();
+      libraryLog.info('Removed ".gbc" extension from "gb" system config');
+    }
+  }
+
+  /**
+   * Reassign existing .gbc games from the "gb" system to the new "gbc" system.
+   * Runs during library loading to fix games scanned before the split.
+   */
+  private async migrateGbcGames(): Promise<void> {
+    let changed = false;
+
+    for (const game of this.games.values()) {
+      if (game.systemId === "gb" && game.romPath.toLowerCase().endsWith(".gbc")) {
+        game.systemId = "gbc";
+        game.system = "Game Boy Color";
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      await this.saveLibrary();
+      const count = [...this.games.values()].filter((g) => g.systemId === "gbc").length;
+      libraryLog.info(`Migrated ${count} Game Boy Color game(s) from "gb" to "gbc" system`);
     }
   }
 

--- a/apps/desktop/src/types/artwork.ts
+++ b/apps/desktop/src/types/artwork.ts
@@ -2,6 +2,7 @@
 export const SYSTEM_ID_MAP: Record<string, number> = {
   arcade: 75,
   gb: 9,
+  gbc: 10,
   gba: 12,
   genesis: 1,
   n64: 14,

--- a/apps/desktop/src/types/displayType.ts
+++ b/apps/desktop/src/types/displayType.ts
@@ -13,6 +13,7 @@ export type DisplayType = "crt" | "lcd-handheld" | "lcd-portable";
 const SYSTEM_DISPLAY_MAP: Record<string, DisplayType> = {
   arcade: "crt",
   gb: "lcd-handheld",
+  gbc: "lcd-handheld",
   gba: "lcd-handheld",
   genesis: "crt",
   n64: "crt",

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -67,10 +67,16 @@ export const DEFAULT_SYSTEMS: Array<GameSystem> = [
     shortName: "Genesis",
   },
   {
-    extensions: [".gb", ".gbc", ".sgb"],
+    extensions: [".gb", ".sgb"],
     id: "gb",
     name: "Game Boy",
     shortName: "GB",
+  },
+  {
+    extensions: [".gbc"],
+    id: "gbc",
+    name: "Game Boy Color",
+    shortName: "GBC",
   },
   {
     extensions: [".gba", ".agb"],

--- a/packages/ui/components/ControlsOverlay/controller-layouts.ts
+++ b/packages/ui/components/ControlsOverlay/controller-layouts.ts
@@ -74,6 +74,8 @@ export const SYSTEM_BUTTONS: Record<string, ReadonlySet<number>> = {
   nes: new Set([0, 2, 3, 4, 5, 6, 7, 8]),
   /* Game Boy: same as NES */
   gb: new Set([0, 2, 3, 4, 5, 6, 7, 8]),
+  /* Game Boy Color: same as Game Boy */
+  gbc: new Set([0, 2, 3, 4, 5, 6, 7, 8]),
   /* SNES: all standard buttons */
   snes: new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
   /* GBA: D-pad, A, B, L, R, Select, Start (no X/Y) */

--- a/packages/ui/components/PlatformIcon.tsx
+++ b/packages/ui/components/PlatformIcon.tsx
@@ -18,6 +18,17 @@ const platformIcons: Record<string, React.FC<{ className?: string }>> = {
       <rect x="11" y="10" width="2" height="2" />
     </svg>
   ),
+  GBC: ({ className }) => (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <rect x="6" y="2" width="12" height="20" rx="1.5" />
+      <rect x="8" y="4" width="8" height="7" rx="0.5" />
+      <rect x="9" y="13" width="2" height="2" />
+      <rect x="13" y="13" width="2" height="2" />
+      <rect x="11" y="15" width="2" height="2" />
+      <rect x="11" y="11" width="2" height="2" />
+      <circle cx="15" cy="5.5" r="0.8" />
+    </svg>
+  ),
   GBA: ({ className }) => (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor">
       <rect x="4" y="8" width="16" height="8" rx="2" />


### PR DESCRIPTION
## Summary

Closes the gap where Game Boy Color (.gbc) ROMs were grouped under the generic "Game Boy" system. They now appear as a distinct "GBC" system in the library.

- Adds new `gbc` system (`id: "gbc"`, `shortName: "GBC"`, extension: `.gbc`)
- Removes `.gbc` from the `gb` system (now `.gb` and `.sgb` only)
- Adds ScreenScraper mapping (`gbc: 10`) for artwork lookups
- Adds display type, platform icon, and controller layout for GBC
- Migrates existing `.gbc` games from `gb` → `gbc` on startup
- Cleans `.gbc` from persisted `gb` system configs on startup

## Test plan

- [x] 3 new migration tests added (game reassignment, config cleanup, no-op when no .gbc games)
- [x] All 614 existing tests pass
- [x] Lint, typecheck, and format pass
- [ ] Manual: scan a directory with both `.gb` and `.gbc` files, verify they appear under separate systems
- [ ] Manual: verify artwork sync works for GBC games (ScreenScraper system ID 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)