### PR TITLE
fix: CI path filters that never actually skipped docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       ui: ${{ steps.filter.outputs.ui }}
+      native: ${{ steps.filter.outputs.native }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,13 +30,22 @@ jobs:
         with:
           filters: |
             code:
-              - '!**/*.md'
-              - '!LICENSE'
-              - '!.gitignore'
-              - '!docs/**'
+              - 'apps/**'
+              - 'packages/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'turbo.json'
+              - 'tsconfig*.json'
+              - 'oxlint.config.ts'
+              - 'vercel.json'
+              - '.github/workflows/**'
             ui:
               - 'packages/ui/**'
               - 'apps/desktop/src/renderer/components/**'
+            native:
+              - 'apps/desktop/native/**'
 
   lint-typecheck-format:
     name: Lint, Type Check & Format
@@ -141,14 +151,10 @@ jobs:
       - run: echo "No code changes detected — skipping"
 
   native-addon:
-    name: Native Addon Build (${{ matrix.os }})
+    name: Native Addon Build (macos-latest)
     needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
+    if: needs.changes.outputs.native == 'true'
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -166,12 +172,9 @@ jobs:
         run: npx node-gyp rebuild
 
   native-addon-skip:
-    name: Native Addon Build (${{ matrix.os }})
+    name: Native Addon Build (macos-latest)
     needs: changes
-    if: needs.changes.outputs.code != 'true'
+    if: needs.changes.outputs.native != 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
     steps:
-      - run: echo "No code changes detected — skipping"
+      - run: echo "No native addon changes detected — skipping"


### PR DESCRIPTION
## Summary

- **The `code` path filter was broken and always returned true.** It used negation-only patterns (`!**/*.md`, `!LICENSE`, etc.) with `dorny/paths-filter`, which uses OR logic by default — a `.md` file fails `!**/*.md` but passes `!LICENSE`, so every PR matched. This means docs-only PRs (like #261 which only changed `DEVELOPMENT_PLAN.md`) ran the full CI pipeline including native addon builds.
- **Replaced with explicit positive patterns** (`apps/**`, `packages/**`, `scripts/**`, config files, workflows) that correctly match only when actual source/config files change.
- **Added a `native` filter** scoped to `apps/desktop/native/**` so the native addon build only runs when C++/gyp files change — not on every code PR.
- **Dropped the Windows native addon matrix entry** which wasn't a required status check and was burning a Windows runner on every code PR unnecessarily.

## What changes for docs-only PRs

Before: Lint + Typecheck + Tests + Chromatic + Native Addon (macOS + Windows) all run
After: Only the skip jobs run (fast no-op to satisfy required checks)

## Test plan

- [ ] Verify this PR's own CI run: `Detect Changes` should show `code=true` (since `.github/workflows/**` is a positive pattern), running lint/tests but skipping native addon
- [ ] After merge, a docs-only PR should show `code=false` and `native=false`, running only skip jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)