### PR TITLE
fix: skip artwork sync for games previously marked as not found

### DIFF
--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -249,7 +249,11 @@ describe("ArtworkService", () => {
 
     it("skips games previously marked as artworkNotFound", async () => {
       const games = [
-        makeGame({ id: "found-before", title: "Previously Not Found", artworkNotFound: Date.now() }),
+        makeGame({
+          id: "found-before",
+          title: "Previously Not Found",
+          artworkNotFound: Date.now(),
+        }),
         makeGame({ id: "never-synced", title: "Never Synced" }),
       ];
       const service = new ArtworkService(createMockLibraryService(games));
@@ -715,7 +719,9 @@ describe("ArtworkService", () => {
       });
 
       // Mock the download to succeed
-      vi.spyOn(service, "downloadArtwork").mockResolvedValue("/tmp/gamelord-test/artwork/game1.png");
+      vi.spyOn(service, "downloadArtwork").mockResolvedValue(
+        "/tmp/gamelord-test/artwork/game1.png",
+      );
 
       const result = await service.syncGame("game1", true);
       expect(result).toBe(true);

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -247,6 +247,26 @@ describe("ArtworkService", () => {
       expect(status.total).toBe(0);
     });
 
+    it("skips games previously marked as artworkNotFound", async () => {
+      const games = [
+        makeGame({ id: "found-before", title: "Previously Not Found", artworkNotFound: Date.now() }),
+        makeGame({ id: "never-synced", title: "Never Synced" }),
+      ];
+      const service = new ArtworkService(createMockLibraryService(games));
+      await flushPromises();
+
+      const progressEvents: Array<ArtworkProgress> = [];
+      service.on("progress", (p: ArtworkProgress) => progressEvents.push(p));
+
+      const status = await service.syncAllGames();
+
+      // Only the never-synced game should be in the batch
+      expect(status.total).toBe(1);
+      const syncedIds = new Set(progressEvents.map((p) => p.gameId));
+      expect(syncedIds.has("found-before")).toBe(false);
+      expect(syncedIds.has("never-synced")).toBe(true);
+    });
+
     it("emits syncComplete event when done", async () => {
       const service = new ArtworkService(createMockLibraryService([]));
       await flushPromises();
@@ -628,6 +648,82 @@ describe("ArtworkService", () => {
       // updateGame should NOT contain a 'system' key since Game Boy has no regional variants
       const updateCall = vi.mocked(libraryService.updateGame).mock.calls[0][1];
       expect(updateCall).not.toHaveProperty("system");
+    });
+
+    it("sets artworkNotFound when game is not found in API", async () => {
+      const game = makeGame();
+      const libraryService = createMockLibraryService([game]);
+      const service = new ArtworkService(libraryService);
+      await flushPromises();
+      await service.setCredentials("user", "pass");
+
+      mockFetchByHash.mockResolvedValue(null);
+      mockFetchByName.mockResolvedValue(null);
+
+      const result = await service.syncGame("game1");
+      expect(result).toBe(false);
+
+      expect(libraryService.updateGame).toHaveBeenCalledWith(
+        "game1",
+        expect.objectContaining({ artworkNotFound: expect.any(Number) }),
+      );
+    });
+
+    it("sets artworkNotFound when game found but has no artwork URL", async () => {
+      const game = makeGame();
+      const libraryService = createMockLibraryService([game]);
+      const service = new ArtworkService(libraryService);
+      await flushPromises();
+      await service.setCredentials("user", "pass");
+
+      mockFetchByHash.mockResolvedValue({
+        title: "Some Game",
+        developer: "Dev",
+        publisher: "Pub",
+        genre: "Action",
+        players: 1,
+        rating: 0.8,
+        releaseDate: "1990-01-01",
+        media: {}, // No artwork URLs
+      });
+
+      const result = await service.syncGame("game1");
+      expect(result).toBe(false);
+
+      expect(libraryService.updateGame).toHaveBeenCalledWith(
+        "game1",
+        expect.objectContaining({ artworkNotFound: expect.any(Number) }),
+      );
+    });
+
+    it("clears artworkNotFound when artwork is successfully found", async () => {
+      const game = makeGame({ artworkNotFound: Date.now() - 86_400_000 });
+      const libraryService = createMockLibraryService([game]);
+      const service = new ArtworkService(libraryService);
+      await flushPromises();
+      await service.setCredentials("user", "pass");
+
+      mockFetchByHash.mockResolvedValue({
+        title: "Some Game",
+        developer: "Dev",
+        publisher: "Pub",
+        genre: "Action",
+        players: 1,
+        rating: 0.8,
+        releaseDate: "1990-01-01",
+        media: { boxArt2d: "https://screenscraper.fr/medias/box2d.png" },
+      });
+
+      // Mock the download to succeed
+      vi.spyOn(service, "downloadArtwork").mockResolvedValue("/tmp/gamelord-test/artwork/game1.png");
+
+      const result = await service.syncGame("game1", true);
+      expect(result).toBe(true);
+
+      expect(libraryService.updateGame).toHaveBeenCalledWith(
+        "game1",
+        expect.objectContaining({ artworkNotFound: undefined }),
+      );
     });
 
     it("falls through to name search on non-auth errors from hash lookup", async () => {

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -321,6 +321,13 @@ export class ArtworkService extends EventEmitter {
     }
 
     if (!gameInfo) {
+      // Mark this game so we don't re-query the API on the next startup sync
+      const notFoundUpdate: Partial<Game> = { artworkNotFound: Date.now() };
+      if (this.syncing) {
+        this.libraryService.updateGameBatched(gameId, notFoundUpdate);
+      } else {
+        await this.libraryService.updateGame(gameId, notFoundUpdate);
+      }
       return false;
     }
 
@@ -358,10 +365,14 @@ export class ArtworkService extends EventEmitter {
     // (which is biased by REGION_PRIORITY toward US even for JP-only games).
     const effectiveRegion = gameInfo.romRegions?.[0] ?? gameInfo.region;
     const regionalName = getRegionalSystemName(game.systemId, effectiveRegion);
+    const hasArtwork = !!coverArtPath && !!artworkUrl;
     const updates: Partial<typeof game> = {
-      ...(coverArtPath && artworkUrl
-        ? { coverArt: `artwork://${gameId}${this.getImageExtension(artworkUrl)}` }
-        : {}),
+      ...(hasArtwork
+        ? {
+            coverArt: `artwork://${gameId}${this.getImageExtension(artworkUrl)}`,
+            artworkNotFound: undefined, // Clear any previous not-found marker
+          }
+        : { artworkNotFound: Date.now() }),
       ...(coverArtAspectRatio !== undefined ? { coverArtAspectRatio } : {}),
       ...(regionalName ? { system: regionalName } : {}),
       ...(gameInfo.romRegions ? { romRegions: gameInfo.romRegions } : {}),
@@ -398,7 +409,7 @@ export class ArtworkService extends EventEmitter {
     this.cancelled = false;
 
     const allGames = this.libraryService.getGames();
-    const gamesToSync = allGames.filter((game) => !game.coverArt);
+    const gamesToSync = allGames.filter((game) => !game.coverArt && !game.artworkNotFound);
 
     return this.runSyncBatch(gamesToSync.map((game) => game.id));
   }

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -9,6 +9,13 @@ export interface GameSystem {
 }
 
 export interface Game {
+  /**
+   * Timestamp (ms since epoch) when artwork sync determined no artwork is available
+   * for this game. Set when ScreenScraper returns no match or no artwork URL.
+   * Prevents redundant API calls on subsequent startup syncs.
+   * Cleared when artwork is successfully downloaded (e.g. via force sync).
+   */
+  artworkNotFound?: number;
   coverArt?: string;
   /** Width / height ratio of the downloaded cover art (e.g. 0.714 for a 3:4.2 box). */
   coverArtAspectRatio?: number;


### PR DESCRIPTION
## Summary

- Adds `artworkNotFound` timestamp field to the `Game` interface
- When artwork sync determines no artwork is available (game not in ScreenScraper, or game found but no artwork URL), the timestamp is persisted on the game record
- `syncAllGames()` now filters out games with `artworkNotFound` set, preventing redundant API calls on every app startup
- The marker is cleared when artwork is successfully downloaded (e.g. via force sync), so games can be retried as ScreenScraper's database grows

Closes #294

## Test plan

- [x] New test: `artworkNotFound` set when game not found in API
- [x] New test: `artworkNotFound` set when game found but has no artwork URL
- [x] New test: `artworkNotFound` cleared when artwork successfully downloaded via force sync
- [x] New test: `syncAllGames` skips games with `artworkNotFound` set
- [x] All 636 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)