### PR TITLE
feat: worker protocol, IPC, and overlay for multi-disc swap

### DIFF
--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -53,6 +53,7 @@ export class GameWindowManager extends EventEmitter {
     avInfo: AVInfo,
     shouldResume = false,
     cardScreenBounds?: { x: number; y: number; width: number; height: number },
+    discInfo?: { paths: Array<string>; initialIndex: number },
   ): BrowserWindow {
     const existingWindow = this.gameWindows.get(game.id);
     if (existingWindow && !existingWindow.isDestroyed()) {
@@ -156,6 +157,12 @@ export class GameWindowManager extends EventEmitter {
       gameWindow.webContents.send("game:loaded", game);
       gameWindow.webContents.send("game:mode", "native");
       gameWindow.webContents.send("game:av-info", avInfo);
+      if (discInfo) {
+        gameWindow.webContents.send("game:disc-info", {
+          total: discInfo.paths.length,
+          currentIndex: discInfo.initialIndex,
+        });
+      }
 
       // If no hero transition, tell renderer to start boot animation immediately
       // and focus the window so keyboard input works right away.

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -25,6 +25,10 @@ export interface EmulationWorkerInitOptions {
   saveStatesDir: string;
   sramDir: string;
   systemDir: string;
+  /** All disc paths for multi-disc games, ordered by disc number. */
+  discPaths?: Array<string>;
+  /** 0-indexed disc to start on (defaults to 0). */
+  initialDiscIndex?: number;
 }
 
 interface PendingRequest {
@@ -194,6 +198,10 @@ export class EmulationWorkerClient extends EventEmitter {
 
   async cheatSet(index: number, enabled: boolean, code: string): Promise<void> {
     await this.sendRequest({ action: "cheatSet", index, enabled, code });
+  }
+
+  async swapDisc(index: number): Promise<void> {
+    await this.sendRequest({ action: "swapDisc", index });
   }
 
   /**
@@ -406,6 +414,10 @@ export class EmulationWorkerClient extends EventEmitter {
       case "serialDetected":
         this.detectedSerial = event.serial;
         libretroLog.info(`CD-ROM serial detected: ${event.serial}`);
+        break;
+
+      case "discChanged":
+        this.emit("discChanged", { index: event.index, total: event.total });
         break;
 
       case "ready":

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -426,6 +426,7 @@ export class EmulatorManager extends EventEmitter {
       client.on("reset", () => this.emit("emulator:reset"));
       client.on("error", (error) => this.emit("emulator:error", error));
       client.on("speedChanged", (data) => this.emit("emulator:speedChanged", data));
+      client.on("discChanged", (data) => this.emit("emulator:discChanged", data));
     }
   }
 
@@ -512,6 +513,16 @@ export class EmulatorManager extends EventEmitter {
       throw new Error("No emulator is currently running");
     }
     await this.currentEmulator.resume();
+  }
+
+  /**
+   * Swap the active disc in a multi-disc game.
+   */
+  async swapDisc(index: number): Promise<void> {
+    if (!this.workerClient?.isRunning()) {
+      throw new Error("No emulator is currently running");
+    }
+    await this.workerClient.swapDisc(index);
   }
 
   /**

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -342,7 +342,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(49);
+      expect(handleCalls).toHaveLength(50);
     });
   });
 
@@ -439,6 +439,8 @@ describe("IPCHandlers", () => {
         sramDir: "/saves",
         saveStatesDir: "/savestates",
         addonPath: "/fake/addon.node",
+        discPaths: undefined,
+        initialDiscIndex: undefined,
       });
       expect(emulatorManagerInstance.setWorkerClient).toHaveBeenCalledWith(workerClientInstance);
       expect(gameWindowManagerInstance.createNativeGameWindow).toHaveBeenCalledWith(
@@ -446,6 +448,7 @@ describe("IPCHandlers", () => {
         workerClientInstance,
         fakeAvInfo,
         false,
+        undefined,
         undefined,
       );
       expect(result).toEqual({ success: true });

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -189,6 +189,22 @@ export class IPCHandlers {
             // Spawn the emulation worker process
             const workerClient = new EmulationWorkerClient();
             const addonPath = resolveAddonPath();
+
+            // Build disc paths for multi-disc games
+            let discPaths: string[] | undefined;
+            let initialDiscIndex: number | undefined;
+            if (game.discGroup) {
+              const allGames = this.libraryService.getGames(systemId);
+              const groupGames = allGames
+                .filter((g) => g.discGroup === game.discGroup)
+                .sort((a, b) => (a.discNumber ?? 0) - (b.discNumber ?? 0));
+              if (groupGames.length > 1) {
+                discPaths = groupGames.map((g) => g.romPath);
+                const launchedIndex = groupGames.findIndex((g) => g.id === game.id);
+                initialDiscIndex = launchedIndex >= 0 ? launchedIndex : 0;
+              }
+            }
+
             const avInfo = await workerClient.init({
               corePath: nativeCore.getCorePath(),
               romPath: nativeCore.getRomPath(),
@@ -197,6 +213,8 @@ export class IPCHandlers {
               sramDir: nativeCore.getSramDir(),
               saveStatesDir: nativeCore.getSaveStatesDir(),
               addonPath,
+              discPaths,
+              initialDiscIndex,
             });
 
             // Store the worker client on the emulator manager for control routing
@@ -213,6 +231,7 @@ export class IPCHandlers {
               avInfo,
               shouldResume,
               cardScreenBounds,
+              discPaths ? { paths: discPaths, initialIndex: initialDiscIndex ?? 0 } : undefined,
             );
           } else {
             // Legacy overlay mode: external RetroArch process
@@ -300,6 +319,16 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to set fast-forward audio:", error);
+        return { success: false, error: errorMessage(error) };
+      }
+    });
+
+    ipcMain.handle("emulation:swapDisc", async (_event, index: number) => {
+      try {
+        await this.emulatorManager.swapDisc(index);
+        return { success: true };
+      } catch (error) {
+        ipcLog.error("Failed to swap disc:", error);
         return { success: false, error: errorMessage(error) };
       }
     });
@@ -513,6 +542,9 @@ export class IPCHandlers {
     this.emulatorManager.on("emulator:reset", () => forwardEvent("emulator:reset"));
     this.emulatorManager.on("emulator:speedChanged", (data) =>
       forwardEvent("emulator:speedChanged", data),
+    );
+    this.emulatorManager.on("emulator:discChanged", (data) =>
+      forwardEvent("emulator:discChanged", data),
     );
     this.emulatorManager.on("emulator:terminated", () => {
       forwardEvent("emulator:terminated");

--- a/apps/desktop/src/main/services/LibraryService.test.ts
+++ b/apps/desktop/src/main/services/LibraryService.test.ts
@@ -6,9 +6,14 @@ import crypto from "node:crypto";
 import zlib from "node:zlib";
 import { execFileSync } from "node:child_process";
 
-// Mock electron before importing LibraryService
+// Mock electron before importing LibraryService.
+// Each test gets its own userData subdirectory to prevent cross-test
+// interference from async writes that haven't settled between tests.
+// Two concurrent LibraryService instances writing to the same .tmp path
+// causes ENOENT races in atomicWriteJSON.
 const TEST_DIR = path.join(os.tmpdir(), "gamelord-library-service-test-" + Date.now());
-const USER_DATA_DIR = path.join(TEST_DIR, "userData");
+let userDataSeq = 0;
+let USER_DATA_DIR = path.join(TEST_DIR, "userData-0");
 const HOME_DIR = path.join(TEST_DIR, "home");
 const ROMS_DIR = path.join(TEST_DIR, "roms");
 
@@ -46,24 +51,37 @@ import type { GameSystem, Game } from "../../types/library";
  */
 async function createService(): Promise<LibraryService> {
   const service = new LibraryService();
-  // Allow the constructor's async calls (loadConfig, loadLibrary) to settle
+  // The constructor fires loadConfig() and loadLibrary() without awaiting them.
+  // loadConfig triggers a chain of async operations (backfill, repair, migrate,
+  // scaffold), each calling saveConfig(). We must wait for the entire chain.
+  //
+  // Poll until the config file on disk stops changing — this signals the last
+  // saveConfig() in the chain has completed.
+  let lastMtime = 0;
+  let stableCount = 0;
   await vi.waitFor(
-    async () => {
-      // Config is loaded when systems array is populated (default config has DEFAULT_SYSTEMS)
-      // or the config file was read successfully
-      const config = service.getConfig();
-      if (
-        config.systems.length === 0 &&
-        !fs.existsSync(path.join(USER_DATA_DIR, "library-config.json"))
-      ) {
-        // Still loading — config hasn't been written yet
-        throw new Error("Config not yet loaded");
+    () => {
+      const configPath = path.join(USER_DATA_DIR, "library-config.json");
+      if (!fs.existsSync(configPath)) {
+        throw new Error("Config file not yet written to disk");
+      }
+      const mtime = fs.statSync(configPath).mtimeMs;
+      if (mtime !== lastMtime) {
+        lastMtime = mtime;
+        stableCount = 0;
+        throw new Error("Config file still being written");
+      }
+      stableCount++;
+      // Require 5 consecutive stable polls (~100ms) to confirm no more writes.
+      // The init chain runs multiple saveConfig() calls in sequence — each one
+      // does stringify + writeFile + rename, so they can land within the same
+      // mtime granularity window on some filesystems.
+      if (stableCount < 5) {
+        throw new Error("Waiting for config to stabilize");
       }
     },
-    { interval: 10, timeout: 2000 },
+    { interval: 20, timeout: 5000 },
   );
-  // Extra tick to ensure saveConfig completes on first-run path
-  await new Promise((resolve) => setTimeout(resolve, 50));
   return service;
 }
 
@@ -114,7 +132,6 @@ const TEST_GB_SYSTEM: GameSystem = {
 };
 
 beforeAll(() => {
-  fs.mkdirSync(USER_DATA_DIR, { recursive: true });
   fs.mkdirSync(HOME_DIR, { recursive: true });
   fs.mkdirSync(ROMS_DIR, { recursive: true });
 });
@@ -124,20 +141,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  // Clean userData files between tests so each test starts fresh
-  for (const file of [
-    "library-config.json",
-    "library-config.json.bak",
-    "library-config.json.tmp",
-    "library.json",
-    "library.json.bak",
-    "library.json.tmp",
-  ]) {
-    const filePath = path.join(USER_DATA_DIR, file);
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
-    }
-  }
+  // Give each test a fresh userData directory so two concurrent
+  // LibraryService instances (previous test's unsettled async + current
+  // test's new instance) never race on the same .tmp file path.
+  userDataSeq++;
+  USER_DATA_DIR = path.join(TEST_DIR, `userData-${userDataSeq}`);
+  fs.mkdirSync(USER_DATA_DIR, { recursive: true });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -85,6 +85,10 @@ export type WorkerCommand =
       sramDir: string;
       saveStatesDir: string;
       addonPath: string;
+      /** All disc paths for multi-disc games, ordered by disc number. */
+      discPaths?: Array<string>;
+      /** 0-indexed disc to start on (defaults to 0). */
+      initialDiscIndex?: number;
     }
   | { action: "pause" }
   | { action: "resume" }
@@ -111,7 +115,8 @@ export type WorkerCommand =
       enabled: boolean;
       code: string;
       requestId: string;
-    };
+    }
+  | { action: "swapDisc"; index: number; requestId: string };
 
 // ---------------------------------------------------------------------------
 // Libretro log levels (from libretro.h RETRO_LOG_*)
@@ -183,4 +188,5 @@ export type WorkerEvent =
       success: boolean;
       error?: string;
       data?: unknown;
-    };
+    }
+  | { type: "discChanged"; index: number; total: number };

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -42,6 +42,9 @@ let sramDir = "";
 let saveStatesDir = "";
 let screenshotDir = "";
 
+// Multi-disc: when set, SRAM derives from the group base name instead of romPath
+let sramBaseName: string | null = null;
+
 // Timing
 let targetFps = 60;
 let speedMultiplier = 1;
@@ -83,7 +86,8 @@ function getRomName(): string {
 }
 
 function getSramPath(): string {
-  return path.join(sramDir, `${getRomName()}.srm`);
+  const name = sramBaseName ?? getRomName();
+  return path.join(sramDir, `${name}.srm`);
 }
 
 function getStatePath(slot: number): string {
@@ -247,6 +251,20 @@ function initialize(command: Extract<WorkerCommand, { action: "init" }>): void {
         send({ type: "serialDetected", serial });
         serialDetected = true;
       }
+    }
+  }
+
+  // Set up multi-disc support
+  if (command.discPaths && command.discPaths.length > 1) {
+    native.setDiscPaths(command.discPaths);
+
+    // Derive SRAM base name from the first disc path (strip disc suffix like " (Disc 1)")
+    const firstDiscName = path.basename(command.discPaths[0], path.extname(command.discPaths[0]));
+    sramBaseName = firstDiscName.replace(/\s*\(Disc\s*\d+\)/i, "").trim();
+
+    // If launching from a non-first disc, swap to it
+    if (command.initialDiscIndex && command.initialDiscIndex > 0) {
+      native.swapDisc(command.initialDiscIndex);
     }
   }
 
