### PR TITLE
fix: map gamepad face buttons by position, not by name

### DIFF
--- a/apps/desktop/src/renderer/hooks/useGamepad.test.ts
+++ b/apps/desktop/src/renderer/hooks/useGamepad.test.ts
@@ -138,17 +138,17 @@ describe("useGamepad", () => {
     act(() => tickPolling());
     expect(gameInput).not.toHaveBeenCalled();
 
-    // Press A button (gamepad index 0 → libretro A = 8)
+    // Press bottom face button (gamepad index 0 → libretro B = 0)
     mockGamepads[0] = createMockGamepad(0, {
       buttons: [{ pressed: true, value: 1 }],
     });
 
     act(() => tickPolling());
-    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.A, true);
+    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.B, true);
   });
 
   it("sends gameInput on button release transition", () => {
-    // Start with A pressed
+    // Start with bottom face button pressed
     mockGamepads[0] = createMockGamepad(0, {
       buttons: [{ pressed: true, value: 1 }],
     });
@@ -157,10 +157,10 @@ describe("useGamepad", () => {
     act(() => tickPolling());
     gameInput.mockClear();
 
-    // Release A
+    // Release bottom face button
     mockGamepads[0] = createMockGamepad(0);
     act(() => tickPolling());
-    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.A, false);
+    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.B, false);
   });
 
   it("does not re-fire for held buttons on subsequent polls", () => {
@@ -222,7 +222,7 @@ describe("useGamepad", () => {
   it("releases all buttons on gamepad disconnect", () => {
     // Start with multiple buttons pressed
     const buttons: Array<Partial<GamepadButton> | null> = new Array(16).fill(null);
-    buttons[0] = { pressed: true, value: 1 }; // A
+    buttons[0] = { pressed: true, value: 1 }; // bottom face → B
     buttons[9] = { pressed: true, value: 1 }; // Start
     mockGamepads[0] = createMockGamepad(0, { buttons });
     renderHook(() => useGamepad({ enabled: true, gameInput }));
@@ -235,8 +235,8 @@ describe("useGamepad", () => {
       window.dispatchEvent(createGamepadEvent("gamepaddisconnected", createMockGamepad(0)));
     });
 
-    // Should release A and Start
-    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.A, false);
+    // Should release B (bottom face) and Start
+    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.B, false);
     expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.START, false);
   });
 
@@ -256,22 +256,22 @@ describe("useGamepad", () => {
 
   it("supports two gamepads on separate ports", () => {
     mockGamepads[0] = createMockGamepad(0, {
-      buttons: [{ pressed: true, value: 1 }], // A on port 0
+      buttons: [{ pressed: true, value: 1 }], // bottom face (B) on port 0
     });
     mockGamepads[1] = createMockGamepad(1, {
-      buttons: [null, { pressed: true, value: 1 }], // B on port 1
+      buttons: [null, { pressed: true, value: 1 }], // right face (A) on port 1
     });
     renderHook(() => useGamepad({ enabled: true, gameInput }));
 
     act(() => tickPolling());
-    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.A, true);
-    expect(gameInput).toHaveBeenCalledWith(1, LIBRETRO_BUTTON.B, true);
+    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.B, true);
+    expect(gameInput).toHaveBeenCalledWith(1, LIBRETRO_BUTTON.A, true);
   });
 
   it("handles multiple simultaneous button presses", () => {
     mockGamepads[0] = createMockGamepad(0, {
       buttons: [
-        { pressed: true, value: 1 }, // A
+        { pressed: true, value: 1 }, // bottom face → B
         null,
         null,
         null,
@@ -281,7 +281,7 @@ describe("useGamepad", () => {
     renderHook(() => useGamepad({ enabled: true, gameInput }));
 
     act(() => tickPolling());
-    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.A, true);
+    expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.B, true);
     expect(gameInput).toHaveBeenCalledWith(0, LIBRETRO_BUTTON.L, true);
     expect(gameInput).toHaveBeenCalledTimes(2);
   });

--- a/apps/desktop/src/renderer/lib/gamepad/mappings.test.ts
+++ b/apps/desktop/src/renderer/lib/gamepad/mappings.test.ts
@@ -21,11 +21,11 @@ describe("STANDARD_GAMEPAD_MAPPING", () => {
     expect(uniqueIds.size).toBe(nonNullIds.length);
   });
 
-  it("maps face buttons correctly (Xbox positional → libretro)", () => {
-    expect(STANDARD_GAMEPAD_MAPPING[0]).toBe(LIBRETRO_BUTTON.A); // bottom face → A
-    expect(STANDARD_GAMEPAD_MAPPING[1]).toBe(LIBRETRO_BUTTON.B); // right face → B
-    expect(STANDARD_GAMEPAD_MAPPING[2]).toBe(LIBRETRO_BUTTON.X); // left face → X
-    expect(STANDARD_GAMEPAD_MAPPING[3]).toBe(LIBRETRO_BUTTON.Y); // top face → Y
+  it("maps face buttons by position (W3C positional → libretro SNES positional)", () => {
+    expect(STANDARD_GAMEPAD_MAPPING[0]).toBe(LIBRETRO_BUTTON.B); // bottom face → B (Cross)
+    expect(STANDARD_GAMEPAD_MAPPING[1]).toBe(LIBRETRO_BUTTON.A); // right face  → A (Circle)
+    expect(STANDARD_GAMEPAD_MAPPING[2]).toBe(LIBRETRO_BUTTON.Y); // left face   → Y (Square)
+    expect(STANDARD_GAMEPAD_MAPPING[3]).toBe(LIBRETRO_BUTTON.X); // top face    → X (Triangle)
   });
 
   it("maps shoulder buttons correctly", () => {

--- a/packages/ui/components/ControllerConfig/controller-mappings.test.ts
+++ b/packages/ui/components/ControllerConfig/controller-mappings.test.ts
@@ -83,10 +83,11 @@ describe("getControllerDisplayName", () => {
 
 describe("getButtonLabel", () => {
   it("returns PlayStation labels for PlayStation controllers", () => {
-    expect(getButtonLabel(LIBRETRO_BUTTON.A, "playstation")).toBe("Cross");
-    expect(getButtonLabel(LIBRETRO_BUTTON.B, "playstation")).toBe("Circle");
-    expect(getButtonLabel(LIBRETRO_BUTTON.X, "playstation")).toBe("Square");
-    expect(getButtonLabel(LIBRETRO_BUTTON.Y, "playstation")).toBe("Triangle");
+    // Libretro SNES naming: B=bottom=Cross, A=right=Circle, Y=left=Square, X=top=Triangle
+    expect(getButtonLabel(LIBRETRO_BUTTON.B, "playstation")).toBe("Cross");
+    expect(getButtonLabel(LIBRETRO_BUTTON.A, "playstation")).toBe("Circle");
+    expect(getButtonLabel(LIBRETRO_BUTTON.Y, "playstation")).toBe("Square");
+    expect(getButtonLabel(LIBRETRO_BUTTON.X, "playstation")).toBe("Triangle");
     expect(getButtonLabel(LIBRETRO_BUTTON.L, "playstation")).toBe("L1");
     expect(getButtonLabel(LIBRETRO_BUTTON.R, "playstation")).toBe("R1");
     expect(getButtonLabel(LIBRETRO_BUTTON.SELECT, "playstation")).toBe("Share");
@@ -152,15 +153,15 @@ describe("mappingToArray", () => {
 
   it("produces null entries for unbound buttons", () => {
     const mapping = getDefaultMapping();
-    // Unbind the A button
+    // Unbind the A button (right face, gamepad index 1)
     const modified = {
       bindings: mapping.bindings.map((b) =>
         b.retroId === LIBRETRO_BUTTON.A ? { ...b, gamepadButtonIndex: null } : b,
       ),
     };
     const array = mappingToArray(modified);
-    // Button index 0 was A, should now be null
-    expect(array[0]).toBeNull();
+    // A is at gamepad index 1 (right face), should now be null
+    expect(array[1]).toBeNull();
   });
 });
 

--- a/packages/ui/components/ControllerConfig/controller-mappings.ts
+++ b/packages/ui/components/ControllerConfig/controller-mappings.ts
@@ -111,11 +111,13 @@ export function getControllerDisplayName(gamepadId: string): string {
  */
 export function getButtonLabel(retroId: number, controllerType: ControllerType): string {
   if (controllerType === "playstation") {
+    // Libretro uses SNES positional naming: B=bottom, A=right, Y=left, X=top.
+    // PlayStation: Cross=bottom, Circle=right, Square=left, Triangle=top.
     const psLabels: Record<number, string> = {
-      [LIBRETRO_BUTTON.A]: "Cross",
-      [LIBRETRO_BUTTON.B]: "Circle",
-      [LIBRETRO_BUTTON.X]: "Square",
-      [LIBRETRO_BUTTON.Y]: "Triangle",
+      [LIBRETRO_BUTTON.B]: "Cross",
+      [LIBRETRO_BUTTON.A]: "Circle",
+      [LIBRETRO_BUTTON.Y]: "Square",
+      [LIBRETRO_BUTTON.X]: "Triangle",
       [LIBRETRO_BUTTON.L]: "L1",
       [LIBRETRO_BUTTON.R]: "R1",
       [LIBRETRO_BUTTON.SELECT]: "Share",

--- a/packages/ui/gamepad/mappings.ts
+++ b/packages/ui/gamepad/mappings.ts
@@ -24,20 +24,21 @@ export const LIBRETRO_BUTTON = {
  * Maps W3C Standard Gamepad API button indices to libretro joypad button IDs.
  * Array index = Gamepad API button index, value = libretro button ID.
  *
- * The W3C standard mapping uses Xbox positional layout:
- *   buttons[0] = A (bottom face)  -> libretro A (8)
- *   buttons[1] = B (right face)   -> libretro B (0)
- *   buttons[2] = X (left face)    -> libretro X (9)
- *   buttons[3] = Y (top face)     -> libretro Y (1)
+ * The W3C standard mapping is positional (Xbox physical layout):
+ *   buttons[0] = bottom face  -> libretro B (0)  = SNES B / PS Cross
+ *   buttons[1] = right face   -> libretro A (8)  = SNES A / PS Circle
+ *   buttons[2] = left face    -> libretro Y (1)  = SNES Y / PS Square
+ *   buttons[3] = top face     -> libretro X (9)  = SNES X / PS Triangle
  *
- * This works correctly with 8BitDo SN30 Pro in XInput mode and any
- * controller reporting mapping: "standard".
+ * Libretro uses SNES positional naming: B=bottom, A=right, Y=left, X=top.
+ * The mapping must be by POSITION, not by name — Xbox A (bottom) maps to
+ * libretro B (bottom), not libretro A (right).
  */
 export const STANDARD_GAMEPAD_MAPPING: Array<number | null> = [
-  LIBRETRO_BUTTON.A, // buttons[0]  - A / Cross (bottom face)
-  LIBRETRO_BUTTON.B, // buttons[1]  - B / Circle (right face)
-  LIBRETRO_BUTTON.X, // buttons[2]  - X / Square (left face)
-  LIBRETRO_BUTTON.Y, // buttons[3]  - Y / Triangle (top face)
+  LIBRETRO_BUTTON.B, // buttons[0]  - bottom face (Xbox A / PS Cross)
+  LIBRETRO_BUTTON.A, // buttons[1]  - right face  (Xbox B / PS Circle)
+  LIBRETRO_BUTTON.Y, // buttons[2]  - left face   (Xbox X / PS Square)
+  LIBRETRO_BUTTON.X, // buttons[3]  - top face    (Xbox Y / PS Triangle)
   LIBRETRO_BUTTON.L, // buttons[4]  - Left bumper
   LIBRETRO_BUTTON.R, // buttons[5]  - Right bumper
   LIBRETRO_BUTTON.L2, // buttons[6]  - Left trigger


### PR DESCRIPTION
## Summary

- Fixes gamepad face button mapping that was swapped in pairs (A↔B, X↔Y) on all XInput controllers
- The `STANDARD_GAMEPAD_MAPPING` incorrectly mapped W3C Gamepad API buttons by **name** (Xbox A → libretro A) instead of by **position** (Xbox A/bottom → libretro B/bottom)
- Libretro uses SNES positional naming where B=bottom and A=right, but the mapping treated them as Xbox names where A=bottom and B=right
- Also fixes `getButtonLabel` PlayStation labels which had the same positional swap

## What was happening

On an 8BitDo SN30 Pro (or any XInput controller), pressing the bottom face button (Cross on PS1) was sending libretro A (8) instead of libretro B (0), making the PSX core interpret it as Circle. All four face buttons were off by one position.

## Test plan

- [x] All gamepad mapping tests updated and passing
- [x] `useGamepad` hook tests updated for correct positional mapping
- [x] Controller config label tests updated
- [x] Lint, typecheck, format all pass
- [ ] Manual test: play a PSX game with SN30 Pro and verify Cross/Circle/Square/Triangle match physical button positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)