### PR TITLE
feat: cheats foundation — database, native addon, worker/IPC

### DIFF
--- a/apps/desktop/native/src/libretro.h
+++ b/apps/desktop/native/src/libretro.h
@@ -171,6 +171,8 @@ typedef void (*retro_unload_game_t)(void);
 typedef unsigned (*retro_get_region_t)(void);
 typedef void *(*retro_get_memory_data_t)(unsigned id);
 typedef size_t (*retro_get_memory_size_t)(unsigned id);
+typedef void (*retro_cheat_reset_t)(void);
+typedef void (*retro_cheat_set_t)(unsigned index, bool enabled, const char *code);
 
 /* Core options v1 structures */
 struct retro_core_option_value {

--- a/apps/desktop/native/src/libretro_core.cc
+++ b/apps/desktop/native/src/libretro_core.cc
@@ -33,6 +33,8 @@ Napi::Object LibretroCore::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("getLogMessages", &LibretroCore::GetLogMessages),
     InstanceMethod("getCoreOptions", &LibretroCore::GetCoreOptions),
     InstanceMethod("setCoreOption", &LibretroCore::SetCoreOption),
+    InstanceMethod("cheatReset", &LibretroCore::CheatReset),
+    InstanceMethod("cheatSet", &LibretroCore::CheatSet),
   });
 
   Napi::FunctionReference *constructor = new Napi::FunctionReference();