@@ -706,6 +724,30 @@ function handleMessage(command: WorkerCommand): void {
       try {
         native?.cheatSet(command.index, command.enabled, command.code);
         sendResponse(command.requestId, true);
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
+    case "swapDisc":
+      try {
+        if (!native) {
+          throw new Error("No core loaded");
+        }
+        const swapSuccess = native.swapDisc(command.index);
+        if (!swapSuccess) {
+          throw new Error(`Failed to swap to disc ${command.index}`);
+        }
+        sendResponse(command.requestId, true);
+        send({
+          type: "discChanged",
+          index: command.index,
+          total: native.getDiscCount(),
+        });
       } catch (error) {
         sendResponse(
           command.requestId,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -50,6 +50,7 @@ contextBridge.exposeInMainWorld("gamelord", {
     setSpeed: (multiplier: number) => ipcRenderer.invoke("emulation:setSpeed", multiplier),
     setFastForwardAudio: (enabled: boolean) =>
       ipcRenderer.invoke("emulation:setFastForwardAudio", enabled),
+    swapDisc: (index: number) => ipcRenderer.invoke("emulation:swapDisc", index),
   },
 
   // Save states
@@ -102,10 +103,12 @@ contextBridge.exposeInMainWorld("gamelord", {
       "emulator:resumed",
       "emulator:reset",
       "emulator:speedChanged",
+      "emulator:discChanged",
       "emulator:terminated",
       "game:loaded",
       "game:mode",
       "game:av-info",
+      "game:disc-info",
       "game:video-frame",
       "game:audio-samples",
       "overlay:show-controls",

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -5,6 +5,8 @@ import {
   type CheatItem,
   type CustomCheatItem,
   ControlsOverlay,
+  DiscSwapOverlay,
+  type DiscInfo,
   type KeyboardBinding,
   filterBindingsForSystem,
   WebGLRenderer,
@@ -149,6 +151,12 @@ export const GameWindow: React.FC = () => {
   const [showControlsHint, setShowControlsHint] = useState(() => {
     return localStorage.getItem("gamelord:controlsHintDismissed") !== "true";
   });
+
+  // Multi-disc state
+  const [discTotal, setDiscTotal] = useState(0);
+  const [currentDiscIndex, setCurrentDiscIndex] = useState(0);
+  const [showDiscSwapOverlay, setShowDiscSwapOverlay] = useState(false);
+  const [swappingDiscIndex, setSwappingDiscIndex] = useState<number | undefined>(undefined);
 
   // Auto-dismiss the controls hint after 8 seconds and persist the dismissal
   useEffect(() => {
@@ -485,6 +493,8 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners("game:prepare-close");
     api.removeAllListeners("game:ready-for-boot");
     api.removeAllListeners("emulator:speedChanged");
+    api.removeAllListeners("emulator:discChanged");
+    api.removeAllListeners("game:disc-info");
     api.removeAllListeners("game:emulation-error");
 
     // Register for SharedArrayBuffer delivery via MessagePort bridge.
@@ -548,6 +558,21 @@ export const GameWindow: React.FC = () => {
       // Reset audio scheduling anchor so leftover scheduling offsets from the
       // previous speed don't cause buffer overlap during the transition.
       audioNextTimeRef.current = 0;
+    });
+
+    api.on("emulator:discChanged", (raw: unknown) => {
+      const data = raw as { index: number; total: number };
+      setCurrentDiscIndex(data.index);
+      setDiscTotal(data.total);
+      setSwappingDiscIndex(undefined);
+      // Auto-close the overlay after a successful swap
+      setShowDiscSwapOverlay(false);
+    });
+
+    api.on("game:disc-info", (raw: unknown) => {
+      const data = raw as { total: number; currentIndex: number };
+      setDiscTotal(data.total);
+      setCurrentDiscIndex(data.currentIndex);
     });
 
     api.on("game:emulation-error", (raw: unknown) => {
@@ -934,6 +959,20 @@ export const GameWindow: React.FC = () => {
         e.preventDefault();
         void handleToggleFastForward();
       }
+      if (e.key === "F6" && discTotal > 1) {
+        e.preventDefault();
+        setShowDiscSwapOverlay((prev) => {
+          const willOpen = !prev;
+          if (willOpen && !isPaused) {
+            pausedByOverlayRef.current = true;
+            api.emulation.pause().catch(console.error);
+          } else if (!willOpen && pausedByOverlayRef.current) {
+            pausedByOverlayRef.current = false;
+            api.emulation.resume().catch(console.error);
+          }
+          return willOpen;
+        });
+      }
       if (e.key === "?" || e.key === "F1") {
         e.preventDefault();
         setShowControlsOverlay((prev) => {
@@ -956,7 +995,14 @@ export const GameWindow: React.FC = () => {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isPaused, selectedSlot, speedMultiplier, preferredFastForwardSpeed, showControlsHint]);
+  }, [
+    isPaused,
+    selectedSlot,
+    speedMultiplier,
+    preferredFastForwardSpeed,
+    showControlsHint,
+    discTotal,
+  ]);
 
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isOverControlsRef = useRef(false);
@@ -1577,6 +1623,36 @@ export const GameWindow: React.FC = () => {
           </div>
         </div>
       </div>
+
+      {/* Disc swap overlay (multi-disc games only) */}
+      {discTotal > 1 && (
+        <DiscSwapOverlay
+          open={showDiscSwapOverlay}
+          onClose={() => {
+            setShowDiscSwapOverlay(false);
+            if (pausedByOverlayRef.current) {
+              pausedByOverlayRef.current = false;
+              api.emulation.resume().catch(console.error);
+            }
+          }}
+          onSwap={(index) => {
+            setSwappingDiscIndex(index);
+            api.emulation.swapDisc(index).catch((error) => {
+              console.error("Disc swap failed:", error);
+              setSwappingDiscIndex(undefined);
+            });
+          }}
+          discs={Array.from(
+            { length: discTotal },
+            (_, i): DiscInfo => ({
+              index: i,
+              label: `Disc ${i + 1}`,
+              status: i === currentDiscIndex ? "current" : "available",
+            }),
+          )}
+          swappingIndex={swappingDiscIndex}
+        />
+      )}
 
       {/* Controls reference overlay */}
       <ControlsOverlay

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -41,6 +41,7 @@ export interface GamelordAPI {
     ) => Promise<{ success: boolean; path?: string; error?: string }>;
     setSpeed: (multiplier: number) => Promise<{ success: boolean; error?: string }>;
     setFastForwardAudio: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+    swapDisc: (index: number) => Promise<{ success: boolean; error?: string }>;
   };
   saveState: {
     save: (slot: number) => Promise<{ success: boolean }>;

--- a/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.stories.tsx
+++ b/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { DiscSwapOverlay } from "./DiscSwapOverlay";
+import type { DiscInfo } from "./DiscSwapOverlay";
+
+const THREE_DISC_GAME: ReadonlyArray<DiscInfo> = [
+  { index: 0, label: "Disc 1", status: "current" },
+  { index: 1, label: "Disc 2", status: "available" },
+  { index: 2, label: "Disc 3", status: "available" },
+];
+
+const INCOMPLETE_SET: ReadonlyArray<DiscInfo> = [
+  { index: 0, label: "Disc 1", status: "current" },
+  { index: 1, label: "Disc 2", status: "missing" },
+  { index: 2, label: "Disc 3", status: "available" },
+];
+
+const meta: Meta<typeof DiscSwapOverlay> = {
+  component: DiscSwapOverlay,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  title: "Components/DiscSwapOverlay",
+  args: {
+    open: true,
+    onClose: fn(),
+    onSwap: fn(),
+    discs: THREE_DISC_GAME,
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "100vh",
+          background: "#111",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DiscSwapOverlay>;
+
+/** 3-disc game, currently on Disc 1. */
+export const ThreeDiscGame: Story = {};
+
+/** Incomplete set — Disc 2 is missing from the library. */
+export const MissingDisc: Story = {
+  args: {
+    discs: INCOMPLETE_SET,
+  },
+};
+
+/** Swap in progress — loading indicator on the target disc. */
+export const SwapInProgress: Story = {
+  args: {
+    swappingIndex: 1,
+  },
+};
+
+/** Currently on Disc 2 (mid-game). */
+export const OnDiscTwo: Story = {
+  args: {
+    discs: [
+      { index: 0, label: "Disc 1", status: "available" },
+      { index: 1, label: "Disc 2", status: "current" },
+      { index: 2, label: "Disc 3", status: "available" },
+    ],
+  },
+};
+
+/** Four-disc game (e.g. Final Fantasy VIII). */
+export const FourDiscGame: Story = {
+  args: {
+    discs: [
+      { index: 0, label: "Disc 1", status: "current" },
+      { index: 1, label: "Disc 2", status: "available" },
+      { index: 2, label: "Disc 3", status: "available" },
+      { index: 3, label: "Disc 4", status: "available" },
+    ],
+  },
+};
+
+export const Closed: Story = {
+  args: {
+    open: false,
+  },
+};

--- a/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.tsx
+++ b/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState } from "react";
+
+export type DiscStatus = "current" | "available" | "missing" | "swapping";
+
+export interface DiscInfo {
+  /** 0-indexed disc number. */
+  index: number;
+  /** Display label (e.g. "Disc 1"). */
+  label: string;
+  status: DiscStatus;
+}
+
+export interface DiscSwapOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  onSwap: (index: number) => void;
+  discs: ReadonlyArray<DiscInfo>;
+  /** Index of the disc currently being swapped to (shows loading state). */
+  swappingIndex?: number;
+}
+
+/**
+ * Delay (ms) to keep the DOM mounted after `open` goes false so exit
+ * animations have time to play. Matches the longest close animation
+ * (dialog-scan-out at 200ms) plus a small buffer.
+ */
+const UNMOUNT_DELAY = 220;
+
+export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
+  open,
+  onClose,
+  onSwap,
+  discs,
+  swappingIndex,
+}) => {
+  // Delayed unmount: keep the DOM alive while exit animations play.
+  const [mounted, setMounted] = useState(open);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setMounted(true);
+    } else if (mounted) {
+      timerRef.current = setTimeout(() => {
+        setMounted(false);
+        timerRef.current = null;
+      }, UNMOUNT_DELAY);
+    }
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [open, mounted]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [open, onClose]);
+
+  if (!open && !mounted) {
+    return null;
+  }
+
+  const closing = !open && mounted;
+  const isSwapping = swappingIndex !== undefined;
+
+  return (
+    <div
+      className={`absolute inset-0 z-50 flex items-center justify-center ${closing ? "animate-overlay-fade-out pointer-events-none" : "animate-overlay-fade-in"}`}
+      role="dialog"
+      aria-label="Disc Swap"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60"
+        data-testid="disc-swap-overlay-backdrop"
+        onClick={closing || isSwapping ? undefined : onClose}
+      />
+
+      {/* Panel */}
+      <div
+        className={`relative z-10 bg-black/90 border border-white/10 rounded-xl p-5 max-w-xs w-full mx-4 shadow-2xl ${closing ? "animate-dialog-scan-out" : "animate-dialog-scan-in"}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-4">
+          <DiscIcon className="size-5 text-white/70" />
+          <h2 className="text-sm font-semibold text-white/90 tracking-wide uppercase">Swap Disc</h2>
+        </div>
+
+        {/* Disc list */}
+        <div className="flex flex-col gap-1.5">
+          {discs.map((disc) => {
+            const isCurrent = disc.status === "current";
+            const isMissing = disc.status === "missing";
+            const isThisSwapping = swappingIndex === disc.index;
+            const canClick = !isCurrent && !isMissing && !isSwapping;
+
+            return (
+              <button
+                key={disc.index}
+                disabled={!canClick}
+                onClick={() => canClick && onSwap(disc.index)}
+                className={`
+                  relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-left
+                  transition-all duration-150
+                  ${isCurrent ? "bg-white/10 border border-white/20" : "border border-transparent"}
+                  ${canClick ? "hover:bg-white/8 hover:border-white/15 cursor-pointer" : ""}
+                  ${isMissing ? "opacity-40 cursor-not-allowed" : ""}
+                  ${isThisSwapping ? "bg-white/5 border-white/15" : ""}
+                `}
+                data-testid={`disc-${disc.index}`}
+              >
+                {/* Disc number indicator */}
+                <div
+                  className={`
+                    flex items-center justify-center size-8 rounded-full text-xs font-bold
+                    transition-colors duration-150
+                    ${isCurrent ? "bg-white/20 text-white" : "bg-white/5 text-white/50"}
+                    ${isThisSwapping ? "bg-white/15 text-white/80" : ""}
+                  `}
+                >
+                  {isThisSwapping ? <LoadingSpinner className="size-4" /> : disc.index + 1}
+                </div>
+
+                {/* Label */}
+                <div className="flex-1 min-w-0">
+                  <span
+                    className={`text-sm ${isCurrent ? "text-white font-medium" : "text-white/70"}`}
+                  >
+                    {disc.label}
+                  </span>
+                  {isCurrent && (
+                    <span className="ml-2 text-[10px] uppercase tracking-wider text-white/40 font-medium">
+                      Current
+                    </span>
+                  )}
+                  {isMissing && (
+                    <span className="ml-2 text-[10px] uppercase tracking-wider text-red-400/60 font-medium">
+                      Missing
+                    </span>
+                  )}
+                  {isThisSwapping && (
+                    <span className="ml-2 text-[10px] uppercase tracking-wider text-white/40 font-medium">
+                      Swapping...
+                    </span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Footer hint */}
+        <p className="mt-3 text-center text-[11px] text-white/25">
+          Press <kbd className="px-1 py-0.5 rounded bg-white/10 text-white/40 text-[10px]">Esc</kbd>{" "}
+          or <kbd className="px-1 py-0.5 rounded bg-white/10 text-white/40 text-[10px]">F6</kbd> to
+          close
+        </p>
+      </div>
+    </div>
+  );
+};
+
+/** Minimal disc/CD icon. */
+function DiscIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+/** Spinning loading indicator. */
+function LoadingSpinner({ className }: { className?: string }) {
+  return (
+    <svg className={`animate-spin ${className ?? ""}`} viewBox="0 0 24 24" fill="none">
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeDasharray="31.4"
+        strokeDashoffset="10"
+        strokeLinecap="round"
+        opacity="0.5"
+      />
+    </svg>
+  );
+}

--- a/packages/ui/components/DiscSwapOverlay/index.ts
+++ b/packages/ui/components/DiscSwapOverlay/index.ts
@@ -1,0 +1,2 @@
+export { DiscSwapOverlay } from "./DiscSwapOverlay";
+export type { DiscSwapOverlayProps, DiscInfo, DiscStatus } from "./DiscSwapOverlay";

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -12,6 +12,7 @@ export * from "./components/ui/switch";
 export * from "./components/ControllerConfig";
 export * from "./components/ControlsOverlay";
 export * from "./components/CheatPanel";
+export * from "./components/DiscSwapOverlay";
 export * from "./components/CoreDownloadBanner";
 export * from "./components/UpdateNotification";
 export * from "./components/GameCard";


### PR DESCRIPTION
## Summary

- Wires disc swap support through the full stack: worker protocol → core-worker → EmulationWorkerClient → EmulatorManager → IPC handlers → preload API → renderer
- SRAM path derives from the group base name so all discs in a set share one save file
- New `DiscSwapOverlay` presentational component in `packages/ui/` with Storybook stories
- F6 keyboard shortcut opens the overlay during gameplay (auto-pauses, auto-closes on swap)
- Launching a multi-disc game resolves the disc group and passes all disc paths to the worker

Closes #269
Closes #270

## Test plan

- [ ] Verify `pnpm typecheck` passes (confirmed locally)
- [ ] Verify `pnpm lint` passes (confirmed locally)
- [ ] Verify all 669 tests pass (confirmed locally)
- [ ] Storybook: check DiscSwapOverlay stories (ThreeDiscGame, MissingDisc, SwapInProgress, OnDiscTwo, FourDiscGame)
- [ ] Manual: launch a multi-disc PSX game, press F6, verify overlay shows all discs
- [ ] Manual: click a different disc in the overlay, verify swap succeeds and overlay auto-closes
- [ ] Manual: verify SRAM saves persist across disc swaps (same .srm file)
- [ ] Manual: verify F6 does nothing for single-disc games

🤖 Generated with [Claude Code](https://claude.com/claude-code)