### PR TITLE
feat: cheat browser panel with persistence and custom cheats

### DIFF
--- a/.claude/rules/shadcn-components.md
+++ b/.claude/rules/shadcn-components.md
@@ -1,0 +1,5 @@
+# Use Existing shadcn/Radix Primitives
+
+Never hand-roll a UI primitive (toggle, switch, select, dialog, dropdown, etc.) when a shadcn/Radix equivalent exists or can be added. Check `packages/ui/components/ui/` before building custom interactive elements.
+
+If the component doesn't exist yet, install the Radix primitive (`@radix-ui/react-*`), create the shadcn wrapper in `packages/ui/components/ui/`, and export it from `packages/ui/index.ts` — then use it. This ensures consistent accessibility, keyboard handling, and styling across the app.

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -30,6 +30,7 @@ vi.mock("../emulator/resolveAddonPath");
 vi.mock("../services/LibraryService");
 vi.mock("../services/ArtworkService");
 vi.mock("../services/CheatDatabaseService");
+vi.mock("../services/CheatPersistenceService");
 vi.mock("../GameWindowManager");
 vi.mock("../logger", () => ({
   ipcLog: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
@@ -41,6 +42,7 @@ import { EmulationWorkerClient } from "../emulator/EmulationWorkerClient";
 import { resolveAddonPath } from "../emulator/resolveAddonPath";
 import { LibraryService } from "../services/LibraryService";
 import { CheatDatabaseService } from "../services/CheatDatabaseService";
+import { CheatPersistenceService } from "../services/CheatPersistenceService";
 import { GameWindowManager } from "../GameWindowManager";
 import { IPCHandlers } from "./handlers";
 import type { Game, GameSystem } from "../../types/library";
@@ -268,6 +270,19 @@ beforeEach(() => {
     return this as unknown as CheatDatabaseService;
   } as unknown as () => CheatDatabaseService);
 
+  // Configure CheatPersistenceService mock constructor
+  vi.mocked(CheatPersistenceService).mockImplementation(function (this: Record<string, unknown>) {
+    Object.assign(this, {
+      getGameState: vi.fn().mockReturnValue({ enabledIndices: [], customCheats: [] }),
+      setCheatEnabled: vi.fn(),
+      addCustomCheat: vi.fn(),
+      removeCustomCheat: vi.fn(),
+      setCustomCheatEnabled: vi.fn(),
+      getEnabledCheats: vi.fn().mockReturnValue([]),
+    });
+    return this as unknown as CheatPersistenceService;
+  } as unknown as () => CheatPersistenceService);
+
   // Instantiate IPCHandlers — triggers all handler registrations
   new IPCHandlers("/fake/preload.js");
 });
@@ -325,7 +340,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(43);
+      expect(handleCalls).toHaveLength(48);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -264,6 +264,8 @@ beforeEach(() => {
     Object.assign(this, {
       ensureDatabase: vi.fn().mockResolvedValue(undefined),
       getCheatsForGame: vi.fn().mockReturnValue([]),
+      isDatabasePresent: vi.fn().mockReturnValue(true),
+      isDownloading: vi.fn().mockReturnValue(false),
       on: cheatEmitter.on.bind(cheatEmitter),
       emit: cheatEmitter.emit.bind(cheatEmitter),
     });
@@ -340,7 +342,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(48);
+      expect(handleCalls).toHaveLength(49);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -350,6 +350,13 @@ export class IPCHandlers {
       },
     );
 
+    ipcMain.handle("cheats:databaseStatus", () => {
+      return {
+        present: this.cheatDatabaseService.isDatabasePresent(),
+        downloading: this.cheatDatabaseService.isDownloading(),
+      };
+    });
+
     ipcMain.handle("cheats:downloadDatabase", async () => {
       try {
         await this.cheatDatabaseService.ensureDatabase();

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -7,6 +7,7 @@ import { LibraryService } from "../services/LibraryService";
 import { ArtworkService } from "../services/ArtworkService";
 import { HomebrewService } from "../services/HomebrewService";
 import { CheatDatabaseService } from "../services/CheatDatabaseService";
+import { CheatPersistenceService } from "../services/CheatPersistenceService";
 import { ScreenScraperError } from "../services/ScreenScraperClient";
 import { GameWindowManager } from "../GameWindowManager";
 import type { AutoUpdaterService } from "../services/AutoUpdaterService";
@@ -30,6 +31,7 @@ export class IPCHandlers {
   private homebrewService: HomebrewService;
   private gameWindowManager: GameWindowManager;
   private cheatDatabaseService: CheatDatabaseService;
+  private cheatPersistenceService: CheatPersistenceService;
   private autoUpdater: AutoUpdaterService | null = null;
   private pendingResumeDialogs = new Map<string, (response: ResumeDialogResponse) => void>();
   /** Whether the homebrew import check has finished (imported, skipped, or errored). */
@@ -45,6 +47,7 @@ export class IPCHandlers {
     this.artworkService = new ArtworkService(this.libraryService);
     this.homebrewService = new HomebrewService(this.libraryService);
     this.cheatDatabaseService = new CheatDatabaseService();
+    this.cheatPersistenceService = new CheatPersistenceService();
     this.gameWindowManager = new GameWindowManager(preloadPath);
     this.setupHandlers();
     this.setupEmulatorEventForwarding();
@@ -198,6 +201,11 @@ export class IPCHandlers {
 
             // Store the worker client on the emulator manager for control routing
             this.emulatorManager.setWorkerClient(workerClient);
+
+            // Auto-apply persisted cheats (non-blocking)
+            this.autoApplyCheats(workerClient, game).catch((error) => {
+              ipcLog.warn("Failed to auto-apply cheats:", error);
+            });
 
             this.gameWindowManager.createNativeGameWindow(
               game,
@@ -382,6 +390,63 @@ export class IPCHandlers {
         return { success: false, error: errorMessage(error) };
       }
     });
+
+    ipcMain.handle("cheats:getGameState", async (event: IpcMainInvokeEvent, gameId: string) => {
+      try {
+        const state = this.cheatPersistenceService.getGameState(gameId);
+        return { success: true, state };
+      } catch (error) {
+        return { success: false, error: errorMessage(error), state: null };
+      }
+    });
+
+    ipcMain.handle(
+      "cheats:toggleCheat",
+      async (event: IpcMainInvokeEvent, gameId: string, index: number, enabled: boolean) => {
+        try {
+          this.cheatPersistenceService.setCheatEnabled(gameId, index, enabled);
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    );
+
+    ipcMain.handle(
+      "cheats:toggleCustomCheat",
+      async (event: IpcMainInvokeEvent, gameId: string, customIndex: number, enabled: boolean) => {
+        try {
+          this.cheatPersistenceService.setCustomCheatEnabled(gameId, customIndex, enabled);
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    );
+
+    ipcMain.handle(
+      "cheats:addCustomCheat",
+      async (event: IpcMainInvokeEvent, gameId: string, description: string, code: string) => {
+        try {
+          this.cheatPersistenceService.addCustomCheat(gameId, description, code);
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    );
+
+    ipcMain.handle(
+      "cheats:removeCustomCheat",
+      async (event: IpcMainInvokeEvent, gameId: string, customIndex: number) => {
+        try {
+          this.cheatPersistenceService.removeCustomCheat(gameId, customIndex);
+          return { success: true };
+        } catch (error) {
+          return { success: false, error: errorMessage(error) };
+        }
+      },
+    );
   }
 
   private setupEmulatorEventForwarding(): void {
@@ -812,5 +877,30 @@ export class IPCHandlers {
         }
       }, 30_000);
     });
+  }
+
+  /**
+   * Apply any previously-enabled cheats for a game after the emulation
+   * worker is initialized. Runs cheatReset first, then sets each enabled cheat.
+   */
+  private async autoApplyCheats(workerClient: EmulationWorkerClient, game: Game): Promise<void> {
+    const romFilename = game.romPath.split("/").pop() || game.romPath;
+    const enabledCheats = this.cheatPersistenceService.getEnabledCheats(
+      game.id,
+      this.cheatDatabaseService,
+      game.systemId,
+      romFilename,
+    );
+
+    if (enabledCheats.length === 0) {
+      return;
+    }
+
+    await workerClient.cheatReset();
+    for (const cheat of enabledCheats) {
+      await workerClient.cheatSet(cheat.index, true, cheat.code);
+    }
+
+    ipcLog.info(`Auto-applied ${enabledCheats.length} cheat(s) for ${game.title}`);
   }
 }

--- a/apps/desktop/src/main/services/CheatDatabaseService.test.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseChtFile, matchChtFilename } from "./CheatDatabaseService";
+import { parseChtFile, matchChtFilename, baseTitle } from "./CheatDatabaseService";
 
 describe("parseChtFile", () => {
   it("parses a standard .cht file with multiple cheats", () => {
@@ -141,5 +141,54 @@ describe("matchChtFilename", () => {
   it("matches against .cht extension only", () => {
     expect(matchChtFilename("Game", "Game.cht")).toBe(true);
     expect(matchChtFilename("Game", "Game.txt")).toBe(false);
+  });
+
+  it("matches when ROM has fewer parenthetical groups than cht file", () => {
+    expect(
+      matchChtFilename(
+        "Resident Evil - Director's Cut (USA)",
+        "Resident Evil - Director's Cut (USA, Europe) (Game Buster).cht",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when both have different region tags", () => {
+    expect(
+      matchChtFilename(
+        "Resident Evil - Survivor (USA)",
+        "Resident Evil - Survivor (USA, Europe) (GameShark).cht",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects different base titles despite similar parentheticals", () => {
+    expect(matchChtFilename("Resident Evil 2 (USA)", "Resident Evil 3 - Nemesis (USA).cht")).toBe(
+      false,
+    );
+  });
+
+  it("matches when ROM has no parenthetical groups at all", () => {
+    expect(
+      matchChtFilename(
+        "Resident Evil - Director's Cut",
+        "Resident Evil - Director's Cut (USA, Europe) (Game Buster).cht",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("baseTitle", () => {
+  it("strips parenthetical groups and normalises whitespace", () => {
+    expect(baseTitle("Resident Evil - Director's Cut (USA, Europe) (Game Buster)")).toBe(
+      "resident evil - director's cut",
+    );
+  });
+
+  it("handles names with no parenthetical groups", () => {
+    expect(baseTitle("Super Mario Bros")).toBe("super mario bros");
+  });
+
+  it("handles names that are all parenthetical groups", () => {
+    expect(baseTitle("(USA) (GameShark)")).toBe("");
   });
 });

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -74,14 +74,42 @@ export function parseChtFile(content: string): Array<CheatEntry> {
 }
 
 /**
- * Check if a .cht filename matches a ROM name (case-insensitive, extension-stripped).
+ * Strip all parenthetical groups (region tags, cheat device names, etc.)
+ * and normalise whitespace to produce a base game title for fuzzy matching.
+ *
+ * "Resident Evil - Director's Cut (USA, Europe) (Game Buster)"
+ *   → "resident evil - director's cut"
+ */
+export function baseTitle(name: string): string {
+  return name
+    .replaceAll(/\([^)]*\)/g, "")
+    .trim()
+    .replaceAll(/\s+/g, " ")
+    .toLowerCase();
+}
+
+/**
+ * Check if a .cht filename matches a ROM name.
+ *
+ * Matching strategy (in priority order):
+ * 1. Exact match (extension-stripped, case-insensitive)
+ * 2. Base-title match — strip all parenthetical groups from both names
+ *    and compare the core title. This handles differing region tags and
+ *    cheat-device suffixes between ROM filenames and the libretro database.
  */
 export function matchChtFilename(romNameNoExt: string, chtFilename: string): boolean {
   if (!chtFilename.toLowerCase().endsWith(".cht")) {
     return false;
   }
   const chtNameNoExt = chtFilename.slice(0, -4);
-  return chtNameNoExt.toLowerCase() === romNameNoExt.toLowerCase();
+
+  // Exact match
+  if (chtNameNoExt.toLowerCase() === romNameNoExt.toLowerCase()) {
+    return true;
+  }
+
+  // Base-title fuzzy match
+  return baseTitle(romNameNoExt) === baseTitle(chtNameNoExt);
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +207,8 @@ export class CheatDatabaseService extends EventEmitter {
       return [];
     }
 
+    const allCheats: Array<CheatEntry> = [];
+
     for (const folder of folders) {
       const systemDir = path.join(this.cheatsDir, "cht", folder);
       if (!fs.existsSync(systemDir)) {
@@ -197,15 +227,19 @@ export class CheatDatabaseService extends EventEmitter {
           const chtPath = path.join(systemDir, entry);
           try {
             const content = fs.readFileSync(chtPath, "utf8");
-            return parseChtFile(content);
+            const cheats = parseChtFile(content);
+            // Re-index so indices are unique across all matched files
+            for (const cheat of cheats) {
+              allCheats.push({ ...cheat, index: allCheats.length });
+            }
           } catch {
-            return [];
+            // Skip unreadable files
           }
         }
       }
     }
 
-    return [];
+    return allCheats;
   }
 
   /** Whether the database has been downloaded at all (may be stale). */

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -208,6 +208,16 @@ export class CheatDatabaseService extends EventEmitter {
     return [];
   }
 
+  /** Whether the database has been downloaded at all (may be stale). */
+  isDatabasePresent(): boolean {
+    return fs.existsSync(this.metadataPath);
+  }
+
+  /** Whether the database is currently being downloaded. */
+  isDownloading(): boolean {
+    return this.downloading;
+  }
+
   /** Whether the database has been downloaded and is not stale. */
   private isDatabaseFresh(): boolean {
     if (!fs.existsSync(this.metadataPath)) {

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -180,7 +180,7 @@ export class CheatDatabaseService extends EventEmitter {
     }
 
     for (const folder of folders) {
-      const systemDir = path.join(this.cheatsDir, folder);
+      const systemDir = path.join(this.cheatsDir, "cht", folder);
       if (!fs.existsSync(systemDir)) {
         continue;
       }

--- a/apps/desktop/src/main/services/CheatPersistenceService.test.ts
+++ b/apps/desktop/src/main/services/CheatPersistenceService.test.ts
@@ -6,7 +6,7 @@ vi.mock("electron", () => ({
 }));
 
 // Must import after mocks are set up
-import { CheatPersistenceService, type GameCheatState } from "./CheatPersistenceService";
+import { CheatPersistenceService } from "./CheatPersistenceService";
 
 // Mock fs for controlled testing
 vi.mock("node:fs", async () => {

--- a/apps/desktop/src/main/services/CheatPersistenceService.test.ts
+++ b/apps/desktop/src/main/services/CheatPersistenceService.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "node:fs";
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => "/tmp/test-cheat-persistence") },
+}));
+
+// Must import after mocks are set up
+import { CheatPersistenceService, type GameCheatState } from "./CheatPersistenceService";
+
+// Mock fs for controlled testing
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // Default: no existing config file
+  vi.mocked(fs.readFileSync).mockImplementation(() => {
+    throw new Error("ENOENT");
+  });
+});
+
+describe("CheatPersistenceService", () => {
+  describe("getGameState", () => {
+    it("returns empty state for unknown game", () => {
+      const service = new CheatPersistenceService();
+      const state = service.getGameState("game-123");
+
+      expect(state).toEqual({ enabledIndices: [], customCheats: [] });
+    });
+
+    it("returns persisted state from config file", () => {
+      const config = {
+        games: {
+          "game-123": {
+            enabledIndices: [0, 2],
+            customCheats: [{ description: "Custom", code: "ABC", enabled: true }],
+          },
+        },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
+
+      const service = new CheatPersistenceService();
+      const state = service.getGameState("game-123");
+
+      expect(state.enabledIndices).toEqual([0, 2]);
+      expect(state.customCheats).toHaveLength(1);
+    });
+  });
+
+  describe("setCheatEnabled", () => {
+    it("enables a cheat by adding its index", () => {
+      const service = new CheatPersistenceService();
+      service.setCheatEnabled("game-1", 3, true);
+
+      const state = service.getGameState("game-1");
+      expect(state.enabledIndices).toContain(3);
+    });
+
+    it("disables a cheat by removing its index", () => {
+      const config = {
+        games: { "game-1": { enabledIndices: [0, 2, 5], customCheats: [] } },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
+
+      const service = new CheatPersistenceService();
+      service.setCheatEnabled("game-1", 2, false);
+
+      const state = service.getGameState("game-1");
+      expect(state.enabledIndices).toEqual([0, 5]);
+    });
+
+    it("keeps indices sorted", () => {
+      const service = new CheatPersistenceService();
+      service.setCheatEnabled("game-1", 5, true);
+      service.setCheatEnabled("game-1", 1, true);
+      service.setCheatEnabled("game-1", 3, true);
+
+      const state = service.getGameState("game-1");
+      expect(state.enabledIndices).toEqual([1, 3, 5]);
+    });
+
+    it("persists to disk on every toggle", () => {
+      const service = new CheatPersistenceService();
+      service.setCheatEnabled("game-1", 0, true);
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      expect(fs.renameSync).toHaveBeenCalled();
+    });
+  });
+
+  describe("addCustomCheat", () => {
+    it("adds a custom cheat with enabled=true", () => {
+      const service = new CheatPersistenceService();
+      service.addCustomCheat("game-1", "Infinite Lives", "APEETPEY");
+
+      const state = service.getGameState("game-1");
+      expect(state.customCheats).toEqual([
+        { description: "Infinite Lives", code: "APEETPEY", enabled: true },
+      ]);
+    });
+
+    it("appends to existing custom cheats", () => {
+      const config = {
+        games: {
+          "game-1": {
+            enabledIndices: [],
+            customCheats: [{ description: "First", code: "AAA", enabled: true }],
+          },
+        },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
+
+      const service = new CheatPersistenceService();
+      service.addCustomCheat("game-1", "Second", "BBB");
+
+      const state = service.getGameState("game-1");
+      expect(state.customCheats).toHaveLength(2);
+      expect(state.customCheats[1]?.description).toBe("Second");
+    });
+  });
+
+  describe("removeCustomCheat", () => {
+    it("removes a custom cheat by index", () => {
+      const config = {
+        games: {
+          "game-1": {
+            enabledIndices: [],
+            customCheats: [
+              { description: "A", code: "AAA", enabled: true },
+              { description: "B", code: "BBB", enabled: true },
+            ],
+          },
+        },
+      };
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(config));
+
+      const service = new CheatPersistenceService();
+      service.removeCustomCheat("game-1", 0);
+
+      const state = service.getGameState("game-1");
+      expect(state.customCheats).toHaveLength(1);
+      expect(state.customCheats[0]?.description).toBe("B");
+    });
+
+    it("ignores out-of-bounds index", () => {
+      const service = new CheatPersistenceService();
+      service.addCustomCheat("game-1", "Test", "AAA");
+      service.removeCustomCheat("game-1", 99);
+
+      const state = service.getGameState("game-1");
+      expect(state.customCheats).toHaveLength(1);
+    });
+  });
+
+  describe("setCustomCheatEnabled", () => {
+    it("toggles a custom cheat", () => {
+      const service = new CheatPersistenceService();
+      service.addCustomCheat("game-1", "Test", "AAA");
+      service.setCustomCheatEnabled("game-1", 0, false);
+
+      const state = service.getGameState("game-1");
+      expect(state.customCheats[0]?.enabled).toBe(false);
+    });
+  });
+
+  describe("loadConfig", () => {
+    it("handles corrupt config gracefully", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue("not json{{{");
+
+      const service = new CheatPersistenceService();
+      const state = service.getGameState("any");
+
+      expect(state).toEqual({ enabledIndices: [], customCheats: [] });
+    });
+
+    it("handles config with missing games field", () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ version: 1 }));
+
+      const service = new CheatPersistenceService();
+      const state = service.getGameState("any");
+
+      expect(state).toEqual({ enabledIndices: [], customCheats: [] });
+    });
+  });
+});

--- a/apps/desktop/src/main/services/CheatPersistenceService.ts
+++ b/apps/desktop/src/main/services/CheatPersistenceService.ts
@@ -1,25 +1,8 @@
 import { app } from "electron";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { CheatEntry } from "../../types/library";
+import type { GameCheatState } from "../../types/library";
 import { CheatDatabaseService } from "./CheatDatabaseService";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-export interface CustomCheat {
-  description: string;
-  code: string;
-  enabled: boolean;
-}
-
-export interface GameCheatState {
-  /** Indices of enabled database cheats */
-  enabledIndices: Array<number>;
-  /** User-defined custom cheats */
-  customCheats: Array<CustomCheat>;
-}
 
 interface CheatConfig {
   games: Record<string, GameCheatState>;

--- a/apps/desktop/src/main/services/CheatPersistenceService.ts
+++ b/apps/desktop/src/main/services/CheatPersistenceService.ts
@@ -1,0 +1,162 @@
+import { app } from "electron";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { CheatEntry } from "../../types/library";
+import { CheatDatabaseService } from "./CheatDatabaseService";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CustomCheat {
+  description: string;
+  code: string;
+  enabled: boolean;
+}
+
+export interface GameCheatState {
+  /** Indices of enabled database cheats */
+  enabledIndices: Array<number>;
+  /** User-defined custom cheats */
+  customCheats: Array<CustomCheat>;
+}
+
+interface CheatConfig {
+  games: Record<string, GameCheatState>;
+}
+
+// ---------------------------------------------------------------------------
+// CheatPersistenceService
+// ---------------------------------------------------------------------------
+
+/**
+ * Persists per-game cheat state: which database cheats are enabled and
+ * any user-defined custom cheats. Stored in `<userData>/cheat-config.json`.
+ */
+export class CheatPersistenceService {
+  private configPath: string;
+  private config: CheatConfig;
+
+  constructor() {
+    this.configPath = path.join(app.getPath("userData"), "cheat-config.json");
+    this.config = this.loadConfig();
+  }
+
+  /** Get the persisted cheat state for a game. */
+  getGameState(gameId: string): GameCheatState {
+    return (
+      this.config.games[gameId] ?? {
+        enabledIndices: [],
+        customCheats: [],
+      }
+    );
+  }
+
+  /** Toggle a database cheat on or off for a game. */
+  setCheatEnabled(gameId: string, index: number, enabled: boolean): void {
+    const state = this.ensureGameState(gameId);
+    const set = new Set(state.enabledIndices);
+
+    if (enabled) {
+      set.add(index);
+    } else {
+      set.delete(index);
+    }
+
+    state.enabledIndices = [...set].sort((a, b) => a - b);
+    this.saveConfig();
+  }
+
+  /** Add a custom cheat for a game. */
+  addCustomCheat(gameId: string, description: string, code: string): void {
+    const state = this.ensureGameState(gameId);
+    state.customCheats.push({ description, code, enabled: true });
+    this.saveConfig();
+  }
+
+  /** Remove a custom cheat by index within the customCheats array. */
+  removeCustomCheat(gameId: string, customIndex: number): void {
+    const state = this.ensureGameState(gameId);
+    if (customIndex >= 0 && customIndex < state.customCheats.length) {
+      state.customCheats.splice(customIndex, 1);
+      this.saveConfig();
+    }
+  }
+
+  /** Toggle a custom cheat on or off. */
+  setCustomCheatEnabled(gameId: string, customIndex: number, enabled: boolean): void {
+    const state = this.ensureGameState(gameId);
+    const cheat = state.customCheats[customIndex];
+    if (cheat) {
+      cheat.enabled = enabled;
+      this.saveConfig();
+    }
+  }
+
+  /**
+   * Get all enabled cheats for a game, merged from database + custom.
+   * Used to auto-apply cheats on game launch.
+   */
+  getEnabledCheats(
+    gameId: string,
+    cheatDatabaseService: CheatDatabaseService,
+    systemId: string,
+    romFilename: string,
+  ): Array<{ index: number; code: string }> {
+    const state = this.getGameState(gameId);
+    const dbCheats = cheatDatabaseService.getCheatsForGame(systemId, romFilename);
+
+    const result: Array<{ index: number; code: string }> = [];
+    let cheatIndex = 0;
+
+    // Database cheats with their original indices
+    for (const cheat of dbCheats) {
+      if (state.enabledIndices.includes(cheat.index)) {
+        result.push({ index: cheatIndex, code: cheat.code });
+      }
+      cheatIndex++;
+    }
+
+    // Custom cheats appended after database cheats
+    for (const custom of state.customCheats) {
+      if (custom.enabled) {
+        result.push({ index: cheatIndex, code: custom.code });
+      }
+      cheatIndex++;
+    }
+
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Private
+  // -------------------------------------------------------------------------
+
+  private ensureGameState(gameId: string): GameCheatState {
+    let state = this.config.games[gameId];
+    if (!state) {
+      state = { enabledIndices: [], customCheats: [] };
+      this.config.games[gameId] = state;
+    }
+    return state;
+  }
+
+  private loadConfig(): CheatConfig {
+    try {
+      const raw = fs.readFileSync(this.configPath, "utf8");
+      const parsed = JSON.parse(raw) as CheatConfig;
+      if (parsed.games && typeof parsed.games === "object") {
+        return parsed;
+      }
+    } catch {
+      // File doesn't exist or is corrupt — start fresh
+    }
+    return { games: {} };
+  }
+
+  private saveConfig(): void {
+    const tmpPath = `${this.configPath}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(this.config, null, 2), "utf8");
+    fs.renameSync(tmpPath, this.configPath);
+  }
+}

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -66,6 +66,15 @@ contextBridge.exposeInMainWorld("gamelord", {
     set: (index: number, enabled: boolean, code: string) =>
       ipcRenderer.invoke("cheats:set", index, enabled, code),
     reset: () => ipcRenderer.invoke("cheats:reset"),
+    getGameState: (gameId: string) => ipcRenderer.invoke("cheats:getGameState", gameId),
+    toggleCheat: (gameId: string, index: number, enabled: boolean) =>
+      ipcRenderer.invoke("cheats:toggleCheat", gameId, index, enabled),
+    toggleCustomCheat: (gameId: string, customIndex: number, enabled: boolean) =>
+      ipcRenderer.invoke("cheats:toggleCustomCheat", gameId, customIndex, enabled),
+    addCustomCheat: (gameId: string, description: string, code: string) =>
+      ipcRenderer.invoke("cheats:addCustomCheat", gameId, description, code),
+    removeCustomCheat: (gameId: string, customIndex: number) =>
+      ipcRenderer.invoke("cheats:removeCustomCheat", gameId, customIndex),
   },
 
   // Run one frame and return video+audio data (called from requestAnimationFrame)

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -62,6 +62,11 @@ contextBridge.exposeInMainWorld("gamelord", {
   cheats: {
     listForGame: (systemId: string, romFilename: string) =>
       ipcRenderer.invoke("cheats:listForGame", systemId, romFilename),
+    databaseStatus: () =>
+      ipcRenderer.invoke("cheats:databaseStatus") as Promise<{
+        present: boolean;
+        downloading: boolean;
+      }>,
     downloadDatabase: () => ipcRenderer.invoke("cheats:downloadDatabase"),
     set: (index: number, enabled: boolean, code: string) =>
       ipcRenderer.invoke("cheats:set", index, enabled, code),

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -142,6 +142,9 @@ export const GameWindow: React.FC = () => {
   const [showCheatPanel, setShowCheatPanel] = useState(false);
   const [cheatItems, setCheatItems] = useState<Array<CheatItem>>([]);
   const [customCheatItems, setCustomCheatItems] = useState<Array<CustomCheatItem>>([]);
+  const [cheatDbStatus, setCheatDbStatus] = useState<
+    "ready" | "downloading" | "not-downloaded" | "error"
+  >("ready");
   const pausedByOverlayRef = useRef(false);
   const [showControlsHint, setShowControlsHint] = useState(() => {
     return localStorage.getItem("gamelord:controlsHintDismissed") !== "true";
@@ -192,6 +195,16 @@ export const GameWindow: React.FC = () => {
   }, [api, game]);
 
   const openCheatPanel = useCallback(async () => {
+    // Check database status first
+    const status = await api.cheats.databaseStatus();
+    if (status.downloading) {
+      setCheatDbStatus("downloading");
+    } else if (!status.present) {
+      setCheatDbStatus("not-downloaded");
+    } else {
+      setCheatDbStatus("ready");
+    }
+
     await loadCheats();
     setShowCheatPanel(true);
     if (!isPaused) {
@@ -199,6 +212,17 @@ export const GameWindow: React.FC = () => {
       api.emulation.pause().catch(console.error);
     }
   }, [loadCheats, isPaused, api]);
+
+  const handleDownloadDatabase = useCallback(async () => {
+    setCheatDbStatus("downloading");
+    const result = await api.cheats.downloadDatabase();
+    if (result.success) {
+      setCheatDbStatus("ready");
+      await loadCheats();
+    } else {
+      setCheatDbStatus("error");
+    }
+  }, [api, loadCheats]);
 
   const handleToggleCheat = useCallback(
     async (index: number, enabled: boolean) => {
@@ -1584,6 +1608,8 @@ export const GameWindow: React.FC = () => {
         onAddCustomCheat={handleAddCustomCheat}
         onRemoveCustomCheat={handleRemoveCustomCheat}
         gameTitle={game?.title ?? ""}
+        databaseStatus={cheatDbStatus}
+        onDownloadDatabase={handleDownloadDatabase}
       />
 
       {/* First-launch controls hint */}

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   Button,
+  CheatPanel,
+  type CheatItem,
+  type CustomCheatItem,
   ControlsOverlay,
   type KeyboardBinding,
   filterBindingsForSystem,
@@ -25,6 +28,7 @@ import {
   FastForward,
   ChevronDown,
   Keyboard,
+  Code,
   Minus,
   Square,
   X,
@@ -135,6 +139,9 @@ export const GameWindow: React.FC = () => {
   });
 
   const [showControlsOverlay, setShowControlsOverlay] = useState(false);
+  const [showCheatPanel, setShowCheatPanel] = useState(false);
+  const [cheatItems, setCheatItems] = useState<Array<CheatItem>>([]);
+  const [customCheatItems, setCustomCheatItems] = useState<Array<CustomCheatItem>>([]);
   const pausedByOverlayRef = useRef(false);
   const [showControlsHint, setShowControlsHint] = useState(() => {
     return localStorage.getItem("gamelord:controlsHintDismissed") !== "true";
@@ -160,6 +167,103 @@ export const GameWindow: React.FC = () => {
   // and trigger state updates during the power-on sequence).
   const handlePowerOnComplete = useCallback(() => setIsPoweringOn(false), []);
   const handlePowerOffComplete = useCallback(() => api.gameWindow.readyToClose(), [api]);
+
+  // -------------------------------------------------------------------------
+  // Cheat panel
+  // -------------------------------------------------------------------------
+  const loadCheats = useCallback(async () => {
+    if (!game) {
+      return;
+    }
+    const romFilename = game.romPath.split("/").pop() || game.romPath;
+    const [cheatsResult, stateResult] = await Promise.all([
+      api.cheats.listForGame(game.systemId, romFilename),
+      api.cheats.getGameState(game.id),
+    ]);
+
+    const enabledIndices = new Set(stateResult.state?.enabledIndices ?? []);
+    setCheatItems(
+      (cheatsResult.cheats ?? []).map((c) => ({
+        ...c,
+        enabled: enabledIndices.has(c.index),
+      })),
+    );
+    setCustomCheatItems(stateResult.state?.customCheats ?? []);
+  }, [api, game]);
+
+  const openCheatPanel = useCallback(async () => {
+    await loadCheats();
+    setShowCheatPanel(true);
+    if (!isPaused) {
+      pausedByOverlayRef.current = true;
+      api.emulation.pause().catch(console.error);
+    }
+  }, [loadCheats, isPaused, api]);
+
+  const handleToggleCheat = useCallback(
+    async (index: number, enabled: boolean) => {
+      if (!game) {
+        return;
+      }
+      // Update local state immediately for responsive UI
+      setCheatItems((prev) => prev.map((c) => (c.index === index ? { ...c, enabled } : c)));
+      // Persist + apply to running core
+      await api.cheats.toggleCheat(game.id, index, enabled);
+      const cheat = cheatItems.find((c) => c.index === index);
+      if (cheat) {
+        await api.cheats.set(index, enabled, cheat.code);
+      }
+    },
+    [api, game, cheatItems],
+  );
+
+  const handleToggleCustomCheat = useCallback(
+    async (customIndex: number, enabled: boolean) => {
+      if (!game) {
+        return;
+      }
+      setCustomCheatItems((prev) =>
+        prev.map((c, i) => (i === customIndex ? { ...c, enabled } : c)),
+      );
+      await api.cheats.toggleCustomCheat(game.id, customIndex, enabled);
+      const cheat = customCheatItems[customIndex];
+      if (cheat) {
+        // Custom cheats are indexed after database cheats
+        await api.cheats.set(cheatItems.length + customIndex, enabled, cheat.code);
+      }
+    },
+    [api, game, cheatItems.length, customCheatItems],
+  );
+
+  const handleAddCustomCheat = useCallback(
+    async (description: string, code: string) => {
+      if (!game) {
+        return;
+      }
+      await api.cheats.addCustomCheat(game.id, description, code);
+      // Reload to get the updated state
+      await loadCheats();
+      // Apply the new cheat (it's enabled by default)
+      await api.cheats.set(cheatItems.length + customCheatItems.length, true, code);
+    },
+    [api, game, loadCheats, cheatItems.length, customCheatItems.length],
+  );
+
+  const handleRemoveCustomCheat = useCallback(
+    async (customIndex: number) => {
+      if (!game) {
+        return;
+      }
+      // Disable the cheat on the core first
+      const cheat = customCheatItems[customIndex];
+      if (cheat?.enabled) {
+        await api.cheats.set(cheatItems.length + customIndex, false, cheat.code);
+      }
+      await api.cheats.removeCustomCheat(game.id, customIndex);
+      await loadCheats();
+    },
+    [api, game, loadCheats, cheatItems.length, customCheatItems],
+  );
 
   const {
     play: playSfx,
@@ -1343,6 +1447,17 @@ export const GameWindow: React.FC = () => {
                     <span>Controls</span>
                     <span className="ml-auto text-xs text-white/30">?</span>
                   </button>
+                  <button
+                    onClick={() => {
+                      playSfx("click");
+                      setShowSettingsMenu(false);
+                      openCheatPanel().catch(console.error);
+                    }}
+                    className="w-full flex items-center gap-2 px-4 py-2 text-sm text-white/80 hover:bg-white/10 transition-colors"
+                  >
+                    <Code className="h-3.5 w-3.5" />
+                    <span>Cheats</span>
+                  </button>
                   <div className="border-t border-white/10 my-1" />
                   <button
                     onClick={() => {
@@ -1450,6 +1565,25 @@ export const GameWindow: React.FC = () => {
           }
         }}
         bindings={filterBindingsForSystem(KEYBOARD_BINDINGS, game?.systemId)}
+      />
+
+      {/* Cheat panel overlay */}
+      <CheatPanel
+        open={showCheatPanel}
+        onClose={() => {
+          setShowCheatPanel(false);
+          if (pausedByOverlayRef.current) {
+            pausedByOverlayRef.current = false;
+            api.emulation.resume().catch(console.error);
+          }
+        }}
+        cheats={cheatItems}
+        onToggleCheat={handleToggleCheat}
+        customCheats={customCheatItems}
+        onToggleCustomCheat={handleToggleCustomCheat}
+        onAddCustomCheat={handleAddCustomCheat}
+        onRemoveCustomCheat={handleRemoveCustomCheat}
+        gameTitle={game?.title ?? ""}
       />
 
       {/* First-launch controls hint */}

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -1,4 +1,4 @@
-import type { GameSystem, Game, LibraryConfig, CheatEntry } from "../../types/library";
+import type { GameSystem, Game, LibraryConfig, CheatEntry, GameCheatState } from "../../types/library";
 
 export interface CoreInfo {
   name: string;
@@ -52,6 +52,28 @@ export interface GamelordAPI {
       code: string,
     ) => Promise<{ success: boolean; error?: string }>;
     reset: () => Promise<{ success: boolean; error?: string }>;
+    getGameState: (
+      gameId: string,
+    ) => Promise<{ success: boolean; state: GameCheatState | null; error?: string }>;
+    toggleCheat: (
+      gameId: string,
+      index: number,
+      enabled: boolean,
+    ) => Promise<{ success: boolean; error?: string }>;
+    toggleCustomCheat: (
+      gameId: string,
+      customIndex: number,
+      enabled: boolean,
+    ) => Promise<{ success: boolean; error?: string }>;
+    addCustomCheat: (
+      gameId: string,
+      description: string,
+      code: string,
+    ) => Promise<{ success: boolean; error?: string }>;
+    removeCustomCheat: (
+      gameId: string,
+      customIndex: number,
+    ) => Promise<{ success: boolean; error?: string }>;
   };
   // Library management (matches preload API)
   library: {

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -51,6 +51,7 @@ export interface GamelordAPI {
       systemId: string,
       romFilename: string,
     ) => Promise<{ success: boolean; cheats: Array<CheatEntry>; error?: string }>;
+    databaseStatus: () => Promise<{ present: boolean; downloading: boolean }>;
     downloadDatabase: () => Promise<{ success: boolean; error?: string }>;
     set: (
       index: number,

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -1,4 +1,10 @@
-import type { GameSystem, Game, LibraryConfig, CheatEntry, GameCheatState } from "../../types/library";
+import type {
+  GameSystem,
+  Game,
+  LibraryConfig,
+  CheatEntry,
+  GameCheatState,
+} from "../../types/library";
 
 export interface CoreInfo {
   name: string;

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -6,6 +6,19 @@ export interface CheatEntry {
   enabled: boolean;
 }
 
+/** A user-defined cheat code not in the database. */
+export interface CustomCheat {
+  description: string;
+  code: string;
+  enabled: boolean;
+}
+
+/** Persisted cheat state for a single game. */
+export interface GameCheatState {
+  enabledIndices: Array<number>;
+  customCheats: Array<CustomCheat>;
+}
+
 export interface GameSystem {
   corePath?: string;
   extensions: Array<string>;

--- a/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
@@ -1,5 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 import { CheatPanel } from "./CheatPanel";
 import type { CheatItem, CustomCheatItem } from "./CheatPanel";
 

--- a/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
@@ -88,3 +88,32 @@ export const CustomCheatsOnly: Story = {
     gameTitle: "Unknown Game",
   },
 };
+
+export const DatabaseNotDownloaded: Story = {
+  args: {
+    cheats: [],
+    customCheats: [],
+    gameTitle: "Resident Evil",
+    databaseStatus: "not-downloaded",
+    onDownloadDatabase: fn(),
+  },
+};
+
+export const DatabaseDownloading: Story = {
+  args: {
+    cheats: [],
+    customCheats: [],
+    gameTitle: "Resident Evil",
+    databaseStatus: "downloading",
+  },
+};
+
+export const DatabaseError: Story = {
+  args: {
+    cheats: [],
+    customCheats: [],
+    gameTitle: "Resident Evil",
+    databaseStatus: "error",
+    onDownloadDatabase: fn(),
+  },
+};

--- a/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import { CheatPanel } from "./CheatPanel";
+import type { CheatItem, CustomCheatItem } from "./CheatPanel";
+
+const SAMPLE_CHEATS: Array<CheatItem> = [
+  { index: 0, description: "Infinite Lives", code: "APEETPEY", enabled: false },
+  { index: 1, description: "Start With 9 Lives", code: "092-17F", enabled: true },
+  { index: 2, description: "Moon Jump", code: "DDA7-136A+DDA9-12DA", enabled: false },
+  { index: 3, description: "Infinite Health", code: "7E0F28:FF", enabled: false },
+  { index: 4, description: "Max Coins", code: "AEUGNSSL", enabled: true },
+];
+
+const MANY_CHEATS: Array<CheatItem> = Array.from({ length: 30 }, (_, i) => ({
+  index: i,
+  description: `Cheat Code ${i + 1} — ${["Infinite Lives", "God Mode", "Max Ammo", "No Clip", "Speed Boost", "One Hit Kill"][i % 6]}`,
+  code: `${String(i).padStart(4, "0")}-${String(i * 7).padStart(4, "0")}`,
+  enabled: i % 5 === 0,
+}));
+
+const SAMPLE_CUSTOM_CHEATS: Array<CustomCheatItem> = [
+  { description: "Custom Infinite Ammo", code: "7E1490:FF", enabled: true },
+  { description: "Debug Mode", code: "XYZZY", enabled: false },
+];
+
+const meta: Meta<typeof CheatPanel> = {
+  component: CheatPanel,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+  title: "Components/CheatPanel",
+  args: {
+    open: true,
+    onClose: fn(),
+    onToggleCheat: fn(),
+    onToggleCustomCheat: fn(),
+    onAddCustomCheat: fn(),
+    onRemoveCustomCheat: fn(),
+    cheats: SAMPLE_CHEATS,
+    customCheats: [],
+    gameTitle: "Super Mario Bros.",
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100vh",
+          background: "#111",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithCustomCheats: Story = {
+  args: {
+    customCheats: SAMPLE_CUSTOM_CHEATS,
+  },
+};
+
+export const ManyCheats: Story = {
+  args: {
+    cheats: MANY_CHEATS,
+    gameTitle: "The Legend of Zelda: A Link to the Past",
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    cheats: [],
+    customCheats: [],
+    gameTitle: "Homebrew Test ROM",
+  },
+};
+
+export const CustomCheatsOnly: Story = {
+  args: {
+    cheats: [],
+    customCheats: SAMPLE_CUSTOM_CHEATS,
+    gameTitle: "Unknown Game",
+  },
+};

--- a/packages/ui/components/CheatPanel/CheatPanel.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.tsx
@@ -1,0 +1,365 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { X, Plus, Trash2, Search } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CheatItem {
+  index: number;
+  description: string;
+  code: string;
+  enabled: boolean;
+}
+
+export interface CustomCheatItem {
+  description: string;
+  code: string;
+  enabled: boolean;
+}
+
+export interface CheatPanelProps {
+  open: boolean;
+  onClose: () => void;
+  cheats: ReadonlyArray<CheatItem>;
+  onToggleCheat: (index: number, enabled: boolean) => void;
+  customCheats: ReadonlyArray<CustomCheatItem>;
+  onToggleCustomCheat: (index: number, enabled: boolean) => void;
+  onAddCustomCheat: (description: string, code: string) => void;
+  onRemoveCustomCheat: (index: number) => void;
+  gameTitle: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const UNMOUNT_DELAY = 220;
+
+// ---------------------------------------------------------------------------
+// CheatPanel
+// ---------------------------------------------------------------------------
+
+export const CheatPanel: React.FC<CheatPanelProps> = ({
+  open,
+  onClose,
+  cheats,
+  onToggleCheat,
+  customCheats,
+  onToggleCustomCheat,
+  onAddCustomCheat,
+  onRemoveCustomCheat,
+  gameTitle,
+}) => {
+  // -------------------------------------------------------------------------
+  // Delayed unmount for exit animations
+  // -------------------------------------------------------------------------
+  const [mounted, setMounted] = useState(open);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setMounted(true);
+    } else if (mounted) {
+      timerRef.current = setTimeout(() => {
+        setMounted(false);
+        timerRef.current = null;
+      }, UNMOUNT_DELAY);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [open, mounted]);
+
+  // -------------------------------------------------------------------------
+  // Escape to close
+  // -------------------------------------------------------------------------
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [open, onClose]);
+
+  // -------------------------------------------------------------------------
+  // Search filter
+  // -------------------------------------------------------------------------
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Reset search when panel opens
+  useEffect(() => {
+    if (open) {
+      setSearchQuery("");
+    }
+  }, [open]);
+
+  const filteredCheats = useMemo(() => {
+    if (!searchQuery.trim()) {
+      return cheats;
+    }
+    const query = searchQuery.toLowerCase();
+    return cheats.filter(
+      (cheat) =>
+        cheat.description.toLowerCase().includes(query) || cheat.code.toLowerCase().includes(query),
+    );
+  }, [cheats, searchQuery]);
+
+  // -------------------------------------------------------------------------
+  // Custom cheat form
+  // -------------------------------------------------------------------------
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newDescription, setNewDescription] = useState("");
+  const [newCode, setNewCode] = useState("");
+  const descriptionInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (showAddForm) {
+      descriptionInputRef.current?.focus();
+    }
+  }, [showAddForm]);
+
+  const handleAddCheat = () => {
+    const trimmedCode = newCode.trim();
+    if (!trimmedCode) {
+      return;
+    }
+    onAddCustomCheat(newDescription.trim() || "Custom Cheat", trimmedCode);
+    setNewDescription("");
+    setNewCode("");
+    setShowAddForm(false);
+  };
+
+  const handleAddFormKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && newCode.trim()) {
+      e.preventDefault();
+      handleAddCheat();
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setShowAddForm(false);
+    }
+  };
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+  if (!open && !mounted) {
+    return null;
+  }
+
+  const closing = !open && mounted;
+  const hasAnyCheats = cheats.length > 0 || customCheats.length > 0;
+
+  return (
+    <div
+      className={`absolute inset-0 z-50 flex items-center justify-center ${closing ? "animate-overlay-fade-out pointer-events-none" : "animate-overlay-fade-in"}`}
+      role="dialog"
+      aria-label="Cheat Codes"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60"
+        data-testid="cheat-panel-backdrop"
+        onClick={closing ? undefined : onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={`relative z-10 bg-black/90 border border-white/10 rounded-xl shadow-2xl max-w-lg w-full mx-4 flex flex-col max-h-[80vh] ${closing ? "animate-dialog-scan-out" : "animate-dialog-scan-in"}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-white/10">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-white truncate">{gameTitle}</h2>
+            <p className="text-xs text-white/40 mt-0.5">Cheat Codes</p>
+          </div>
+          <button
+            className="p-1.5 rounded-lg text-white/40 hover:text-white hover:bg-white/10 transition-colors"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Search bar (only shown when there are database cheats to search) */}
+        {cheats.length > 5 && (
+          <div className="px-5 pt-3">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white/30" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search cheats..."
+                className="w-full bg-white/5 border border-white/10 rounded-lg pl-8 pr-3 py-1.5 text-xs text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Cheat list */}
+        <div className="flex-1 overflow-y-auto px-5 py-3 space-y-1">
+          {/* Empty state */}
+          {!hasAnyCheats && (
+            <div className="py-8 text-center">
+              <p className="text-sm text-white/40">No cheats found for this game.</p>
+              <p className="text-xs text-white/25 mt-1">Add a custom cheat below.</p>
+            </div>
+          )}
+
+          {/* Database cheats */}
+          {filteredCheats.map((cheat) => (
+            <CheatRow
+              key={`db-${cheat.index}`}
+              description={cheat.description}
+              code={cheat.code}
+              enabled={cheat.enabled}
+              onToggle={(enabled) => onToggleCheat(cheat.index, enabled)}
+            />
+          ))}
+
+          {/* Search no results */}
+          {cheats.length > 0 && filteredCheats.length === 0 && searchQuery.trim() && (
+            <p className="py-4 text-center text-xs text-white/30">
+              No cheats matching &ldquo;{searchQuery}&rdquo;
+            </p>
+          )}
+
+          {/* Custom cheats section */}
+          {customCheats.length > 0 && (
+            <>
+              {cheats.length > 0 && (
+                <div className="border-t border-white/10 mt-3 pt-3">
+                  <p className="text-[10px] font-medium uppercase tracking-wider text-white/25 mb-2">
+                    Custom Cheats
+                  </p>
+                </div>
+              )}
+              {customCheats.map((cheat, i) => (
+                <CheatRow
+                  key={`custom-${i}`}
+                  description={cheat.description}
+                  code={cheat.code}
+                  enabled={cheat.enabled}
+                  onToggle={(enabled) => onToggleCustomCheat(i, enabled)}
+                  onRemove={() => onRemoveCustomCheat(i)}
+                />
+              ))}
+            </>
+          )}
+        </div>
+
+        {/* Add custom cheat */}
+        <div className="border-t border-white/10 px-5 py-3">
+          {showAddForm ? (
+            <div className="space-y-2" onKeyDown={handleAddFormKeyDown}>
+              <input
+                ref={descriptionInputRef}
+                type="text"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                placeholder="Description (optional)"
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-xs text-white placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+              />
+              <input
+                type="text"
+                value={newCode}
+                onChange={(e) => setNewCode(e.target.value)}
+                placeholder="Cheat code (e.g. APEETPEY)"
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-xs text-white font-mono placeholder:text-white/30 focus:outline-none focus:ring-1 focus:ring-white/20"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleAddCheat}
+                  disabled={!newCode.trim()}
+                  className="flex-1 bg-white/10 hover:bg-white/15 disabled:opacity-30 disabled:hover:bg-white/10 text-white text-xs font-medium rounded-lg py-1.5 transition-colors"
+                >
+                  Add
+                </button>
+                <button
+                  onClick={() => setShowAddForm(false)}
+                  className="px-3 text-white/40 hover:text-white text-xs rounded-lg py-1.5 transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="flex items-center gap-1.5 text-xs text-white/40 hover:text-white transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Add custom cheat
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// CheatRow
+// ---------------------------------------------------------------------------
+
+interface CheatRowProps {
+  description: string;
+  code: string;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  onRemove?: () => void;
+}
+
+const CheatRow: React.FC<CheatRowProps> = ({ description, code, enabled, onToggle, onRemove }) => {
+  return (
+    <div className="flex items-center gap-3 py-1.5 group">
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-white/80 truncate">{description}</p>
+        <p className="text-[10px] text-white/25 font-mono truncate">{code}</p>
+      </div>
+
+      {onRemove && (
+        <button
+          onClick={onRemove}
+          className="p-1 rounded text-white/20 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+          aria-label={`Remove ${description}`}
+        >
+          <Trash2 className="w-3 h-3" />
+        </button>
+      )}
+
+      {/* Toggle switch */}
+      <button
+        role="switch"
+        aria-checked={enabled}
+        aria-label={`Toggle ${description}`}
+        onClick={() => onToggle(!enabled)}
+        className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${enabled ? "bg-green-500/80" : "bg-white/10"}`}
+      >
+        <span
+          className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform ${enabled ? "translate-x-[15px]" : "translate-x-[2px]"}`}
+        />
+      </button>
+    </div>
+  );
+};

--- a/packages/ui/components/CheatPanel/CheatPanel.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { X, Plus, Trash2, Search } from "lucide-react";
+import { Switch } from "../ui/switch";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,6 +19,8 @@ export interface CustomCheatItem {
   enabled: boolean;
 }
 
+export type CheatDatabaseStatus = "ready" | "downloading" | "not-downloaded" | "error";
+
 export interface CheatPanelProps {
   open: boolean;
   onClose: () => void;
@@ -28,6 +31,10 @@ export interface CheatPanelProps {
   onAddCustomCheat: (description: string, code: string) => void;
   onRemoveCustomCheat: (index: number) => void;
   gameTitle: string;
+  /** Status of the cheat database. Controls empty-state messaging. */
+  databaseStatus?: CheatDatabaseStatus;
+  /** Callback to trigger cheat database download. */
+  onDownloadDatabase?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -50,6 +57,8 @@ export const CheatPanel: React.FC<CheatPanelProps> = ({
   onAddCustomCheat,
   onRemoveCustomCheat,
   gameTitle,
+  databaseStatus = "ready",
+  onDownloadDatabase,
 }) => {
   // -------------------------------------------------------------------------
   // Delayed unmount for exit animations
@@ -218,8 +227,42 @@ export const CheatPanel: React.FC<CheatPanelProps> = ({
 
         {/* Cheat list */}
         <div className="flex-1 overflow-y-auto px-5 py-3 space-y-1">
-          {/* Empty state */}
-          {!hasAnyCheats && (
+          {/* Empty / download states */}
+          {!hasAnyCheats && databaseStatus === "downloading" && (
+            <div className="py-8 text-center">
+              <div className="inline-block w-5 h-5 border-2 border-white/20 border-t-white/60 rounded-full animate-spin mb-3" />
+              <p className="text-sm text-white/40">Downloading cheat database…</p>
+              <p className="text-xs text-white/25 mt-1">This only happens once.</p>
+            </div>
+          )}
+          {!hasAnyCheats && databaseStatus === "not-downloaded" && (
+            <div className="py-8 text-center">
+              <p className="text-sm text-white/40">Cheat database not downloaded yet.</p>
+              {onDownloadDatabase && (
+                <button
+                  onClick={onDownloadDatabase}
+                  className="mt-3 px-4 py-1.5 bg-white/10 hover:bg-white/15 text-white text-xs font-medium rounded-lg transition-colors"
+                >
+                  Download Cheat Database
+                </button>
+              )}
+            </div>
+          )}
+          {!hasAnyCheats && databaseStatus === "error" && (
+            <div className="py-8 text-center">
+              <p className="text-sm text-red-400/80">Failed to download cheat database.</p>
+              {onDownloadDatabase && (
+                <button
+                  onClick={onDownloadDatabase}
+                  className="mt-3 px-4 py-1.5 bg-white/10 hover:bg-white/15 text-white text-xs font-medium rounded-lg transition-colors"
+                >
+                  Retry Download
+                </button>
+              )}
+              <p className="text-xs text-white/25 mt-2">You can still add custom cheats below.</p>
+            </div>
+          )}
+          {!hasAnyCheats && databaseStatus === "ready" && (
             <div className="py-8 text-center">
               <p className="text-sm text-white/40">No cheats found for this game.</p>
               <p className="text-xs text-white/25 mt-1">Add a custom cheat below.</p>
@@ -348,18 +391,12 @@ const CheatRow: React.FC<CheatRowProps> = ({ description, code, enabled, onToggl
         </button>
       )}
 
-      {/* Toggle switch */}
-      <button
-        role="switch"
-        aria-checked={enabled}
+      <Switch
+        checked={enabled}
+        onCheckedChange={onToggle}
         aria-label={`Toggle ${description}`}
-        onClick={() => onToggle(!enabled)}
-        className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${enabled ? "bg-green-500/80" : "bg-white/15"}`}
-      >
-        <span
-          className={`absolute top-[3px] w-3.5 h-3.5 rounded-full bg-white shadow-sm transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-[3px]"}`}
-        />
-      </button>
+        className="data-[state=checked]:bg-green-500/80 data-[state=unchecked]:bg-white/15"
+      />
     </div>
   );
 };

--- a/packages/ui/components/CheatPanel/CheatPanel.tsx
+++ b/packages/ui/components/CheatPanel/CheatPanel.tsx
@@ -354,10 +354,10 @@ const CheatRow: React.FC<CheatRowProps> = ({ description, code, enabled, onToggl
         aria-checked={enabled}
         aria-label={`Toggle ${description}`}
         onClick={() => onToggle(!enabled)}
-        className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${enabled ? "bg-green-500/80" : "bg-white/10"}`}
+        className={`relative w-9 h-5 rounded-full transition-colors flex-shrink-0 ${enabled ? "bg-green-500/80" : "bg-white/15"}`}
       >
         <span
-          className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white shadow-sm transition-transform ${enabled ? "translate-x-[15px]" : "translate-x-[2px]"}`}
+          className={`absolute top-[3px] w-3.5 h-3.5 rounded-full bg-white shadow-sm transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-[3px]"}`}
         />
       </button>
     </div>

--- a/packages/ui/components/CheatPanel/index.ts
+++ b/packages/ui/components/CheatPanel/index.ts
@@ -1,2 +1,7 @@
 export { CheatPanel } from "./CheatPanel";
-export type { CheatPanelProps, CheatItem, CustomCheatItem } from "./CheatPanel";
+export type {
+  CheatPanelProps,
+  CheatItem,
+  CustomCheatItem,
+  CheatDatabaseStatus,
+} from "./CheatPanel";

--- a/packages/ui/components/CheatPanel/index.ts
+++ b/packages/ui/components/CheatPanel/index.ts
@@ -1,0 +1,2 @@
+export { CheatPanel } from "./CheatPanel";
+export type { CheatPanelProps, CheatItem, CustomCheatItem } from "./CheatPanel";

--- a/packages/ui/components/ui/switch.tsx
+++ b/packages/ui/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "../../utils";
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -7,6 +7,7 @@ export * from "./components/ui/dialog";
 export * from "./components/ui/input";
 export * from "./components/ui/select";
 export * from "./components/ui/dropdown-menu";
+export * from "./components/ui/switch";
 
 export * from "./components/ControllerConfig";
 export * from "./components/ControlsOverlay";

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -10,6 +10,7 @@ export * from "./components/ui/dropdown-menu";
 
 export * from "./components/ControllerConfig";
 export * from "./components/ControlsOverlay";
+export * from "./components/CheatPanel";
 export * from "./components/CoreDownloadBanner";
 export * from "./components/UpdateNotification";
 export * from "./components/GameCard";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1844,6 +1847,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -7157,6 +7173,21 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.1.8
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.8)(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
## Summary

- **Per-game cheat persistence** (#280): Stores enabled cheat indices and custom cheats per game in `<userData>/cheat-config.json`. Auto-applies persisted cheats on game launch.
- **Cheat browser panel** (#278): Presentational `CheatPanel` component in `packages/ui/` with dark glass overlay, toggle switches, search filter (for large lists), and CRT scan animations matching the existing ControlsOverlay aesthetic.
- **Custom cheat entry** (#279): Inline form in the cheat panel for adding user-defined cheats with description and code fields. Custom cheats are persisted and can be toggled/removed independently.
- **GameWindow integration**: Accessible from the settings menu (gear > Cheats). Auto-pauses the game when opened, resumes on close.

### Storybook stories

5 stories covering: default cheats, empty state, many cheats (scrollable with search), with custom cheats, and custom cheats only.

Closes #278, Closes #279, Closes #280

## Test plan

- [x] All 966 tests pass (658 desktop + 308 UI)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)
- [x] Format passes (`pnpm format`)
- [x] Storybook stories render correctly (verified all 5 stories)
- [ ] Manual: launch a game, open cheats panel from settings menu, toggle cheats, add custom cheat, verify persistence across game restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)