@@ -213,6 +215,31 @@ void LibretroCore::Run(const Napi::CallbackInfo &info) {
 void LibretroCore::Reset(const Napi::CallbackInfo &info) {
   if (!game_loaded_ || !fn_reset_) return;
   fn_reset_();
+}
+
+void LibretroCore::CheatReset(const Napi::CallbackInfo &info) {
+  if (!game_loaded_ || !fn_cheat_reset_) return;
+  fn_cheat_reset_();
+}
+
+void LibretroCore::CheatSet(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (!game_loaded_ || !fn_cheat_set_) {
+    Napi::Error::New(env, "No game loaded or core does not support cheats").ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (info.Length() < 3 || !info[0].IsNumber() || !info[1].IsBoolean() || !info[2].IsString()) {
+    Napi::TypeError::New(env, "Expected (index: number, enabled: boolean, code: string)").ThrowAsJavaScriptException();
+    return;
+  }
+
+  unsigned index = info[0].As<Napi::Number>().Uint32Value();
+  bool enabled = info[1].As<Napi::Boolean>().Value();
+  std::string code = info[2].As<Napi::String>().Utf8Value();
+
+  fn_cheat_set_(index, enabled, code.c_str());
 }
 
 Napi::Value LibretroCore::GetSystemInfo(const Napi::CallbackInfo &info) {
@@ -555,6 +582,8 @@ bool LibretroCore::ResolveFunctions() {
   RESOLVE(get_region);
   RESOLVE(get_memory_data);
   RESOLVE(get_memory_size);
+  RESOLVE(cheat_reset);
+  RESOLVE(cheat_set);
 
 #undef RESOLVE
 

--- a/apps/desktop/native/src/libretro_core.h
+++ b/apps/desktop/native/src/libretro_core.h
@@ -49,6 +49,8 @@ private:
   Napi::Value GetLogMessages(const Napi::CallbackInfo &info);
   Napi::Value GetCoreOptions(const Napi::CallbackInfo &info);
   Napi::Value SetCoreOption(const Napi::CallbackInfo &info);
+  void CheatReset(const Napi::CallbackInfo &info);
+  void CheatSet(const Napi::CallbackInfo &info);
 
   // Internal
   void CloseCore();
@@ -96,6 +98,8 @@ private:
   retro_get_region_t fn_get_region_ = nullptr;
   retro_get_memory_data_t fn_get_memory_data_ = nullptr;
   retro_get_memory_size_t fn_get_memory_size_ = nullptr;
+  retro_cheat_reset_t fn_cheat_reset_ = nullptr;
+  retro_cheat_set_t fn_cheat_set_ = nullptr;
 
   // State
   std::atomic<bool> core_loaded_{false};

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -183,6 +183,14 @@ export class EmulationWorkerClient extends EventEmitter {
     return (result as { path: string }).path;
   }
 
+  async cheatReset(): Promise<void> {
+    await this.sendRequest({ action: "cheatReset" });
+  }
+
+  async cheatSet(index: number, enabled: boolean, code: string): Promise<void> {
+    await this.sendRequest({ action: "cheatSet", index, enabled, code });
+  }
+
   /**
    * Mark the worker as shutting down so that a process exit during the
    * async shutdown sequence doesn't emit an unexpected-exit error.

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -29,6 +29,7 @@ vi.mock("../emulator/EmulationWorkerClient");
 vi.mock("../emulator/resolveAddonPath");
 vi.mock("../services/LibraryService");
 vi.mock("../services/ArtworkService");
+vi.mock("../services/CheatDatabaseService");
 vi.mock("../GameWindowManager");
 vi.mock("../logger", () => ({
   ipcLog: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -39,6 +40,7 @@ import { EmulatorManager } from "../emulator/EmulatorManager";
 import { EmulationWorkerClient } from "../emulator/EmulationWorkerClient";
 import { resolveAddonPath } from "../emulator/resolveAddonPath";
 import { LibraryService } from "../services/LibraryService";
+import { CheatDatabaseService } from "../services/CheatDatabaseService";
 import { GameWindowManager } from "../GameWindowManager";
 import { IPCHandlers } from "./handlers";
 import type { Game, GameSystem } from "../../types/library";
@@ -254,6 +256,18 @@ beforeEach(() => {
     return gameWindowManagerInstance as unknown as GameWindowManager;
   } as unknown as () => GameWindowManager);
 
+  // Configure CheatDatabaseService mock constructor
+  const cheatEmitter = new EventEmitter();
+  vi.mocked(CheatDatabaseService).mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, {
+      ensureDatabase: vi.fn().mockResolvedValue(undefined),
+      getCheatsForGame: vi.fn().mockReturnValue([]),
+      on: cheatEmitter.on.bind(cheatEmitter),
+      emit: cheatEmitter.emit.bind(cheatEmitter),
+    });
+    return this as unknown as CheatDatabaseService;
+  } as unknown as () => CheatDatabaseService);
+
   // Instantiate IPCHandlers — triggers all handler registrations
   new IPCHandlers("/fake/preload.js");
 });
@@ -311,7 +325,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(39);
+      expect(handleCalls).toHaveLength(43);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -6,6 +6,7 @@ import { resolveAddonPath } from "../emulator/resolveAddonPath";
 import { LibraryService } from "../services/LibraryService";
 import { ArtworkService } from "../services/ArtworkService";
 import { HomebrewService } from "../services/HomebrewService";
+import { CheatDatabaseService } from "../services/CheatDatabaseService";
 import { ScreenScraperError } from "../services/ScreenScraperClient";
 import { GameWindowManager } from "../GameWindowManager";
 import type { AutoUpdaterService } from "../services/AutoUpdaterService";
@@ -28,6 +29,7 @@ export class IPCHandlers {
   private artworkService: ArtworkService;
   private homebrewService: HomebrewService;
   private gameWindowManager: GameWindowManager;
+  private cheatDatabaseService: CheatDatabaseService;
   private autoUpdater: AutoUpdaterService | null = null;
   private pendingResumeDialogs = new Map<string, (response: ResumeDialogResponse) => void>();
   /** Whether the homebrew import check has finished (imported, skipped, or errored). */
@@ -42,6 +44,7 @@ export class IPCHandlers {
     this.libraryService = new LibraryService();
     this.artworkService = new ArtworkService(this.libraryService);
     this.homebrewService = new HomebrewService(this.libraryService);
+    this.cheatDatabaseService = new CheatDatabaseService();
     this.gameWindowManager = new GameWindowManager(preloadPath);
     this.setupHandlers();
     this.setupEmulatorEventForwarding();
@@ -128,6 +131,11 @@ export class IPCHandlers {
               error: `${biosCheck.systemName} requires BIOS files that are missing: ${fileList}. Place them in: ${biosCheck.biosDir}`,
             };
           }
+
+          // Ensure cheat database is downloaded (non-blocking background task)
+          this.cheatDatabaseService.ensureDatabase().catch((error) => {
+            ipcLog.warn("Cheat database download failed:", error);
+          });
 
           // Convert renderer-relative card bounds to screen coordinates
           let cardScreenBounds: { x: number; y: number; width: number; height: number } | undefined;
@@ -319,6 +327,61 @@ export class IPCHandlers {
         return { success: false, error: errorMessage(error) };
       }
     });
+
+    // Cheats
+    ipcMain.handle(
+      "cheats:listForGame",
+      async (event: IpcMainInvokeEvent, systemId: string, romFilename: string) => {
+        try {
+          const cheats = this.cheatDatabaseService.getCheatsForGame(systemId, romFilename);
+          return { success: true, cheats };
+        } catch (error) {
+          ipcLog.error("Failed to list cheats:", error);
+          return { success: false, error: errorMessage(error), cheats: [] };
+        }
+      },
+    );
+
+    ipcMain.handle("cheats:downloadDatabase", async () => {
+      try {
+        await this.cheatDatabaseService.ensureDatabase();
+        return { success: true };
+      } catch (error) {
+        ipcLog.error("Failed to download cheat database:", error);
+        return { success: false, error: errorMessage(error) };
+      }
+    });
+
+    ipcMain.handle(
+      "cheats:set",
+      async (event: IpcMainInvokeEvent, index: number, enabled: boolean, code: string) => {
+        try {
+          const workerClient = this.emulatorManager.getWorkerClient();
+          if (!workerClient) {
+            return { success: false, error: "No emulator running" };
+          }
+          await workerClient.cheatSet(index, enabled, code);
+          return { success: true };
+        } catch (error) {
+          ipcLog.error("Failed to set cheat:", error);
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    );
+
+    ipcMain.handle("cheats:reset", async () => {
+      try {
+        const workerClient = this.emulatorManager.getWorkerClient();
+        if (!workerClient) {
+          return { success: false, error: "No emulator running" };
+        }
+        await workerClient.cheatReset();
+        return { success: true };
+      } catch (error) {
+        ipcLog.error("Failed to reset cheats:", error);
+        return { success: false, error: errorMessage(error) };
+      }
+    });
   }
 
   private setupEmulatorEventForwarding(): void {
@@ -363,6 +426,9 @@ export class IPCHandlers {
     });
     this.emulatorManager.on("core:downloadProgress", (data) =>
       forwardEvent("core:downloadProgress", data),
+    );
+    this.cheatDatabaseService.on("progress", (data) =>
+      forwardEvent("cheats:downloadProgress", data),
     );
 
     // Native mode: game window close doesn't go through EmulatorManager events,

--- a/apps/desktop/src/main/services/CheatDatabaseService.test.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.test.ts
@@ -116,7 +116,8 @@ cheat0_code = "ABC123"
   });
 
   it("handles Windows-style line endings", () => {
-    const content = "cheats = 1\r\ncheat0_desc = \"Test\"\r\ncheat0_code = \"ABC\"\r\ncheat0_enable = false\r\n";
+    const content =
+      'cheats = 1\r\ncheat0_desc = "Test"\r\ncheat0_code = "ABC"\r\ncheat0_enable = false\r\n';
     const cheats = parseChtFile(content);
 
     expect(cheats).toHaveLength(1);

--- a/apps/desktop/src/main/services/CheatDatabaseService.test.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { parseChtFile, matchChtFilename } from "./CheatDatabaseService";
+
+describe("parseChtFile", () => {
+  it("parses a standard .cht file with multiple cheats", () => {
+    const content = `cheats = 3
+
+cheat0_desc = "Infinite Lives"
+cheat0_code = "APEETPEY"
+cheat0_enable = false
+
+cheat1_desc = "Start With 9 Lives"
+cheat1_code = "092-17F"
+cheat1_enable = false
+
+cheat2_desc = "Moon Jump"
+cheat2_code = "DDA7-136A+DDA9-12DA"
+cheat2_enable = true
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(3);
+    expect(cheats[0]).toEqual({
+      index: 0,
+      description: "Infinite Lives",
+      code: "APEETPEY",
+      enabled: false,
+    });
+    expect(cheats[1]).toEqual({
+      index: 1,
+      description: "Start With 9 Lives",
+      code: "092-17F",
+      enabled: false,
+    });
+    expect(cheats[2]).toEqual({
+      index: 2,
+      description: "Moon Jump",
+      code: "DDA7-136A+DDA9-12DA",
+      enabled: true,
+    });
+  });
+
+  it("handles quoted values with escaped quotes", () => {
+    const content = `cheats = 1
+
+cheat0_desc = "Player 1 \\"Infinite\\" Health"
+cheat0_code = "7E0F28:FF"
+cheat0_enable = false
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.description).toBe('Player 1 "Infinite" Health');
+  });
+
+  it("handles values without quotes", () => {
+    const content = `cheats = 1
+
+cheat0_desc = Infinite Lives
+cheat0_code = APEETPEY
+cheat0_enable = false
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.description).toBe("Infinite Lives");
+    expect(cheats[0]?.code).toBe("APEETPEY");
+  });
+
+  it("returns empty array for empty file", () => {
+    expect(parseChtFile("")).toEqual([]);
+  });
+
+  it("returns empty array when cheats = 0", () => {
+    expect(parseChtFile("cheats = 0")).toEqual([]);
+  });
+
+  it("skips cheats with missing code", () => {
+    const content = `cheats = 2
+
+cheat0_desc = "Has Code"
+cheat0_code = "APEETPEY"
+cheat0_enable = false
+
+cheat1_desc = "Missing Code"
+cheat1_enable = false
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.description).toBe("Has Code");
+  });
+
+  it("uses index as description when desc is missing", () => {
+    const content = `cheats = 1
+
+cheat0_code = "APEETPEY"
+cheat0_enable = false
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.description).toBe("Cheat 0");
+  });
+
+  it("defaults enabled to false when enable line is missing", () => {
+    const content = `cheats = 1
+
+cheat0_desc = "Test"
+cheat0_code = "ABC123"
+`;
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.enabled).toBe(false);
+  });
+
+  it("handles Windows-style line endings", () => {
+    const content = "cheats = 1\r\ncheat0_desc = \"Test\"\r\ncheat0_code = \"ABC\"\r\ncheat0_enable = false\r\n";
+    const cheats = parseChtFile(content);
+
+    expect(cheats).toHaveLength(1);
+    expect(cheats[0]?.code).toBe("ABC");
+  });
+});
+
+describe("matchChtFilename", () => {
+  it("matches exact ROM filename (no extension)", () => {
+    expect(matchChtFilename("Super Mario Bros. (USA)", "Super Mario Bros. (USA).cht")).toBe(true);
+  });
+
+  it("rejects non-matching filename", () => {
+    expect(matchChtFilename("Super Mario Bros. (USA)", "Zelda (USA).cht")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchChtFilename("super mario bros", "Super Mario Bros.cht")).toBe(true);
+  });
+
+  it("matches against .cht extension only", () => {
+    expect(matchChtFilename("Game", "Game.cht")).toBe(true);
+    expect(matchChtFilename("Game", "Game.txt")).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -30,30 +30,38 @@ export function parseChtFile(content: string): Array<CheatEntry> {
 
   for (const line of lines) {
     const eqIndex = line.indexOf("=");
-    if (eqIndex === -1) continue;
+    if (eqIndex === -1) {
+      continue;
+    }
 
     const key = line.slice(0, eqIndex).trim();
     let value = line.slice(eqIndex + 1).trim();
 
     // Strip surrounding quotes
     if (value.startsWith('"') && value.endsWith('"')) {
-      value = value.slice(1, -1).replace(/\\"/g, '"');
+      value = value.slice(1, -1).replaceAll(String.raw`\"`, '"');
     }
 
     kvMap.set(key, value);
   }
 
   const countStr = kvMap.get("cheats");
-  if (!countStr) return [];
+  if (!countStr) {
+    return [];
+  }
 
-  const count = parseInt(countStr, 10);
-  if (!Number.isFinite(count) || count <= 0) return [];
+  const count = Number.parseInt(countStr, 10);
+  if (!Number.isFinite(count) || count <= 0) {
+    return [];
+  }
 
   const cheats: Array<CheatEntry> = [];
 
   for (let i = 0; i < count; i++) {
     const code = kvMap.get(`cheat${i}_code`);
-    if (!code) continue; // Skip cheats without a code — they're useless
+    if (!code) {
+      continue;
+    } // Skip cheats without a code — they're useless
 
     const description = kvMap.get(`cheat${i}_desc`) || `Cheat ${i}`;
     const enableStr = kvMap.get(`cheat${i}_enable`);
@@ -69,7 +77,9 @@ export function parseChtFile(content: string): Array<CheatEntry> {
  * Check if a .cht filename matches a ROM name (case-insensitive, extension-stripped).
  */
 export function matchChtFilename(romNameNoExt: string, chtFilename: string): boolean {
-  if (!chtFilename.toLowerCase().endsWith(".cht")) return false;
+  if (!chtFilename.toLowerCase().endsWith(".cht")) {
+    return false;
+  }
   const chtNameNoExt = chtFilename.slice(0, -4);
   return chtNameNoExt.toLowerCase() === romNameNoExt.toLowerCase();
 }
@@ -143,9 +153,13 @@ export class CheatDatabaseService extends EventEmitter {
 
   /** Ensure the cheat database exists. Downloads if missing or stale. Non-blocking. */
   async ensureDatabase(): Promise<void> {
-    if (this.downloading) return;
+    if (this.downloading) {
+      return;
+    }
 
-    if (this.isDatabaseFresh()) return;
+    if (this.isDatabaseFresh()) {
+      return;
+    }
 
     try {
       await this.downloadDatabase();
@@ -161,11 +175,15 @@ export class CheatDatabaseService extends EventEmitter {
     const romNameNoExt = path.basename(romFilename, path.extname(romFilename));
     const folders = SYSTEM_CHT_FOLDERS[systemId];
 
-    if (!folders) return [];
+    if (!folders) {
+      return [];
+    }
 
     for (const folder of folders) {
       const systemDir = path.join(this.cheatsDir, folder);
-      if (!fs.existsSync(systemDir)) continue;
+      if (!fs.existsSync(systemDir)) {
+        continue;
+      }
 
       let entries: Array<string>;
       try {
@@ -192,7 +210,9 @@ export class CheatDatabaseService extends EventEmitter {
 
   /** Whether the database has been downloaded and is not stale. */
   private isDatabaseFresh(): boolean {
-    if (!fs.existsSync(this.metadataPath)) return false;
+    if (!fs.existsSync(this.metadataPath)) {
+      return false;
+    }
 
     try {
       const raw = fs.readFileSync(this.metadataPath, "utf8");
@@ -266,53 +286,55 @@ export class CheatDatabaseService extends EventEmitter {
           return;
         }
 
-        https.get(targetUrl, (response) => {
-          if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
-            response.destroy();
-            const location = response.headers.location;
-            if (!location) {
-              reject(new Error("Redirect without Location header"));
+        https
+          .get(targetUrl, (response) => {
+            if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
+              response.destroy();
+              const location = response.headers.location;
+              if (!location) {
+                reject(new Error("Redirect without Location header"));
+                return;
+              }
+              follow(location, redirectCount + 1);
               return;
             }
-            follow(location, redirectCount + 1);
-            return;
-          }
 
-          if (response.statusCode !== 200) {
-            response.destroy();
-            reject(new Error(`HTTP ${response.statusCode} downloading cheat database`));
-            return;
-          }
-
-          const totalBytes = parseInt(response.headers["content-length"] || "0", 10);
-          let downloadedBytes = 0;
-
-          const file = fs.createWriteStream(dest);
-
-          response.on("data", (chunk: Buffer) => {
-            downloadedBytes += chunk.length;
-            if (totalBytes > 0) {
-              onProgress(Math.round((downloadedBytes / totalBytes) * 85));
+            if (response.statusCode !== 200) {
+              response.destroy();
+              reject(new Error(`HTTP ${response.statusCode} downloading cheat database`));
+              return;
             }
-          });
 
-          response.pipe(file);
+            const totalBytes = Number.parseInt(response.headers["content-length"] || "0", 10);
+            let downloadedBytes = 0;
 
-          file.on("finish", () => {
-            file.close();
-            resolve();
-          });
+            const file = fs.createWriteStream(dest);
 
-          file.on("error", (error) => {
-            file.close();
-            try {
-              fs.unlinkSync(dest);
-            } catch {
-              // Ignore
-            }
-            reject(error);
-          });
-        }).on("error", reject);
+            response.on("data", (chunk: Buffer) => {
+              downloadedBytes += chunk.length;
+              if (totalBytes > 0) {
+                onProgress(Math.round((downloadedBytes / totalBytes) * 85));
+              }
+            });
+
+            response.pipe(file);
+
+            file.on("finish", () => {
+              file.close();
+              resolve();
+            });
+
+            file.on("error", (error) => {
+              file.close();
+              try {
+                fs.unlinkSync(dest);
+              } catch {
+                // Ignore
+              }
+              reject(error);
+            });
+          })
+          .on("error", reject);
       };
 
       follow(url, 0);

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -1,0 +1,348 @@
+import { app } from "electron";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as https from "node:https";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { CheatEntry } from "../../types/library";
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// .cht parser (pure function, no side effects — easy to test)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a libretro .cht file into structured cheat entries.
+ *
+ * Format:
+ * ```
+ * cheats = 3
+ * cheat0_desc = "Infinite Lives"
+ * cheat0_code = "APEETPEY"
+ * cheat0_enable = false
+ * ```
+ */
+export function parseChtFile(content: string): Array<CheatEntry> {
+  const lines = content.split(/\r?\n/);
+  const kvMap = new Map<string, string>();
+
+  for (const line of lines) {
+    const eqIndex = line.indexOf("=");
+    if (eqIndex === -1) continue;
+
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+
+    // Strip surrounding quotes
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\"/g, '"');
+    }
+
+    kvMap.set(key, value);
+  }
+
+  const countStr = kvMap.get("cheats");
+  if (!countStr) return [];
+
+  const count = parseInt(countStr, 10);
+  if (!Number.isFinite(count) || count <= 0) return [];
+
+  const cheats: Array<CheatEntry> = [];
+
+  for (let i = 0; i < count; i++) {
+    const code = kvMap.get(`cheat${i}_code`);
+    if (!code) continue; // Skip cheats without a code — they're useless
+
+    const description = kvMap.get(`cheat${i}_desc`) || `Cheat ${i}`;
+    const enableStr = kvMap.get(`cheat${i}_enable`);
+    const enabled = enableStr === "true" || enableStr === "1";
+
+    cheats.push({ index: i, description, code, enabled });
+  }
+
+  return cheats;
+}
+
+/**
+ * Check if a .cht filename matches a ROM name (case-insensitive, extension-stripped).
+ */
+export function matchChtFilename(romNameNoExt: string, chtFilename: string): boolean {
+  if (!chtFilename.toLowerCase().endsWith(".cht")) return false;
+  const chtNameNoExt = chtFilename.slice(0, -4);
+  return chtNameNoExt.toLowerCase() === romNameNoExt.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// System ID mapping: our systemId → libretro-database cht/ folder name(s)
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps GameLord system IDs to the corresponding folder names in
+ * libretro-database/cht/. Some systems have multiple possible folder names
+ * due to regional naming differences in the database.
+ */
+const SYSTEM_CHT_FOLDERS: Record<string, Array<string>> = {
+  nes: ["Nintendo - Nintendo Entertainment System"],
+  snes: ["Nintendo - Super Nintendo Entertainment System"],
+  genesis: ["Sega - Mega Drive - Genesis"],
+  gb: ["Nintendo - Game Boy"],
+  gbc: ["Nintendo - Game Boy Color"],
+  gba: ["Nintendo - Game Boy Advance"],
+  n64: ["Nintendo - Nintendo 64"],
+  psx: ["Sony - PlayStation"],
+  psp: ["Sony - PlayStation Portable"],
+  nds: ["Nintendo - Nintendo DS"],
+  saturn: ["Sega - Saturn"],
+  arcade: ["FBNeo - Arcade Games"],
+};
+
+// ---------------------------------------------------------------------------
+// Download progress
+// ---------------------------------------------------------------------------
+
+export interface CheatDatabaseProgress {
+  phase: "downloading" | "extracting" | "done" | "error";
+  percent: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Metadata for tracking database freshness
+// ---------------------------------------------------------------------------
+
+interface CheatDatabaseMetadata {
+  lastDownloaded: number; // ms since epoch
+}
+
+const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// ---------------------------------------------------------------------------
+// CheatDatabaseService
+// ---------------------------------------------------------------------------
+
+/**
+ * Downloads and manages the libretro cheat database (.cht files).
+ *
+ * - Downloads the libretro-database repo archive on first game launch
+ * - Extracts only the cht/ subtree to <userData>/cheats/
+ * - Matches cheats to ROMs by filename
+ * - Re-downloads if the database is >7 days old
+ */
+export class CheatDatabaseService extends EventEmitter {
+  private cheatsDir: string;
+  private metadataPath: string;
+  private downloading = false;
+
+  constructor() {
+    super();
+    this.cheatsDir = path.join(app.getPath("userData"), "cheats");
+    this.metadataPath = path.join(this.cheatsDir, "metadata.json");
+  }
+
+  /** Ensure the cheat database exists. Downloads if missing or stale. Non-blocking. */
+  async ensureDatabase(): Promise<void> {
+    if (this.downloading) return;
+
+    if (this.isDatabaseFresh()) return;
+
+    try {
+      await this.downloadDatabase();
+    } catch (error) {
+      // Non-fatal — cheats are simply unavailable
+      const message = error instanceof Error ? error.message : String(error);
+      this.emitProgress("error", 0, message);
+    }
+  }
+
+  /** Get cheats for a specific game by system ID and ROM filename. */
+  getCheatsForGame(systemId: string, romFilename: string): Array<CheatEntry> {
+    const romNameNoExt = path.basename(romFilename, path.extname(romFilename));
+    const folders = SYSTEM_CHT_FOLDERS[systemId];
+
+    if (!folders) return [];
+
+    for (const folder of folders) {
+      const systemDir = path.join(this.cheatsDir, folder);
+      if (!fs.existsSync(systemDir)) continue;
+
+      let entries: Array<string>;
+      try {
+        entries = fs.readdirSync(systemDir);
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        if (matchChtFilename(romNameNoExt, entry)) {
+          const chtPath = path.join(systemDir, entry);
+          try {
+            const content = fs.readFileSync(chtPath, "utf8");
+            return parseChtFile(content);
+          } catch {
+            return [];
+          }
+        }
+      }
+    }
+
+    return [];
+  }
+
+  /** Whether the database has been downloaded and is not stale. */
+  private isDatabaseFresh(): boolean {
+    if (!fs.existsSync(this.metadataPath)) return false;
+
+    try {
+      const raw = fs.readFileSync(this.metadataPath, "utf8");
+      const metadata: CheatDatabaseMetadata = JSON.parse(raw);
+      return Date.now() - metadata.lastDownloaded < STALE_THRESHOLD_MS;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Download the libretro-database archive and extract the cht/ directory. */
+  private async downloadDatabase(): Promise<void> {
+    this.downloading = true;
+
+    try {
+      fs.mkdirSync(this.cheatsDir, { recursive: true });
+
+      const tarballUrl =
+        "https://github.com/libretro/libretro-database/archive/refs/heads/master.tar.gz";
+
+      this.emitProgress("downloading", 0);
+
+      const tarballPath = path.join(this.cheatsDir, "libretro-database.tar.gz");
+
+      await this.downloadFile(tarballUrl, tarballPath, (percent) => {
+        this.emitProgress("downloading", percent);
+      });
+
+      this.emitProgress("extracting", 85);
+
+      await this.extractChtFiles(tarballPath);
+
+      // Clean up tarball
+      try {
+        fs.unlinkSync(tarballPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      // Write metadata
+      const metadata: CheatDatabaseMetadata = { lastDownloaded: Date.now() };
+      fs.writeFileSync(this.metadataPath, JSON.stringify(metadata, null, 2));
+
+      this.emitProgress("done", 100);
+    } catch (error) {
+      // Clean up partial download
+      const tarballPath = path.join(this.cheatsDir, "libretro-database.tar.gz");
+      if (fs.existsSync(tarballPath)) {
+        try {
+          fs.unlinkSync(tarballPath);
+        } catch {
+          // Ignore
+        }
+      }
+      throw error;
+    } finally {
+      this.downloading = false;
+    }
+  }
+
+  /** Download a file with progress tracking (follows redirects). */
+  private downloadFile(
+    url: string,
+    dest: string,
+    onProgress: (percent: number) => void,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const follow = (targetUrl: string, redirectCount: number): void => {
+        if (redirectCount > 5) {
+          reject(new Error("Too many redirects downloading cheat database"));
+          return;
+        }
+
+        https.get(targetUrl, (response) => {
+          if (response.statusCode && response.statusCode >= 300 && response.statusCode < 400) {
+            response.destroy();
+            const location = response.headers.location;
+            if (!location) {
+              reject(new Error("Redirect without Location header"));
+              return;
+            }
+            follow(location, redirectCount + 1);
+            return;
+          }
+
+          if (response.statusCode !== 200) {
+            response.destroy();
+            reject(new Error(`HTTP ${response.statusCode} downloading cheat database`));
+            return;
+          }
+
+          const totalBytes = parseInt(response.headers["content-length"] || "0", 10);
+          let downloadedBytes = 0;
+
+          const file = fs.createWriteStream(dest);
+
+          response.on("data", (chunk: Buffer) => {
+            downloadedBytes += chunk.length;
+            if (totalBytes > 0) {
+              onProgress(Math.round((downloadedBytes / totalBytes) * 85));
+            }
+          });
+
+          response.pipe(file);
+
+          file.on("finish", () => {
+            file.close();
+            resolve();
+          });
+
+          file.on("error", (error) => {
+            file.close();
+            try {
+              fs.unlinkSync(dest);
+            } catch {
+              // Ignore
+            }
+            reject(error);
+          });
+        }).on("error", reject);
+      };
+
+      follow(url, 0);
+    });
+  }
+
+  /**
+   * Extract only the cht/ subdirectory from the downloaded tarball.
+   *
+   * Uses the system `tar` command (available on macOS and Linux) to avoid
+   * adding a Node tar dependency. The --include flag filters to only the
+   * cht/ directory, and --strip-components removes the repo root prefix.
+   */
+  private async extractChtFiles(tarballPath: string): Promise<void> {
+    await execFileAsync("tar", [
+      "xzf",
+      tarballPath,
+      "--strip-components=1",
+      "--include=*/cht/*",
+      "-C",
+      this.cheatsDir,
+    ]);
+  }
+
+  private emitProgress(
+    phase: CheatDatabaseProgress["phase"],
+    percent: number,
+    error?: string,
+  ): void {
+    const progress: CheatDatabaseProgress = { phase, percent, error };
+    this.emit("progress", progress);
+  }
+}

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -40,6 +40,8 @@ export interface NativeLibretroCore {
   getLogMessages(): Array<{ level: number; message: string }>;
   getCoreOptions(): Record<string, string>;
   setCoreOption(key: string, value: string): boolean;
+  cheatReset(): void;
+  cheatSet(index: number, enabled: boolean, code: string): void;
 }
 
 export interface NativeAddon {
@@ -96,6 +98,14 @@ export type WorkerCommand =
       videoSAB: SharedArrayBuffer;
       audioSAB: SharedArrayBuffer;
       videoBufferSize: number;
+    }
+  | { action: "cheatReset"; requestId: string }
+  | {
+      action: "cheatSet";
+      index: number;
+      enabled: boolean;
+      code: string;
+      requestId: string;
     };
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -649,6 +649,32 @@ function handleMessage(command: WorkerCommand): void {
       Atomics.store(controlView, CTRL_AUDIO_SAMPLE_RATE, sampleRate);
       break;
 
+    case "cheatReset":
+      try {
+        native?.cheatReset();
+        sendResponse(command.requestId, true);
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
+    case "cheatSet":
+      try {
+        native?.cheatSet(command.index, command.enabled, command.code);
+        sendResponse(command.requestId, true);
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
     case "shutdown":
       try {
         stopEmulationLoop();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -58,6 +58,16 @@ contextBridge.exposeInMainWorld("gamelord", {
     load: (slot: number) => ipcRenderer.invoke("savestate:load", slot),
   },
 
+  // Cheats
+  cheats: {
+    listForGame: (systemId: string, romFilename: string) =>
+      ipcRenderer.invoke("cheats:listForGame", systemId, romFilename),
+    downloadDatabase: () => ipcRenderer.invoke("cheats:downloadDatabase"),
+    set: (index: number, enabled: boolean, code: string) =>
+      ipcRenderer.invoke("cheats:set", index, enabled, code),
+    reset: () => ipcRenderer.invoke("cheats:reset"),
+  },
+
   // Run one frame and return video+audio data (called from requestAnimationFrame)
   tick: () => ipcRenderer.invoke("game:tick"),
 
@@ -86,6 +96,7 @@ contextBridge.exposeInMainWorld("gamelord", {
       "game:audio-samples",
       "overlay:show-controls",
       "core:downloadProgress",
+      "cheats:downloadProgress",
       "library:scanProgress",
       "library:scanAmbiguous",
       "library:homebrewImported",

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -1,4 +1,4 @@
-import type { GameSystem, Game, LibraryConfig } from "../../types/library";
+import type { GameSystem, Game, LibraryConfig, CheatEntry } from "../../types/library";
 
 export interface CoreInfo {
   name: string;
@@ -39,6 +39,19 @@ export interface GamelordAPI {
   saveState: {
     save: (slot: number) => Promise<{ success: boolean }>;
     load: (slot: number) => Promise<{ success: boolean }>;
+  };
+  cheats: {
+    listForGame: (
+      systemId: string,
+      romFilename: string,
+    ) => Promise<{ success: boolean; cheats: Array<CheatEntry>; error?: string }>;
+    downloadDatabase: () => Promise<{ success: boolean; error?: string }>;
+    set: (
+      index: number,
+      enabled: boolean,
+      code: string,
+    ) => Promise<{ success: boolean; error?: string }>;
+    reset: () => Promise<{ success: boolean; error?: string }>;
   };
   // Library management (matches preload API)
   library: {

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -1,3 +1,11 @@
+/** A single cheat code parsed from a libretro .cht database file. */
+export interface CheatEntry {
+  index: number;
+  description: string;
+  code: string;
+  enabled: boolean;
+}
+
 export interface GameSystem {
   corePath?: string;
   extensions: Array<string>;


### PR DESCRIPTION
## Summary

- **Native addon**: Wire up `retro_cheat_reset` and `retro_cheat_set` libretro API functions through the C++ N-API addon. Cores that don't support cheats gracefully no-op.
- **Worker protocol**: Add `cheatReset` and `cheatSet` commands to the worker message protocol, worker command handler, and `EmulationWorkerClient`.
- **Cheat database service**: Download the libretro-database `.cht` archive on first game launch (background, non-blocking). Parse `.cht` files into structured `CheatEntry` objects. Match cheats to ROMs by filename. Re-download if stale (>7 days).
- **IPC integration**: Full renderer → main → worker → native chain for listing cheats, toggling cheats on a running core, and resetting all cheats. Preload API typed end-to-end via `window.gamelord.cheats`.

No UI yet — this is the foundation layer. Phase 2 (cheat browser panel, custom entry, per-game persistence) will follow.

Closes #275, Closes #276, Closes #277

## Test plan

- [x] Native addon compiles (`node-gyp rebuild`)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Format passes (`pnpm format`)
- [x] All 645 tests pass (`pnpm test`) — includes 13 new `.cht` parser tests
- [ ] Manual: launch a game, confirm cheat database downloads in background
- [ ] Manual: call `window.gamelord.cheats.listForGame(systemId, romFilename)` in dev tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)