### PR TITLE
feat: add SwanStation as PSX core option for full chtdb cheat support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,6 +42,7 @@ apps/desktop/src/preload.ts   - Renderer API bridge
 ## Supported Cores
 
 - **NES:** fceumm (primary), nestopia, mesen
+- **PSX:** pcsx_rearmed (PCSX ReARMed, primary), mednafen_psx_hw (Beetle PSX HW), swanstation (SwanStation) — requires BIOS file (`scph5501.bin`). SwanStation (DuckStation fork) enables full chtdb cheat support including extended code types.
 - **Sega Saturn:** mednafen_saturn (Beetle Saturn, primary), yabause — requires BIOS files (`sega_101.bin`, `mpr-17933.bin`)
 - Cores located at: `~/Library/Application Support/GameLord/cores/`
 - BIOS files located at: `~/Library/Application Support/GameLord/BIOS/` (created automatically on startup, mirrors OpenEmu convention)

--- a/apps/desktop/native/src/libretro_core.cc
+++ b/apps/desktop/native/src/libretro_core.cc
@@ -39,6 +39,7 @@ Napi::Object LibretroCore::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("swapDisc", &LibretroCore::SwapDisc),
     InstanceMethod("getCurrentDiscIndex", &LibretroCore::GetCurrentDiscIndex),
     InstanceMethod("getDiscCount", &LibretroCore::GetDiscCount),
+    InstanceMethod("getDiscLabel", &LibretroCore::GetDiscLabel),
   });
 
   Napi::FunctionReference *constructor = new Napi::FunctionReference();
