### PR TITLE
feat: auto-sync artwork on library load

### DIFF
--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -311,7 +311,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(39);
+      expect(handleCalls).toHaveLength(41);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -647,6 +647,15 @@ export class IPCHandlers {
         return { success: false, error: errorMessage(error) };
       }
     });
+
+    ipcMain.handle("artwork:isCredentialPromptDismissed", () => {
+      return this.artworkService.isCredentialPromptDismissed();
+    });
+
+    ipcMain.handle("artwork:dismissCredentialPrompt", async () => {
+      await this.artworkService.dismissCredentialPrompt();
+      return { success: true };
+    });
   }
 
   private setupDialogHandlers(): void {

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -188,6 +188,42 @@ describe("ArtworkService", () => {
     });
   });
 
+  describe("credential prompt dismissal", () => {
+    it("is not dismissed by default", async () => {
+      const service = new ArtworkService(createMockLibraryService());
+      await flushPromises();
+
+      expect(service.isCredentialPromptDismissed()).toBe(false);
+    });
+
+    it("reports dismissed after calling dismissCredentialPrompt", async () => {
+      const service = new ArtworkService(createMockLibraryService());
+      await flushPromises();
+
+      await service.dismissCredentialPrompt();
+      expect(service.isCredentialPromptDismissed()).toBe(true);
+    });
+
+    it("persists dismissal to config file", async () => {
+      const service = new ArtworkService(createMockLibraryService());
+      await flushPromises();
+
+      await service.dismissCredentialPrompt();
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        "/tmp/gamelord-test/artwork-config.json",
+        expect.stringContaining('"credentialPromptDismissed": true'),
+      );
+    });
+
+    it("loads dismissed state from persisted config", async () => {
+      mockReadFile.mockResolvedValue(JSON.stringify({ credentialPromptDismissed: true }));
+      const service = new ArtworkService(createMockLibraryService());
+      await flushPromises();
+
+      expect(service.isCredentialPromptDismissed()).toBe(true);
+    });
+  });
+
   describe("syncAllGames", () => {
     it("returns immediately if already syncing", async () => {
       const game = makeGame();

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -258,6 +258,17 @@ export class ArtworkService extends EventEmitter {
     await this.saveConfig();
   }
 
+  /** Whether the user has permanently dismissed the credential setup prompt. */
+  isCredentialPromptDismissed(): boolean {
+    return this.config.credentialPromptDismissed === true;
+  }
+
+  /** Persist the user's choice to never be prompted for credentials again. */
+  async dismissCredentialPrompt(): Promise<void> {
+    this.config.credentialPromptDismissed = true;
+    await this.saveConfig();
+  }
+
   /**
    * Run the full artwork pipeline for a single game.
    * Returns true if artwork was found and downloaded.

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -171,6 +171,9 @@ contextBridge.exposeInMainWorld("gamelord", {
     setCredentials: (userId: string, userPassword: string) =>
       ipcRenderer.invoke("artwork:setCredentials", userId, userPassword),
     clearCredentials: () => ipcRenderer.invoke("artwork:clearCredentials"),
+    isCredentialPromptDismissed: () =>
+      ipcRenderer.invoke("artwork:isCredentialPromptDismissed") as Promise<boolean>,
+    dismissCredentialPrompt: () => ipcRenderer.invoke("artwork:dismissCredentialPrompt"),
   },
 
   // SharedArrayBuffer frame port (zero-copy frame/audio transfer)

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -84,6 +84,7 @@ export const LibraryView: React.FC<{
   const [credentialPassword, setCredentialPassword] = useState("");
   const [credentialError, setCredentialError] = useState("");
   const [isValidatingCredentials, setIsValidatingCredentials] = useState(false);
+  const [dontAskAgain, setDontAskAgain] = useState(false);
   /** Notification banner shown after sync completes or errors. */
   const [syncNotification, setSyncNotification] = useState<{
     message: string;
@@ -153,6 +154,22 @@ export const LibraryView: React.FC<{
       if (loadedGames.length > 0) {
         // Library has games — no need to wait for homebrew import.
         setIsImportingHomebrew(false);
+
+        // Auto-sync artwork for any games missing cover art
+        try {
+          const { hasCredentials } = await api.artwork.getCredentials();
+          if (hasCredentials) {
+            await api.artwork.syncAll();
+          } else {
+            // No credentials — prompt unless the user previously opted out
+            const dismissed = await api.artwork.isCredentialPromptDismissed();
+            if (!dismissed) {
+              setShowCredentialsDialog(true);
+            }
+          }
+        } catch (error) {
+          console.error("Auto-sync check failed:", error);
+        }
       } else {
         // Library is empty. Check if the homebrew import check already
         // completed (the event may have fired before we registered our
@@ -505,23 +522,6 @@ export const LibraryView: React.FC<{
 
   const isSyncing = syncCounter !== null;
 
-  const handleDownloadArtwork = async () => {
-    const { hasCredentials } = await api.artwork.getCredentials();
-    if (!hasCredentials) {
-      setShowCredentialsDialog(true);
-      return;
-    }
-    // Sort by title so artwork loads in the same order the user sees in the grid
-    const sortedIds = [...games].sort((a, b) => a.title.localeCompare(b.title)).map((g) => g.id);
-    await api.artwork.syncGames(sortedIds);
-  };
-
-  const handleCancelArtworkSync = async () => {
-    await api.artwork.cancelSync();
-    setSyncCounter(null);
-    artworkSyncStore.clear();
-  };
-
   const handleSaveCredentials = async () => {
     if (!credentialUserId || !credentialPassword) {
       setCredentialError("Both username and password are required.");
@@ -751,14 +751,6 @@ export const LibraryView: React.FC<{
         onSelect: () => void handleSelectDirectory(),
         keywords: ["browse", "directory", "import"],
       },
-      {
-        id: "download-artwork",
-        label: "Download Artwork",
-        group: "Actions",
-        icon: <ImageDown className="h-4 w-4 mr-3 shrink-0 text-muted-foreground" />,
-        onSelect: () => void handleDownloadArtwork(),
-        keywords: ["art", "cover", "metadata", "sync"],
-      },
     ];
     return [...libraryActions, ...commandPaletteActions];
   }, [commandPaletteActions]);
@@ -816,30 +808,8 @@ export const LibraryView: React.FC<{
                 <ImageDown className="h-3 w-3 animate-pulse" />
               )}
               {syncPaused ? "Paused" : "Syncing"} {syncCounter.current}/{syncCounter.total}
-              <button
-                onClick={() => {
-                  playSfx("click");
-                  void handleCancelArtworkSync();
-                }}
-                className="ml-1 hover:text-destructive transition-colors"
-                aria-label="Cancel artwork sync"
-              >
-                <X className="h-3 w-3" />
-              </button>
             </Badge>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              playSfx("click");
-              void handleDownloadArtwork();
-            }}
-            disabled={isSyncing}
-          >
-            <ImageDown className="h-4 w-4 mr-2" />
-            Download Artwork
-          </Button>
           <Button
             variant="outline"
             size="sm"
@@ -1062,35 +1032,52 @@ export const LibraryView: React.FC<{
               </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => {
-                playSfx("dialogClose");
-                setCredentialUserId("");
-                setCredentialPassword("");
-                setCredentialError("");
-              }}
-            >
-              Cancel
-            </AlertDialogCancel>
-            {/* Use a regular Button instead of AlertDialogAction to prevent
-                the dialog from auto-closing when validation fails. */}
-            <Button
-              onClick={() => {
-                playSfx("click");
-                void handleSaveCredentials();
-              }}
-              disabled={isValidatingCredentials}
-            >
-              {isValidatingCredentials ? (
-                <>
-                  <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
-                  Validating...
-                </>
-              ) : (
-                "Save & Download"
-              )}
-            </Button>
+          <AlertDialogFooter className="flex-col gap-3 sm:flex-col">
+            <div className="flex items-center justify-between w-full">
+              <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
+                <input
+                  checked={dontAskAgain}
+                  className="rounded border-input"
+                  onChange={(e) => setDontAskAgain(e.target.checked)}
+                  type="checkbox"
+                />
+                Don&apos;t ask again
+              </label>
+              <div className="flex gap-2">
+                <AlertDialogCancel
+                  onClick={() => {
+                    playSfx("dialogClose");
+                    if (dontAskAgain) {
+                      void api.artwork.dismissCredentialPrompt();
+                    }
+                    setCredentialUserId("");
+                    setCredentialPassword("");
+                    setCredentialError("");
+                    setDontAskAgain(false);
+                  }}
+                >
+                  Cancel
+                </AlertDialogCancel>
+                {/* Use a regular Button instead of AlertDialogAction to prevent
+                    the dialog from auto-closing when validation fails. */}
+                <Button
+                  onClick={() => {
+                    playSfx("click");
+                    void handleSaveCredentials();
+                  }}
+                  disabled={isValidatingCredentials}
+                >
+                  {isValidatingCredentials ? (
+                    <>
+                      <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                      Validating...
+                    </>
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              </div>
+            </div>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -75,6 +75,8 @@ export interface GamelordAPI {
       userPassword: string,
     ) => Promise<{ success: boolean; error?: string; errorCode?: string }>;
     clearCredentials: () => Promise<{ success: boolean; error?: string }>;
+    isCredentialPromptDismissed: () => Promise<boolean>;
+    dismissCredentialPrompt: () => Promise<{ success: boolean }>;
   };
 
   // Auto-updates

--- a/apps/desktop/src/types/artwork.ts
+++ b/apps/desktop/src/types/artwork.ts
@@ -80,6 +80,8 @@ export interface ScreenScraperGameInfo {
 }
 
 export interface ArtworkConfig {
+  /** User dismissed the credential setup prompt ("don't ask again"). */
+  credentialPromptDismissed?: boolean;
   preferences?: {
     autoSyncOnScan: boolean;
     preferredRegion: string;


### PR DESCRIPTION
## Summary

- Artwork sync now runs automatically when the library loads — no manual button needed
- If ScreenScraper credentials aren't configured, a prompt appears with a "Don't ask again" checkbox
- Removed the "Download Artwork" button from the header toolbar and command palette
- Removed the cancel X from the sync progress badge (now a passive status indicator)
- Single-game sync via right-click context menu is unchanged

## Test plan

- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 632/632 tests pass (4 new tests for dismiss methods)
- [ ] Manual: launch app with credentials configured → artwork sync starts automatically
- [ ] Manual: launch app without credentials → dialog prompts automatically
- [ ] Manual: dismiss with "Don't ask again" checked → dialog does not reappear on next launch
- [ ] Manual: dismiss without checkbox → dialog reappears on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)