### PR TITLE
perf: allow artwork sync to continue during gameplay

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -96,7 +96,7 @@ Items are grouped by priority. Work top-down within each tier.
 - [x] **Fix test environment** — Switch vitest config from jsdom to happy-dom (per project conventions)
 - [x] **Fix game ID hashing** — Replace `MD5(romPath)` in `LibraryService.ts` with `SHA-256(fileContent)` so IDs survive file moves
 - [x] **ROM checksum validation** — Compute CRC32/SHA-1/MD5 checksums on ROM files at scan time via single-pass streaming. Stored in required `romHashes` field on `Game`. Backfill on startup for existing libraries. ArtworkService simplified to use pre-computed MD5. — [#61](https://github.com/ryanmagoon/gamelord/issues/61)
-- [x] **Artwork sync auto-pause during gameplay** — Artwork sync now auto-pauses when a game launches and resumes when the emulator exits, preventing main process event loop contention. Also batches library.json writes (every 10 games instead of every game) to reduce I/O. Renderer shows a "Paused" badge. — [#246](https://github.com/ryanmagoon/gamelord/issues/246)
+- [x] **Artwork sync continues during gameplay** — Replaced the hard auto-pause with three targeted optimizations so artwork sync runs transparently during gameplay: (1) JSON.stringify offloaded to a worker thread so large library serialization doesn't block the main event loop, (2) artwork progress IPC events scoped to library windows only (no longer broadcast to game windows), (3) disk flushes deferred during gameplay and flushed when the game exits. — [#246](https://github.com/ryanmagoon/gamelord/issues/246)
 
 ### P2 — Performance
 

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -498,6 +498,16 @@ export class GameWindowManager extends EventEmitter {
     return this.gameWindows.get(gameId);
   }
 
+  /** Returns true if the given BrowserWindow is a game window managed by this class. */
+  isGameWindow(window: BrowserWindow): boolean {
+    for (const gw of this.gameWindows.values()) {
+      if (gw === window) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private setupIpcHandlers(): void {
     ipcMain.on("game-window:minimize", (event) => {
       const window = BrowserWindow.fromWebContents(event.sender);

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -311,7 +311,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(41);
+      expect(handleCalls).toHaveLength(39);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -332,12 +332,14 @@ export class IPCHandlers {
 
     this.emulatorManager.on("gameLaunched", (data) => {
       forwardEvent("emulator:launched", data);
-      // Auto-pause artwork sync during gameplay to avoid I/O contention
-      this.artworkService.pause();
+      // Tell artwork sync to defer disk flushes during gameplay.
+      // Sync continues (API calls + image downloads are non-blocking),
+      // but we skip flushSave() to avoid any remaining event loop pressure.
+      this.artworkService.setGameplayActive(true);
     });
     this.emulatorManager.on("emulator:exited", (data) => {
       forwardEvent("emulator:exited", data);
-      this.artworkService.resume();
+      this.artworkService.setGameplayActive(false);
     });
     this.emulatorManager.on("emulator:error", (error) => forwardEvent("emulator:error", error));
     this.emulatorManager.on("emulator:stateSaved", (data) =>
@@ -357,16 +359,16 @@ export class IPCHandlers {
     );
     this.emulatorManager.on("emulator:terminated", () => {
       forwardEvent("emulator:terminated");
-      this.artworkService.resume();
+      this.artworkService.setGameplayActive(false);
     });
     this.emulatorManager.on("core:downloadProgress", (data) =>
       forwardEvent("core:downloadProgress", data),
     );
 
     // Native mode: game window close doesn't go through EmulatorManager events,
-    // so we listen on GameWindowManager directly to resume artwork sync.
+    // so we listen on GameWindowManager directly to end gameplay mode.
     this.gameWindowManager.on("gameWindowClosed", () => {
-      this.artworkService.resume();
+      this.artworkService.setGameplayActive(false);
     });
   }
 
@@ -550,18 +552,22 @@ export class IPCHandlers {
   }
 
   private setupArtworkHandlers(): void {
-    // Forward artwork progress events to all renderer windows
-    const forwardEvent = (eventName: string, data?: unknown) => {
+    // Forward artwork events only to non-game windows (library UI).
+    // Broadcasting to game windows wastes IPC bandwidth and adds event loop
+    // pressure during gameplay — the game window doesn't use these events.
+    const forwardToLibraryWindows = (eventName: string, data?: unknown) => {
       const windows = BrowserWindow.getAllWindows();
-      windows.forEach((window: BrowserWindow) => {
-        window.webContents.send(eventName, data);
-      });
+      for (const window of windows) {
+        if (!this.gameWindowManager.isGameWindow(window)) {
+          window.webContents.send(eventName, data);
+        }
+      }
     };
 
-    this.artworkService.on("progress", (data) => forwardEvent("artwork:progress", data));
-    this.artworkService.on("syncComplete", (data) => forwardEvent("artwork:syncComplete", data));
-    this.artworkService.on("paused", () => forwardEvent("artwork:syncPaused"));
-    this.artworkService.on("resumed", () => forwardEvent("artwork:syncResumed"));
+    this.artworkService.on("progress", (data) => forwardToLibraryWindows("artwork:progress", data));
+    this.artworkService.on("syncComplete", (data) =>
+      forwardToLibraryWindows("artwork:syncComplete", data),
+    );
 
     ipcMain.handle("artwork:syncGame", async (_event, gameId: string) => {
       try {
@@ -577,7 +583,7 @@ export class IPCHandlers {
       const syncPromise = this.artworkService.syncAllGames();
       syncPromise.catch((error) => {
         ipcLog.error("Artwork sync failed:", error);
-        forwardEvent("artwork:syncError", {
+        forwardToLibraryWindows("artwork:syncError", {
           error: error instanceof Error ? error.message : String(error),
           errorCode: error instanceof ScreenScraperError ? error.errorCode : undefined,
         });
@@ -590,7 +596,7 @@ export class IPCHandlers {
       const syncPromise = this.artworkService.syncGames(gameIds);
       syncPromise.catch((error) => {
         ipcLog.error("Artwork sync for imported games failed:", error);
-        forwardEvent("artwork:syncError", {
+        forwardToLibraryWindows("artwork:syncError", {
           error: error instanceof Error ? error.message : String(error),
           errorCode: error instanceof ScreenScraperError ? error.errorCode : undefined,
         });
@@ -600,16 +606,6 @@ export class IPCHandlers {
 
     ipcMain.handle("artwork:cancelSync", () => {
       this.artworkService.cancelSync();
-      return { success: true };
-    });
-
-    ipcMain.handle("artwork:pause", () => {
-      this.artworkService.pause();
-      return { success: true };
-    });
-
-    ipcMain.handle("artwork:resume", () => {
-      this.artworkService.resume();
       return { success: true };
     });
 

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -818,28 +818,65 @@ describe("ArtworkService", () => {
     });
   });
 
-  describe("pause/resume", () => {
-    it("emits paused/resumed events", async () => {
-      const game = makeGame({
-        id: "g1",
-        title: "Game 1",
-        coverArt: undefined,
-      });
-      const lib = createMockLibraryService([game]);
+  describe("gameplay-aware sync", () => {
+    it("defers flushSave during gameplay", async () => {
+      // Create 12 games so we cross the 10-game flush threshold
+      const games = Array.from({ length: 12 }, (_, i) =>
+        makeGame({ id: `g${i}`, title: `Game ${i}`, coverArt: undefined }),
+      );
+      const lib = createMockLibraryService(games);
       const service = new ArtworkService(lib);
       await flushPromises();
-
-      // Store config so createClient works
       await service.setCredentials("user1", "pass1");
       await flushPromises();
 
-      const events: Array<string> = [];
-      service.on("paused", () => events.push("paused"));
-      service.on("resumed", () => events.push("resumed"));
+      mockFetchByHash.mockResolvedValue(null);
 
-      // Start sync — the sync loop will process game1 and complete
-      // We need to pause before it processes the game.
-      // Mock fetchByHash to stall so we can pause mid-sync.
+      // Activate gameplay mode before starting sync
+      service.setGameplayActive(true);
+      expect(service.isGameplayActive()).toBe(true);
+
+      await service.syncAllGames();
+
+      // flushSave should NOT have been called at the 10-game checkpoint
+      // (only the final flush at the end of the batch)
+      expect(lib.flushSave).toHaveBeenCalledTimes(1);
+    });
+
+    it("flushes normally when gameplay is not active", async () => {
+      const games = Array.from({ length: 12 }, (_, i) =>
+        makeGame({ id: `g${i}`, title: `Game ${i}`, coverArt: undefined }),
+      );
+      const lib = createMockLibraryService(games);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+      await service.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      mockFetchByHash.mockResolvedValue(null);
+
+      await service.syncAllGames();
+
+      // 10-game checkpoint flush + final flush = 2 calls
+      expect(lib.flushSave).toHaveBeenCalledTimes(2);
+    });
+
+    it("flushes deferred writes when gameplay ends", async () => {
+      const lib = createMockLibraryService([]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+
+      // Simulate: sync is running and gameplay was active
+      // setGameplayActive(false) should trigger a flush
+      // We need to fake the syncing state
+      const games = [makeGame({ id: "g1", title: "Game 1", coverArt: undefined })];
+      const libWithGame = createMockLibraryService(games);
+      const serviceWithGame = new ArtworkService(libWithGame);
+      await flushPromises();
+      await serviceWithGame.setCredentials("user1", "pass1");
+      await flushPromises();
+
+      // Stall the sync so we can test gameplay toggle mid-sync
       const stallControl = { resolve: () => {} };
       mockFetchByHash.mockImplementation(
         () =>
@@ -848,25 +885,28 @@ describe("ArtworkService", () => {
           }),
       );
 
-      const syncPromise = service.syncAllGames();
-
-      // Wait for the stall to be set up
+      serviceWithGame.setGameplayActive(true);
+      const syncPromise = serviceWithGame.syncAllGames();
       await flushPromises();
 
-      service.pause();
-      expect(events).toContain("paused");
-      expect(service.isPaused()).toBe(true);
+      // End gameplay while sync is in progress — should trigger flush
+      serviceWithGame.setGameplayActive(false);
+      expect(libWithGame.flushSave).toHaveBeenCalled();
 
-      service.resume();
-      expect(events).toContain("resumed");
-      expect(service.isPaused()).toBe(false);
-
-      // Unblock the stalled request and let sync finish
       stallControl.resolve();
       await syncPromise;
     });
 
-    it("blocks the sync loop when paused and resumes on resume()", async () => {
+    it("getSyncStatus reflects inProgress state", async () => {
+      const lib = createMockLibraryService([]);
+      const service = new ArtworkService(lib);
+      await flushPromises();
+
+      const status = service.getSyncStatus();
+      expect(status).toEqual({ inProgress: false });
+    });
+
+    it("continues syncing during gameplay instead of pausing", async () => {
       const games = [
         makeGame({ id: "g1", title: "Game 1", coverArt: undefined }),
         makeGame({ id: "g2", title: "Game 2", coverArt: undefined }),
@@ -883,81 +923,14 @@ describe("ArtworkService", () => {
         return null;
       });
 
-      // After processing game 1, pause
-      service.on("progress", (p: ArtworkProgress) => {
-        if (p.gameId === "g1" && p.phase === "not-found") {
-          service.pause();
-        }
-      });
+      // Activate gameplay before sync
+      service.setGameplayActive(true);
 
-      const syncPromise = service.syncAllGames();
-      // Let game 1 finish
-      await flushPromises();
-      await new Promise((r) => setTimeout(r, 50));
+      await service.syncAllGames();
 
-      // Only game 1 should have been queried (hash + name = 2 calls)
-      const callsBeforeResume = callCount;
-
-      // Resume and let sync finish
-      service.resume();
-      await syncPromise;
-
-      // Game 2 should now also have been queried
-      expect(callCount).toBeGreaterThan(callsBeforeResume);
-    });
-
-    it("cancel unblocks a paused sync", async () => {
-      const games = [
-        makeGame({ id: "g1", title: "Game 1", coverArt: undefined }),
-        makeGame({ id: "g2", title: "Game 2", coverArt: undefined }),
-      ];
-      const lib = createMockLibraryService(games);
-      const service = new ArtworkService(lib);
-      await flushPromises();
-      await service.setCredentials("user1", "pass1");
-      await flushPromises();
-
-      mockFetchByHash.mockResolvedValue(null);
-
-      // Pause after game 1 finishes
-      service.on("progress", (p: ArtworkProgress) => {
-        if (p.gameId === "g1" && p.phase === "not-found") {
-          service.pause();
-        }
-      });
-
-      const syncPromise = service.syncAllGames();
-      // Let game 1 process and trigger the pause
-      await new Promise((r) => setTimeout(r, 50));
-
-      expect(service.isPaused()).toBe(true);
-
-      // Cancel should unblock and finish the sync
-      service.cancelSync();
-      expect(service.isPaused()).toBe(false);
-
-      await syncPromise;
-    });
-
-    it("pause is a no-op when not syncing", () => {
-      const lib = createMockLibraryService([]);
-      const service = new ArtworkService(lib);
-
-      const events: Array<string> = [];
-      service.on("paused", () => events.push("paused"));
-
-      service.pause();
-      expect(events).toHaveLength(0);
-      expect(service.isPaused()).toBe(false);
-    });
-
-    it("getSyncStatus includes paused state", async () => {
-      const lib = createMockLibraryService([]);
-      const service = new ArtworkService(lib);
-      await flushPromises();
-
-      const status = service.getSyncStatus();
-      expect(status).toEqual({ inProgress: false, paused: false });
+      // Both games should have been processed — sync was not blocked
+      // Each game: 1 fetchByHash call, 2 games = 2 calls
+      expect(callCount).toBe(2);
     });
   });
 

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -59,8 +59,7 @@ export class ArtworkService extends EventEmitter {
   private config: ArtworkConfig = {};
   private cancelled = false;
   private syncing = false;
-  private paused = false;
-  private pauseResolve: (() => void) | null = null;
+  private gameplayActive = false;
   private lastRequestTime = 0;
   private configLoaded: Promise<void>;
 
@@ -428,47 +427,30 @@ export class ArtworkService extends EventEmitter {
   /** Cancel an in-progress bulk sync. */
   cancelSync(): void {
     this.cancelled = true;
-    // If paused, unblock so the loop can exit
-    if (this.pauseResolve) {
-      this.pauseResolve();
-      this.pauseResolve = null;
-    }
-    this.paused = false;
   }
 
   /**
-   * Pause the sync loop after the current game finishes processing.
-   * The loop blocks at the next `waitIfPaused()` checkpoint until `resume()` is called.
+   * Signal that a game is actively running (or has stopped).
+   * During gameplay, the sync loop continues but defers disk flushes
+   * to avoid any event loop pressure from JSON serialization + file I/O.
+   * Deferred flushes run automatically when gameplay ends.
    */
-  pause(): void {
-    if (!this.syncing || this.paused) {
-      return;
+  setGameplayActive(active: boolean): void {
+    this.gameplayActive = active;
+    if (!active && this.syncing) {
+      // Gameplay ended — flush any deferred writes immediately
+      void this.libraryService.flushSave();
     }
-    this.paused = true;
-    this.emit("paused");
   }
 
-  /** Resume a paused sync loop. */
-  resume(): void {
-    if (!this.paused) {
-      return;
-    }
-    this.paused = false;
-    if (this.pauseResolve) {
-      this.pauseResolve();
-      this.pauseResolve = null;
-    }
-    this.emit("resumed");
-  }
-
-  /** Returns whether the sync is currently paused. */
-  isPaused(): boolean {
-    return this.paused;
+  /** Returns whether gameplay is currently active. */
+  isGameplayActive(): boolean {
+    return this.gameplayActive;
   }
 
   /** Get current sync status. */
-  getSyncStatus(): { inProgress: boolean; paused: boolean } {
-    return { inProgress: this.syncing, paused: this.paused };
+  getSyncStatus(): { inProgress: boolean } {
+    return { inProgress: this.syncing };
   }
 
   /**
@@ -583,13 +565,6 @@ export class ArtworkService extends EventEmitter {
         break;
       }
 
-      // If paused (e.g. during gameplay), block here until resumed
-      await this.waitIfPaused();
-
-      if (this.cancelled) {
-        break;
-      }
-
       const game = this.libraryService.getGame(gameId);
       if (!game) {
         processed++;
@@ -662,8 +637,10 @@ export class ArtworkService extends EventEmitter {
 
       processed++;
 
-      // Flush batched saves to disk every 10 games to bound data loss on crash
-      if (processed % 10 === 0) {
+      // Flush batched saves to disk every 10 games to bound data loss on crash.
+      // During gameplay, defer flushing to avoid any event loop pressure —
+      // the in-memory state is already updated and flushes when gameplay ends.
+      if (processed % 10 === 0 && !this.gameplayActive) {
         await this.libraryService.flushSave();
       }
     }
@@ -672,8 +649,7 @@ export class ArtworkService extends EventEmitter {
     await this.libraryService.flushSave();
 
     this.syncing = false;
-    this.paused = false;
-    this.pauseResolve = null;
+    this.gameplayActive = false;
     const status: ArtworkSyncStatus = {
       inProgress: false,
       processed,
@@ -684,16 +660,6 @@ export class ArtworkService extends EventEmitter {
     };
     this.emit("syncComplete", status);
     return status;
-  }
-
-  /** Block until the sync is unpaused. Returns immediately if not paused. */
-  private waitIfPaused(): Promise<void> {
-    if (!this.paused) {
-      return Promise.resolve();
-    }
-    return new Promise<void>((resolve) => {
-      this.pauseResolve = resolve;
-    });
   }
 
   /** Enforce rate limiting by waiting if needed since the last API request. */

--- a/apps/desktop/src/main/services/LibraryService.ts
+++ b/apps/desktop/src/main/services/LibraryService.ts
@@ -2,6 +2,7 @@ import { promises as fs, createReadStream } from "node:fs";
 import path from "node:path";
 import { app } from "electron";
 import { EventEmitter } from "node:events";
+import { Worker } from "node:worker_threads";
 import {
   Game,
   GameSystem,
@@ -221,11 +222,15 @@ export class LibraryService extends EventEmitter {
    * Writes to a `.tmp` file first, renames the existing file to `.bak`,
    * then renames `.tmp` to the final path. This ensures the file is
    * never in a partially-written state.
+   *
+   * JSON serialization runs in a worker thread to avoid blocking the main
+   * process event loop — large libraries (1000+ games) can take 10-50ms+
+   * to stringify, which starves frame/audio IPC during gameplay.
    */
   private async atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
     const tmpPath = `${filePath}.tmp`;
     const bakPath = `${filePath}.bak`;
-    const content = JSON.stringify(data, null, 2);
+    const content = await this.stringifyInWorker(data);
 
     await fs.writeFile(tmpPath, content, "utf8");
 
@@ -236,6 +241,37 @@ export class LibraryService extends EventEmitter {
     }
 
     await fs.rename(tmpPath, filePath);
+  }
+
+  /**
+   * Serialize data to JSON in a worker thread to keep the main event loop free.
+   * Spawns a short-lived worker for each call — the overhead (~2ms) is negligible
+   * compared to the stringify time it offloads, and avoids managing a persistent worker.
+   * Falls back to synchronous stringify if the worker file isn't found (e.g. in tests).
+   */
+  private stringifyInWorker(data: unknown): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const workerPath = path.join(__dirname, "../workers/json-stringify-worker.js");
+      let worker: Worker;
+      try {
+        worker = new Worker(workerPath);
+      } catch {
+        // Worker file doesn't exist (tests, or pre-build). Fall back to sync stringify.
+        resolve(JSON.stringify(data, null, 2));
+        return;
+      }
+      worker.on("message", (content: string) => {
+        resolve(content);
+        void worker.terminate();
+      });
+      worker.on("error", (err: Error) => {
+        // Worker failed — fall back to sync stringify rather than crashing
+        resolve(JSON.stringify(data, null, 2));
+        void worker.terminate();
+        libraryLog.warn("JSON stringify worker failed, fell back to sync:", err.message);
+      });
+      worker.postMessage(data);
+    });
   }
 
   private async saveConfig(): Promise<void> {

--- a/apps/desktop/src/main/workers/json-stringify-worker.ts
+++ b/apps/desktop/src/main/workers/json-stringify-worker.ts
@@ -1,0 +1,15 @@
+/**
+ * Worker thread for offloading JSON.stringify from the main thread.
+ *
+ * Large libraries (1000+ games) can take 10-50ms+ to serialize, which blocks
+ * the main process event loop and starves frame/audio IPC during gameplay.
+ * Running serialization in a worker thread keeps the event loop free.
+ */
+import { parentPort } from "node:worker_threads";
+
+if (parentPort) {
+  parentPort.on("message", (data: unknown) => {
+    const content = JSON.stringify(data, null, 2);
+    parentPort?.postMessage(content);
+  });
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -92,8 +92,6 @@ contextBridge.exposeInMainWorld("gamelord", {
       "artwork:progress",
       "artwork:syncComplete",
       "artwork:syncError",
-      "artwork:syncPaused",
-      "artwork:syncResumed",
       "dialog:showResumeGame",
       "game:prepare-close",
       "game:emulation-error",
@@ -164,8 +162,6 @@ contextBridge.exposeInMainWorld("gamelord", {
     syncAll: () => ipcRenderer.invoke("artwork:syncAll"),
     syncGames: (gameIds: Array<string>) => ipcRenderer.invoke("artwork:syncGames", gameIds),
     cancelSync: () => ipcRenderer.invoke("artwork:cancelSync"),
-    pause: () => ipcRenderer.invoke("artwork:pause"),
-    resume: () => ipcRenderer.invoke("artwork:resume"),
     getSyncStatus: () => ipcRenderer.invoke("artwork:getSyncStatus"),
     getCredentials: () => ipcRenderer.invoke("artwork:getCredentials"),
     setCredentials: (userId: string, userPassword: string) =>

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -21,7 +21,7 @@ import {
   type ArtworkSyncPhase,
   type CommandAction,
 } from "@gamelord/ui";
-import { Plus, FolderOpen, RefreshCw, ImageDown, Pause, X } from "lucide-react";
+import { Plus, FolderOpen, RefreshCw, ImageDown, X } from "lucide-react";
 import type { Game as AppGame, GameSystem } from "../../types/library";
 import type { ArtworkProgress } from "../../types/artwork";
 import type { GamelordAPI } from "../types/global";
@@ -68,7 +68,6 @@ export const LibraryView: React.FC<{
   // Each GameCard subscribes to its own phase via useSyncExternalStore.
   const [artworkSyncStore] = useState(() => new ArtworkSyncStore());
   const [syncCounter, setSyncCounter] = useState<{ current: number; total: number } | null>(null);
-  const [syncPaused, setSyncPaused] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const phaseCleanupTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   /** Track sync results for the notification summary. */
@@ -261,7 +260,6 @@ export const LibraryView: React.FC<{
 
     api.on("artwork:syncComplete", () => {
       setSyncCounter(null);
-      setSyncPaused(false);
       loadLibrary();
 
       // Show summary notification
@@ -323,7 +321,6 @@ export const LibraryView: React.FC<{
     api.on("artwork:syncError", (raw: unknown) => {
       const data = raw as { error: string; errorCode?: string };
       setSyncCounter(null);
-      setSyncPaused(false);
       artworkSyncStore.clear();
       syncResults.current = { found: 0, notFound: 0, errors: 0 };
 
@@ -356,9 +353,6 @@ export const LibraryView: React.FC<{
       setSyncNotification({ message, variant: "error" });
     });
 
-    api.on("artwork:syncPaused", () => setSyncPaused(true));
-    api.on("artwork:syncResumed", () => setSyncPaused(false));
-
     return () => {
       api.removeAllListeners("library:scanProgress");
       api.removeAllListeners("library:homebrewImported");
@@ -366,8 +360,6 @@ export const LibraryView: React.FC<{
       api.removeAllListeners("artwork:progress");
       api.removeAllListeners("artwork:syncComplete");
       api.removeAllListeners("artwork:syncError");
-      api.removeAllListeners("artwork:syncPaused");
-      api.removeAllListeners("artwork:syncResumed");
       // Clear all cleanup timers
       phaseCleanupTimers.current.forEach((timer) => clearTimeout(timer));
       phaseCleanupTimers.current.clear();
@@ -802,12 +794,8 @@ export const LibraryView: React.FC<{
           {/* Sync progress badge — replaces the old purple banner */}
           {isSyncing && (
             <Badge variant="secondary" className="gap-1.5 text-xs font-normal">
-              {syncPaused ? (
-                <Pause className="h-3 w-3" />
-              ) : (
-                <ImageDown className="h-3 w-3 animate-pulse" />
-              )}
-              {syncPaused ? "Paused" : "Syncing"} {syncCounter.current}/{syncCounter.total}
+              <ImageDown className="h-3 w-3 animate-pulse" />
+              Syncing {syncCounter.current}/{syncCounter.total}
             </Badge>
           )}
           <Button


### PR DESCRIPTION
## Summary

Replaces the hard auto-pause of artwork sync during gameplay with three targeted optimizations that eliminate event loop contention without stopping sync:

- **JSON.stringify offloaded to a worker thread** — large library serialization (10-50ms+ for 1000+ games) no longer blocks the main process event loop, keeping frame/audio IPC responsive
- **Artwork progress IPC events scoped to library windows only** — game windows no longer receive unnecessary `artwork:progress` broadcasts, reducing IPC noise during gameplay
- **Disk flushes deferred during gameplay** — `flushSave()` is skipped at the 10-game checkpoint while a game is running (in-memory state is already updated). Deferred writes flush automatically when the game exits

Users' artwork downloads now continue seamlessly in the background while playing, rather than pausing and resuming.

Closes #246

## Test plan

- [x] All 628 existing tests pass
- [x] New tests for gameplay-aware sync behavior (deferred flush, continued sync during gameplay)
- [x] Lint, typecheck, format all pass
- [ ] Manual: start an artwork sync, launch a game, verify sync continues and game has no frame drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)