@@ -590,6 +591,27 @@ Napi::Value LibretroCore::GetDiscCount(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
   uint32_t count = s_instance ? static_cast<uint32_t>(s_instance->disc_paths_.size()) : 0;
   return Napi::Number::New(env, count);
+}
+
+Napi::Value LibretroCore::GetDiscLabel(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (!s_instance || !s_instance->has_disc_control_ext_ ||
+      !s_instance->disc_control_ext_cb_.get_image_label) {
+    return env.Null();
+  }
+
+  unsigned index = 0;
+  if (info.Length() > 0 && info[0].IsNumber()) {
+    index = info[0].As<Napi::Number>().Uint32Value();
+  }
+
+  char label[256] = {};
+  bool ok = s_instance->disc_control_ext_cb_.get_image_label(index, label, sizeof(label));
+  if (!ok || label[0] == '\0') {
+    return env.Null();
+  }
+
+  return Napi::String::New(env, label);
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/native/src/libretro_core.h
+++ b/apps/desktop/native/src/libretro_core.h
@@ -55,6 +55,7 @@ private:
   Napi::Value SwapDisc(const Napi::CallbackInfo &info);
   Napi::Value GetCurrentDiscIndex(const Napi::CallbackInfo &info);
   Napi::Value GetDiscCount(const Napi::CallbackInfo &info);
+  Napi::Value GetDiscLabel(const Napi::CallbackInfo &info);
 
   // Internal
   void CloseCore();

--- a/apps/desktop/src/main/emulator/CoreDownloader.ts
+++ b/apps/desktop/src/main/emulator/CoreDownloader.ts
@@ -37,13 +37,14 @@ const SYSTEM_CORES: Record<string, Array<string>> = {
   nds: ["desmume_libretro"],
   nes: ["fceumm_libretro", "nestopia_libretro", "mesen_libretro"],
   psp: ["ppsspp_libretro"],
-  psx: ["pcsx_rearmed_libretro", "mednafen_psx_hw_libretro"],
+  psx: ["pcsx_rearmed_libretro", "mednafen_psx_hw_libretro", "swanstation_libretro"],
   saturn: ["mednafen_saturn_libretro", "yabause_libretro"],
   snes: ["snes9x_libretro", "bsnes_libretro"],
 };
 
 /** Human-readable display names for cores. */
 const CORE_DISPLAY_NAMES: Record<string, string> = {
+  swanstation_libretro: "SwanStation",
   mednafen_psx_hw_libretro: "Beetle PSX HW",
   bsnes_libretro: "bsnes",
   desmume_libretro: "DeSmuME",
@@ -68,6 +69,8 @@ const CORE_DISPLAY_NAMES: Record<string, string> = {
 /** Short descriptions for cores. */
 const CORE_DESCRIPTIONS: Record<string, string> = {
   bsnes_libretro: "Cycle-accurate. Perfect accuracy, higher CPU usage.",
+  swanstation_libretro:
+    "High-accuracy PSX emulation with full chtdb cheat support including extended code types.",
   fceumm_libretro: "Accurate and fast NES emulation.",
   gambatte_libretro: "Accurate Game Boy/Color emulation.",
   genesis_plus_gx_libretro: "Accurate Genesis/Mega Drive emulation.",

--- a/apps/desktop/src/main/emulator/EmulatorManager.test.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.test.ts
@@ -152,6 +152,32 @@ describe("EmulatorManager — power save blocker", () => {
   });
 });
 
+describe("EmulatorManager — activeCoreId normalization", () => {
+  let manager: EmulatorManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new EmulatorManager();
+  });
+
+  it("strips _libretro suffix when coreName is explicitly provided", async () => {
+    await manager.launchGame("/rom.cue", "psx", undefined, undefined, "swanstation_libretro");
+    expect(manager.getActiveCoreId()).toBe("swanstation");
+  });
+
+  it("strips _libretro suffix for other cores too", async () => {
+    await manager.launchGame("/rom.nes", "nes", undefined, undefined, "fceumm_libretro");
+    expect(manager.getActiveCoreId()).toBe("fceumm");
+  });
+
+  it("extracts core ID from path when no coreName is provided", async () => {
+    // When no coreName is given, the mock returns "/tmp/cores/test_libretro.dylib"
+    // which should be extracted to "test"
+    await manager.launchGame("/rom.nes", "nes");
+    expect(manager.getActiveCoreId()).toBe("test");
+  });
+});
+
 describe("EmulatorManager — BIOS validation", () => {
   let manager: EmulatorManager;
 

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -307,7 +307,7 @@ export class EmulatorManager extends EventEmitter {
       nds: ["desmume_libretro"],
       nes: ["fceumm_libretro", "nestopia_libretro", "mesen_libretro"],
       psp: ["ppsspp_libretro"],
-      psx: ["pcsx_rearmed_libretro", "mednafen_psx_hw_libretro"],
+      psx: ["pcsx_rearmed_libretro", "mednafen_psx_hw_libretro", "swanstation_libretro"],
       saturn: ["mednafen_saturn_libretro", "yabause_libretro"],
       snes: ["snes9x_libretro", "bsnes_libretro"],
     };
@@ -438,7 +438,7 @@ export class EmulatorManager extends EventEmitter {
 
   /**
    * Get the identifier of the currently active libretro core
-   * (e.g. "mednafen_psx_hw", "pcsx_rearmed", "duckstation").
+   * (e.g. "mednafen_psx_hw", "pcsx_rearmed", "swanstation").
    * Returns null when no game is running.
    */
   getActiveCoreId(): string | null {

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -245,7 +245,7 @@ export class EmulatorManager extends EventEmitter {
     // Track the active core identifier for feature gating (e.g. chtdb cheats).
     // Extract from the core filename if no explicit coreName was provided.
     if (coreName) {
-      this.activeCoreId = coreName;
+      this.activeCoreId = coreName.replace(/_libretro$/, "");
     } else if (options.corePath) {
       // Core path like ".../cores/mednafen_psx_hw_libretro.dylib" → "mednafen_psx_hw"
       const coreFilename = path.basename(options.corePath);

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -345,8 +345,19 @@ export class IPCHandlers {
           // Chtdb cheats are only included when the active core is SwanStation,
           // since its extended code types are incompatible with other cores.
           const workerClient = this.emulatorManager.getWorkerClient();
-          const serial = workerClient?.getDetectedSerial() ?? undefined;
+          const runtimeSerial = workerClient?.getDetectedSerial() ?? undefined;
           const coreId = this.emulatorManager.getActiveCoreId() ?? undefined;
+
+          // Fall back to the serial stored in the game's metadata (from ScreenScraper)
+          // when the core doesn't expose it at runtime (e.g. SwanStation).
+          let serial = runtimeSerial;
+          if (!serial) {
+            const game = this.libraryService
+              .getGames(systemId)
+              .find((g) => g.romPath.endsWith(romFilename));
+            serial = game?.serial;
+          }
+
           const cheats = this.cheatDatabaseService.getCheatsForGame(
             systemId,
             romFilename,
@@ -903,7 +914,7 @@ export class IPCHandlers {
    */
   private async autoApplyCheats(workerClient: EmulationWorkerClient, game: Game): Promise<void> {
     const romFilename = game.romPath.split("/").pop() || game.romPath;
-    const serial = workerClient.getDetectedSerial() ?? undefined;
+    const serial = workerClient.getDetectedSerial() ?? game.serial;
     const coreId = this.emulatorManager.getActiveCoreId() ?? undefined;
     const enabledCheats = this.cheatPersistenceService.getEnabledCheats(
       game.id,

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -342,7 +342,7 @@ export class IPCHandlers {
       async (event: IpcMainInvokeEvent, systemId: string, romFilename: string) => {
         try {
           // Pass the CD-ROM serial and core ID for chtdb serial-based lookup.
-          // Chtdb cheats are only included when the active core is DuckStation,
+          // Chtdb cheats are only included when the active core is SwanStation,
           // since its extended code types are incompatible with other cores.
           const workerClient = this.emulatorManager.getWorkerClient();
           const serial = workerClient?.getDetectedSerial() ?? undefined;

--- a/apps/desktop/src/main/services/ArtworkService.test.ts
+++ b/apps/desktop/src/main/services/ArtworkService.test.ts
@@ -98,6 +98,7 @@ function createMockLibraryService(games: Array<Game> = []): LibraryService {
       }
     }),
     flushSave: vi.fn(async () => {}),
+    whenReady: vi.fn(async () => {}),
   } as unknown as LibraryService;
 }
 

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -122,30 +122,32 @@ export class ArtworkService extends EventEmitter {
   }
 
   /**
-   * One-time backfill for games synced before ROM-level region/serial tracking.
-   * Queries ScreenScraper by hash (no artwork download) to get romRegions
-   * and romSerial, then re-derives the regional system display name.
-   * Skips games that already have both romRegions and serial, or that lack
-   * metadata (never synced). Requires credentials — silently skips if unconfigured.
+   * Reconcile metadata for previously-synced games that are missing fields
+   * added after their original sync (e.g. serial, romRegions).
+   *
+   * Queries ScreenScraper by hash (no artwork download) and patches only
+   * the missing fields. Scoped to disc-based systems (PSX, Saturn) for
+   * serial, since that's the only field currently needing reconciliation.
+   *
+   * Requires credentials — silently skips if unconfigured.
    */
   private async backfillRomRegions(): Promise<void> {
-    // Wait for config to load (fire-and-forget constructor)
+    // Wait for both config and library to load before checking games
     await this.configLoaded;
+    await this.libraryService.whenReady();
 
     if (!this.hasCredentials()) {
       return;
     }
 
     const games = this.libraryService.getGames();
-    const needsBackfill = games.filter(
-      (g) => g.metadata && (!g.romRegions || g.romRegions.length === 0 || !g.serial),
-    );
+    const needsBackfill = games.filter((g) => g.metadata && this.hasMissingMetadata(g));
 
     if (needsBackfill.length === 0) {
       return;
     }
 
-    artworkLog.info(`Backfilling ROM metadata for ${needsBackfill.length} game(s)`);
+    artworkLog.info(`Reconciling metadata for ${needsBackfill.length} game(s)`);
 
     let client: ScreenScraperClient;
     try {
@@ -254,6 +256,29 @@ export class ArtworkService extends EventEmitter {
   async setCredentials(userId: string, userPassword: string): Promise<void> {
     this.config.screenscraper = { userId, userPassword };
     await this.saveConfig();
+  }
+
+  /**
+   * Check whether a synced game is missing any metadata fields that
+   * ScreenScraper could provide. Used to decide which games need
+   * reconciliation on startup.
+   */
+  /**
+   * Check whether a previously-synced game is missing metadata fields that
+   * ScreenScraper could provide. Only returns true for games that have been
+   * successfully synced before (have cover art or populated metadata) but
+   * are missing fields added after the original sync.
+   */
+  private hasMissingMetadata(game: Game): boolean {
+    // Only reconcile games that were successfully synced (have cover art)
+    // and are disc-based systems that benefit from serial metadata.
+    if (!game.coverArt) {
+      return false;
+    }
+    if (!game.serial && (game.systemId === "psx" || game.systemId === "saturn")) {
+      return true;
+    }
+    return false;
   }
 
   /** Check whether user credentials are configured. */

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -165,12 +165,13 @@ export class ArtworkService extends EventEmitter {
         await this.waitForRateLimit();
         const gameInfo = await client.fetchByHash(game.romHashes.md5, game.systemId);
 
-        if (gameInfo && (gameInfo.romRegions?.length || gameInfo.gameId)) {
+        if (gameInfo && (gameInfo.romRegions?.length || gameInfo.gameId || gameInfo.romSerial)) {
           const effectiveRegion = gameInfo.romRegions?.[0];
           const regionalName = getRegionalSystemName(game.systemId, effectiveRegion ?? "");
           const updates: Partial<Game> = {
             ...(gameInfo.romRegions?.length ? { romRegions: gameInfo.romRegions } : {}),
             ...(regionalName ? { system: regionalName } : {}),
+            ...(gameInfo.romSerial ? { serial: gameInfo.romSerial } : {}),
           };
 
           // Backfill disc grouping if not already set by .m3u
@@ -400,6 +401,7 @@ export class ArtworkService extends EventEmitter {
       ...(coverArtAspectRatio !== undefined ? { coverArtAspectRatio } : {}),
       ...(regionalName ? { system: regionalName } : {}),
       ...(gameInfo.romRegions ? { romRegions: gameInfo.romRegions } : {}),
+      ...(gameInfo.romSerial ? { serial: gameInfo.romSerial } : {}),
       ...discUpdates,
       metadata: {
         developer: gameInfo.developer,

--- a/apps/desktop/src/main/services/ArtworkService.ts
+++ b/apps/desktop/src/main/services/ArtworkService.ts
@@ -122,11 +122,11 @@ export class ArtworkService extends EventEmitter {
   }
 
   /**
-   * One-time backfill for games synced before ROM-level region tracking.
-   * Queries ScreenScraper by hash (no artwork download) to get romRegions,
-   * then re-derives the regional system display name. Skips games that
-   * already have romRegions or that lack metadata (never synced).
-   * Requires credentials — silently skips if unconfigured.
+   * One-time backfill for games synced before ROM-level region/serial tracking.
+   * Queries ScreenScraper by hash (no artwork download) to get romRegions
+   * and romSerial, then re-derives the regional system display name.
+   * Skips games that already have both romRegions and serial, or that lack
+   * metadata (never synced). Requires credentials — silently skips if unconfigured.
    */
   private async backfillRomRegions(): Promise<void> {
     // Wait for config to load (fire-and-forget constructor)
@@ -138,14 +138,14 @@ export class ArtworkService extends EventEmitter {
 
     const games = this.libraryService.getGames();
     const needsBackfill = games.filter(
-      (g) => g.metadata && (!g.romRegions || g.romRegions.length === 0),
+      (g) => g.metadata && (!g.romRegions || g.romRegions.length === 0 || !g.serial),
     );
 
     if (needsBackfill.length === 0) {
       return;
     }
 
-    artworkLog.info(`Backfilling ROM regions for ${needsBackfill.length} game(s)`);
+    artworkLog.info(`Backfilling ROM metadata for ${needsBackfill.length} game(s)`);
 
     let client: ScreenScraperClient;
     try {

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -352,7 +352,7 @@ export class CheatDatabaseService extends EventEmitter {
    * Otherwise only libretro-database cheats are returned.
    *
    * @param coreId - The libretro core identifier (e.g. "mednafen_psx_hw",
-   *   "duckstation"). When set to "duckstation", chtdb cheats are included
+   *   "swanstation"). When set to "swanstation", chtdb cheats are included
    *   unfiltered. For all other cores, chtdb is skipped because its extended
    *   code types (A7, F4, 90, etc.) cause glitchy behaviour.
    */
@@ -362,10 +362,10 @@ export class CheatDatabaseService extends EventEmitter {
     serial?: string,
     coreId?: string,
   ): Array<CheatEntry> {
-    // Chtdb cheats are only safe with DuckStation's cheat engine — even
-    // "standard format" codes use DuckStation-specific activation semantics
-    // that cause incorrect behaviour on Beetle PSX.
-    const useChtdb = serial && coreId === "duckstation";
+    // Chtdb cheats are only safe with SwanStation's cheat engine (DuckStation
+    // fork) — even "standard format" codes use DuckStation-specific activation
+    // semantics that cause incorrect behaviour on Beetle PSX / PCSX ReARMed.
+    const useChtdb = serial && coreId === "swanstation";
     const chtdbCheats = useChtdb ? this.getCheatsFromChtdb(serial) : [];
 
     // Filename-matched libretro cheats (works with all cores)

--- a/apps/desktop/src/main/services/LibraryService.ts
+++ b/apps/desktop/src/main/services/LibraryService.ts
@@ -86,6 +86,8 @@ export class LibraryService extends EventEmitter {
   private romsCacheDir: string;
   /** Tracks whether batched updates need flushing to disk. */
   private dirty = false;
+  /** Resolves once the library JSON has been loaded from disk. */
+  private libraryLoaded: Promise<void>;
 
   constructor() {
     super();
@@ -103,9 +105,14 @@ export class LibraryService extends EventEmitter {
     this.loadConfig().catch((error: unknown) => {
       libraryLog.error("Failed to load config:", error);
     });
-    this.loadLibrary().catch((error: unknown) => {
+    this.libraryLoaded = this.loadLibrary().catch((error: unknown) => {
       libraryLog.error("Failed to load library:", error);
     });
+  }
+
+  /** Wait for the library to finish loading from disk. */
+  whenReady(): Promise<void> {
+    return this.libraryLoaded;
   }
 
   private async loadConfig(): Promise<void> {

--- a/apps/desktop/src/main/services/ScreenScraperClient.test.ts
+++ b/apps/desktop/src/main/services/ScreenScraperClient.test.ts
@@ -415,6 +415,42 @@ describe("ScreenScraperClient", () => {
     });
   });
 
+  describe("ROM serial extraction", () => {
+    it("extracts romSerial from jeu.rom.romserial", () => {
+      const client = new ScreenScraperClient(dummyCredentials);
+      const fixture = makeGameResponseFixture({
+        rom: { id: "1234", romserial: "SLUS-00551" },
+      });
+      const result = client.parseGameResponse(fixture);
+      expect(assertDefined(result).romSerial).toBe("SLUS-00551");
+    });
+
+    it("trims whitespace from romSerial", () => {
+      const client = new ScreenScraperClient(dummyCredentials);
+      const fixture = makeGameResponseFixture({
+        rom: { id: "1234", romserial: "  SLUS-00170  " },
+      });
+      const result = client.parseGameResponse(fixture);
+      expect(assertDefined(result).romSerial).toBe("SLUS-00170");
+    });
+
+    it("omits romSerial when jeu.rom is absent", () => {
+      const client = new ScreenScraperClient(dummyCredentials);
+      const fixture = makeGameResponseFixture();
+      const result = client.parseGameResponse(fixture);
+      expect(assertDefined(result).romSerial).toBeUndefined();
+    });
+
+    it("omits romSerial when romserial is empty string", () => {
+      const client = new ScreenScraperClient(dummyCredentials);
+      const fixture = makeGameResponseFixture({
+        rom: { id: "1234", romserial: "" },
+      });
+      const result = client.parseGameResponse(fixture);
+      expect(assertDefined(result).romSerial).toBeUndefined();
+    });
+  });
+
   describe("media selection", () => {
     it("returns undefined when no media of requested type exists", () => {
       const client = new ScreenScraperClient(dummyCredentials);

--- a/apps/desktop/src/main/services/ScreenScraperClient.ts
+++ b/apps/desktop/src/main/services/ScreenScraperClient.ts
@@ -212,6 +212,11 @@ export class ScreenScraperClient {
       ? (romRegionsRaw as Array<string>).filter((r) => typeof r === "string" && r.length > 0)
       : undefined;
 
+    // jeu.rom.romserial — disc serial (e.g. "SLUS-00551") for disc-based systems
+    const romSerialRaw = rom?.romserial;
+    const romSerial =
+      typeof romSerialRaw === "string" && romSerialRaw.length > 0 ? romSerialRaw.trim() : undefined;
+
     // jeu.rom.discnum — 1-indexed disc number for multi-disc games (e.g. "2")
     const discNumRaw = rom?.discnum;
     const discNumParsed =
@@ -231,6 +236,7 @@ export class ScreenScraperClient {
       region,
       releaseDate,
       ...(romRegions && romRegions.length > 0 ? { romRegions } : {}),
+      ...(romSerial ? { romSerial } : {}),
       synopsis,
       title,
     };

--- a/apps/desktop/src/main/workers/core-worker-protocol.test.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.test.ts
@@ -99,17 +99,17 @@ describe("extractSerialFromLog", () => {
   it("extracts serial from SwanStation 'Inserted media' log", () => {
     expect(
       extractSerialFromLog(
-        'Inserted media from /path/to/Resident Evil (USA).cue (SLUS-00170, Resident Evil)',
+        "Inserted media from /path/to/Resident Evil (USA).cue (SLUS-00170, Resident Evil)",
       ),
     ).toBe("SLUS-00170");
   });
 
   it("extracts serial from SwanStation log with various prefixes", () => {
-    expect(
-      extractSerialFromLog('Inserted media from /rom.cue (SCES-00001, Some Game)'),
-    ).toBe("SCES-00001");
-    expect(
-      extractSerialFromLog('Inserted media from /rom.cue (SCPS-10001, JP Game)'),
-    ).toBe("SCPS-10001");
+    expect(extractSerialFromLog("Inserted media from /rom.cue (SCES-00001, Some Game)")).toBe(
+      "SCES-00001",
+    );
+    expect(extractSerialFromLog("Inserted media from /rom.cue (SCPS-10001, JP Game)")).toBe(
+      "SCPS-10001",
+    );
   });
 });

--- a/apps/desktop/src/main/workers/core-worker-protocol.test.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.test.ts
@@ -95,4 +95,21 @@ describe("extractSerialFromLog", () => {
     expect(extractSerialFromLog("CD-ROM ID: SLES-01234")).toBe("SLES-01234");
     expect(extractSerialFromLog("CD-ROM ID: SLPM86001")).toBe("SLPM86001");
   });
+
+  it("extracts serial from SwanStation 'Inserted media' log", () => {
+    expect(
+      extractSerialFromLog(
+        'Inserted media from /path/to/Resident Evil (USA).cue (SLUS-00170, Resident Evil)',
+      ),
+    ).toBe("SLUS-00170");
+  });
+
+  it("extracts serial from SwanStation log with various prefixes", () => {
+    expect(
+      extractSerialFromLog('Inserted media from /rom.cue (SCES-00001, Some Game)'),
+    ).toBe("SCES-00001");
+    expect(
+      extractSerialFromLog('Inserted media from /rom.cue (SCPS-10001, JP Game)'),
+    ).toBe("SCPS-10001");
+  });
 });

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -142,14 +142,26 @@ export function filterForwardableLogs(
 /**
  * Extract a CD-ROM serial from a core log message.
  *
- * PSX cores (e.g. Beetle PSX, PCSX ReARMed) log the disc serial as:
- * `CD-ROM ID: SLUS00551` or `CD-ROM ID: SLUS-00551`
+ * Different PSX cores log the serial in different formats:
+ * - Beetle PSX / PCSX ReARMed: `CD-ROM ID: SLUS00551`
+ * - SwanStation: `Inserted media from /path (SLUS-00551, Game Title)`
  *
  * Returns the raw serial string if found, or null.
  */
 export function extractSerialFromLog(message: string): string | null {
-  const match = message.match(/CD-ROM ID:\s*([A-Za-z]{4}-?\d{5})/);
-  return match ? match[1] : null;
+  // Beetle PSX / PCSX ReARMed format
+  const cdromMatch = message.match(/CD-ROM ID:\s*([A-Za-z]{4}-?\d{5})/);
+  if (cdromMatch) {
+    return cdromMatch[1];
+  }
+
+  // SwanStation format: "Inserted media from /path (SLUS-00551, Title)"
+  const swanMatch = message.match(/Inserted media from .+\(([A-Za-z]{4}-\d{5}),/);
+  if (swanMatch) {
+    return swanMatch[1];
+  }
+
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -46,6 +46,7 @@ export interface NativeLibretroCore {
   swapDisc(index: number): boolean;
   getCurrentDiscIndex(): number;
   getDiscCount(): number;
+  getDiscLabel(index?: number): string | null;
 }
 
 export interface NativeAddon {

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -224,16 +224,29 @@ function initialize(command: Extract<WorkerCommand, { action: "init" }>): void {
     throw new Error(`Failed to load game: ${romPath}`);
   }
 
-  // Check for CD-ROM serial in post-load log messages (PSX cores).
-  // Some cores (e.g. SwanStation) may log the serial during the first
-  // retro_run call rather than during retro_load_game, so the emulation
-  // loop also checks (see drainLogsAndDetectSerial).
+  // Detect CD-ROM serial. Strategy (in priority order):
+  // 1. Parse from post-load log messages (Beetle PSX / PCSX ReARMed)
+  // 2. Query the disc control ext callback's get_image_label (SwanStation)
+  // 3. Check during emulation loop for late log messages (see drainLogs)
   for (const entry of native.getLogMessages()) {
     const serial = extractSerialFromLog(entry.message);
     if (serial) {
       send({ type: "serialDetected", serial });
       serialDetected = true;
       break;
+    }
+  }
+
+  // Fallback: ask the core for the disc label via disc control ext callback.
+  // SwanStation returns the game serial (e.g. "SLUS-00170") as the label.
+  if (!serialDetected) {
+    const label = native.getDiscLabel(0);
+    if (label) {
+      const serial = label.match(/[A-Za-z]{4}-?\d{5}/)?.[0];
+      if (serial) {
+        send({ type: "serialDetected", serial });
+        serialDetected = true;
+      }
     }
   }
 

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -33,6 +33,7 @@ import { filterForwardableLogs, extractSerialFromLog } from "./core-worker-proto
 let native: NativeLibretroCore | null = null;
 let isRunning = false;
 let isPaused = false;
+let serialDetected = false;
 let loopTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Paths received from main process during init
@@ -223,11 +224,15 @@ function initialize(command: Extract<WorkerCommand, { action: "init" }>): void {
     throw new Error(`Failed to load game: ${romPath}`);
   }
 
-  // Check for CD-ROM serial in post-load log messages (PSX cores)
+  // Check for CD-ROM serial in post-load log messages (PSX cores).
+  // Some cores (e.g. SwanStation) may log the serial during the first
+  // retro_run call rather than during retro_load_game, so the emulation
+  // loop also checks (see drainLogsAndDetectSerial).
   for (const entry of native.getLogMessages()) {
     const serial = extractSerialFromLog(entry.message);
     if (serial) {
       send({ type: "serialDetected", serial });
+      serialDetected = true;
       break;
     }
   }
@@ -338,6 +343,25 @@ function startEmulationLoop(): void {
   const basePeriod = 1000 / targetFps;
   let nextFrameTime = performance.now() + basePeriod;
 
+  /** Drain buffered log messages. Also checks for late serial detection
+   *  (some cores like SwanStation log the disc serial during the first
+   *  retro_run call rather than during retro_load_game). */
+  const drainLogs = () => {
+    if (!native) {
+      return;
+    }
+    for (const entry of filterForwardableLogs(native.getLogMessages())) {
+      if (!serialDetected) {
+        const serial = extractSerialFromLog(entry.message);
+        if (serial) {
+          send({ type: "serialDetected", serial });
+          serialDetected = true;
+        }
+      }
+      send({ type: "log", level: entry.level, message: entry.message });
+    }
+  };
+
   const scheduleNext = () => {
     if (!isRunning) {
       return;
@@ -437,10 +461,7 @@ function startEmulationLoop(): void {
       }
     }
 
-    // Drain buffered log messages, dropping debug-level noise.
-    for (const entry of filterForwardableLogs(native.getLogMessages())) {
-      send({ type: "log", level: entry.level, message: entry.message });
-    }
+    drainLogs();
 
     scheduleNext();
   };
@@ -507,10 +528,7 @@ function startEmulationLoop(): void {
         }
       }
 
-      // Drain buffered log messages, dropping debug-level noise.
-      for (const entry of filterForwardableLogs(native.getLogMessages())) {
-        send({ type: "log", level: entry.level, message: entry.message });
-      }
+      drainLogs();
     }
 
     scheduleNext();

--- a/apps/desktop/src/types/artwork.ts
+++ b/apps/desktop/src/types/artwork.ts
@@ -85,6 +85,12 @@ export interface ScreenScraperGameInfo {
    * Only present for hash-based lookups where ScreenScraper matches a known ROM.
    */
   romRegions?: Array<string>;
+  /**
+   * Disc serial from the matched ROM entry (e.g. "SLUS-00551").
+   * Present for disc-based systems (PSX, Saturn, etc.) when ScreenScraper
+   * has the serial for the matched ROM dump.
+   */
+  romSerial?: string;
   releaseDate?: string;
   synopsis?: string;
   title: string;

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -67,6 +67,12 @@ export interface Game {
   romMtime?: number;
   romPath: string;
   /**
+   * Disc serial (e.g. "SLUS-00551") from ScreenScraper's `rom.romserial`.
+   * Present for disc-based systems (PSX, Saturn) after artwork sync.
+   * Used for chtdb cheat lookup when the core doesn't expose the serial at runtime.
+   */
+  serial?: string;
+  /**
    * Region codes from the matched ROM entry in ScreenScraper (e.g. ["jp"], ["us", "eu"]).
    * Set during artwork sync from rom.regions.regions_shortname. Used to derive the
    * regional system display name (e.g. "Super Famicom" for JP SNES ROMs).


### PR DESCRIPTION
## Summary

Closes #302

Adds SwanStation (DuckStation's libretro fork) as a PSX core option and wires up the chtdb cheat database so users can access extended GameShark cheats (A7, F4, 90, 50-series code types) that are incompatible with other PSX cores.

### Core registration
- Registers `swanstation_libretro` alongside PCSX ReARMed (primary) and Beetle PSX HW
- Available on the libretro buildbot — downloads via the existing core download service
- Uses the same `scph5501.bin` BIOS (no BIOS changes needed)

### Serial detection for chtdb lookup
SwanStation doesn't expose the disc serial at runtime (no parseable log messages, `get_image_label` returns null). The serial is needed to look up cheats in the chtdb database.

**Solution:** Extract `rom.romserial` from ScreenScraper API responses during artwork sync and store it on the `Game` object. The cheat lookup falls back to `game.serial` when the core doesn't provide a runtime serial.

- New `serial` field on the `Game` interface
- `romSerial` extraction in `ScreenScraperClient`
- Startup metadata reconciliation for existing games missing serial
- `LibraryService.whenReady()` to avoid race condition with library loading
- Native addon `getDiscLabel()` method (fallback for cores that support it)
- Runtime log detection for Beetle PSX / PCSX ReARMed (still works)

### Cheat database coverage
The chtdb repo has limited coverage compared to gamehacking.org (which MiSTer uses). Filed #304 to integrate gamehacking.org as a more comprehensive cheat source.

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 729 tests pass
- [x] Manual: verified chtdb cheats (Quick Turn, Invincibility, Nemesis Rocket Launcher) appear for RE Director's Cut when running SwanStation with serial patched

🤖 Generated with [Claude Code](https://claude.com/claude-code)