### PR TITLE
chore: add .claude/projects/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ test-roms/
 # Claude Code
 .claude/settings.json
 .claude/worktrees/
+.claude/projects/
 
 # Entire
 .entire/


### PR DESCRIPTION
## Summary
- Adds `.claude/projects/` to `.gitignore` — this directory stores Claude Code's machine-local auto-memory and should not be tracked in version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)