### PR TITLE
fix: CRT Geom text legibility on PS1 480i boot screen

### DIFF
--- a/packages/ui/webgl/WebGLRenderer.ts
+++ b/packages/ui/webgl/WebGLRenderer.ts
@@ -332,6 +332,16 @@ export class WebGLRenderer {
       gl.uniform1f(gl.getUniformLocation(program, "u_time"), performance.now() / 1000.0);
       gl.uniform1i(gl.getUniformLocation(program, "u_frameCount"), this.frameCount);
 
+      // Set preset-level shader parameters as uniforms
+      if (this.currentPreset?.parameters) {
+        for (const [name, value] of Object.entries(this.currentPreset.parameters)) {
+          const loc = gl.getUniformLocation(program, name);
+          if (loc) {
+            gl.uniform1f(loc, value);
+          }
+        }
+      }
+
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
 
       // For feedback passes that are also the last pass, re-draw to screen.

--- a/packages/ui/webgl/crt-geom-deluxe-shaders.ts
+++ b/packages/ui/webgl/crt-geom-deluxe-shaders.ts
@@ -28,18 +28,15 @@ const float overscan_y     = 0.98;
 const float aspect_x       = 1.0;
 const float aspect_y       = 0.75;
 
-// Scanlines & bloom
-const float scanline_weight = 0.3;
+// Scanlines & bloom (scanline_weight is a uniform set from preset parameters)
 const float geom_lum        = 0.0;
 const float halation         = 0.1;
 const float rasterbloom_raw  = 0.0;
 const float rasterbloom      = rasterbloom_raw / 10.0;
 const float width            = 2.0;
 
-// Mask
+// Mask (aperture_strength, aperture_brightboost are uniforms set from preset parameters)
 const int   mask_type           = 1;
-const float aperture_strength   = 0.4;
-const float aperture_brightboost = 0.4;
 
 // Toggles
 const float curvature        = 1.0;
@@ -410,7 +407,9 @@ void main() {
   v_cosangle = cos(angle);
   v_stretch = maxscale(v_sinangle, v_cosangle);
 
-  v_ilfac = vec2(1.0, clamp(floor(u_textureSize.y / 200.0), 1.0, 2.0));
+  // Interlace detection disabled: libretro cores deliver deinterlaced progressive
+  // frames, so the shader should not skip scanlines for >200-line content.
+  v_ilfac = vec2(1.0, 1.0);
   v_one = v_ilfac / u_textureSize;
 
   v_mod_factor = a_texCoord.x * u_textureSize.x * u_resolution.x / u_textureSize.x;
@@ -426,6 +425,11 @@ uniform vec2 u_resolution;
 uniform vec2 u_textureSize;
 uniform vec2 u_originalSize;
 uniform int u_frameCount;
+
+// Tunable parameters (set from preset)
+uniform float u_scanlineWeight;
+uniform float u_apertureStrength;
+uniform float u_apertureBrightboost;
 
 in vec2 v_texCoord;
 in vec2 v_sinangle;
@@ -485,7 +489,7 @@ float corner(vec2 coord) {
 
 vec4 scanlineWeights(float distance_, vec4 color) {
   vec4 wid = 2.0 + 2.0 * pow(color, vec4(4.0));
-  vec4 weights = vec4(distance_ / scanline_weight);
+  vec4 weights = vec4(distance_ / u_scanlineWeight);
   return (geom_lum + 1.4) * exp(-pow(weights * inversesqrt(0.5 * wid), wid)) / (0.6 + 0.2 * wid);
 }
 
@@ -521,7 +525,7 @@ void main() {
   // Save xy after rbloom for halation lookup (before Lanczos snapping)
   vec2 xy0 = xy;
 
-  // Interlace factor
+  // Interlace factor (always 1.0 — cores deliver progressive frames)
   vec2 ilfac = v_ilfac;
 
   // Sub-texel position
@@ -586,8 +590,8 @@ void main() {
   vec2 u_tex_size1 = u_resolution / v_TextureSize;
   float nbright = 255.0 - 255.0 * mask.a;
   float fbright = nbright / (u_tex_size1.x * u_tex_size1.y);
-  float aperture_average = mix(1.0 - aperture_strength * (1.0 - aperture_brightboost), 1.0, fbright);
-  vec3 clow = vec3(1.0 - aperture_strength) * mul_res + vec3(aperture_strength * aperture_brightboost) * mul_res * mul_res;
+  float aperture_average = mix(1.0 - u_apertureStrength * (1.0 - u_apertureBrightboost), 1.0, fbright);
+  vec3 clow = vec3(1.0 - u_apertureStrength) * mul_res + vec3(u_apertureStrength * u_apertureBrightboost) * mul_res * mul_res;
   float ifbright = 1.0 / fbright;
   vec3 chi = vec3(ifbright * aperture_average) * mul_res - vec3(ifbright - 1.0) * clow;
   vec3 cout = mix(clow, chi, mask.rgb);

--- a/packages/ui/webgl/presets/crt-geom-deluxe.test.ts
+++ b/packages/ui/webgl/presets/crt-geom-deluxe.test.ts
@@ -6,7 +6,7 @@ describe("crt-geom-deluxe preset", () => {
   it("is registered in PRESET_LIST", () => {
     const found = PRESET_LIST.find((p) => p.id === "crt-geom-deluxe");
     expect(found).toBeDefined();
-    expect(found!.label).toBe("CRT Geom Deluxe");
+    expect(found?.label).toBe("CRT Geom Deluxe");
   });
 
   it("is registered in PRESET_MAP", () => {
@@ -144,5 +144,33 @@ describe("crt-geom-deluxe GLSL sources", () => {
   it("pass 1 fragment shader references u_feedback for self-feedback", () => {
     const pass1 = crtGeomDeluxePreset.passes[1];
     expect(pass1.fragmentSource).toContain("u_feedback");
+  });
+});
+
+describe("crt-geom-deluxe parameters", () => {
+  it("exposes tunable parameters", () => {
+    expect(crtGeomDeluxePreset.parameters).toBeDefined();
+  });
+
+  it("has scanline weight tuned for text legibility", () => {
+    expect(crtGeomDeluxePreset.parameters?.u_scanlineWeight).toBe(0.35);
+  });
+
+  it("has aperture strength softer than original default", () => {
+    expect(crtGeomDeluxePreset.parameters?.u_apertureStrength).toBe(0.35);
+  });
+
+  it("has aperture bright boost matching original default", () => {
+    expect(crtGeomDeluxePreset.parameters?.u_apertureBrightboost).toBe(0.4);
+  });
+
+  it("pass 4 fragment shader declares uniform for scanline weight", () => {
+    const pass4 = crtGeomDeluxePreset.passes[4];
+    expect(pass4.fragmentSource).toContain("uniform float u_scanlineWeight");
+  });
+
+  it("pass 4 fragment shader declares uniform for aperture strength", () => {
+    const pass4 = crtGeomDeluxePreset.passes[4];
+    expect(pass4.fragmentSource).toContain("uniform float u_apertureStrength");
   });
 });

--- a/packages/ui/webgl/presets/crt-geom-deluxe.ts
+++ b/packages/ui/webgl/presets/crt-geom-deluxe.ts
@@ -14,6 +14,11 @@ export const crtGeomDeluxePreset: ShaderPresetDefinition = {
   id: "crt-geom-deluxe",
   label: "CRT Geom Deluxe",
   luts: [],
+  parameters: {
+    u_scanlineWeight: 0.35,
+    u_apertureStrength: 0.35,
+    u_apertureBrightboost: 0.4,
+  },
   passes: [
     {
       index: 0,

--- a/packages/ui/webgl/presets/crt-geom.test.ts
+++ b/packages/ui/webgl/presets/crt-geom.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { crtGeomPreset } from "./crt-geom";
+import { PRESET_LIST, PRESET_MAP } from "./index";
+
+describe("crt-geom preset", () => {
+  it("is registered in PRESET_LIST", () => {
+    const found = PRESET_LIST.find((p) => p.id === "crt-geom");
+    expect(found).toBeDefined();
+    expect(found?.label).toBe("CRT Geom");
+  });
+
+  it("is registered in PRESET_MAP", () => {
+    expect(PRESET_MAP.get("crt-geom")).toBe(crtGeomPreset);
+  });
+
+  it("has 1 pass", () => {
+    expect(crtGeomPreset.passes).toHaveLength(1);
+  });
+
+  it("has no LUT textures", () => {
+    expect(crtGeomPreset.luts).toHaveLength(0);
+  });
+});
+
+describe("crt-geom parameters", () => {
+  it("exposes tunable parameters", () => {
+    expect(crtGeomPreset.parameters).toBeDefined();
+  });
+
+  it("has scanline weight tuned for text legibility", () => {
+    expect(crtGeomPreset.parameters?.u_scanlineWeight).toBe(0.35);
+  });
+
+  it("has mask strength softer than original default", () => {
+    expect(crtGeomPreset.parameters?.u_maskStrength).toBe(0.25);
+  });
+
+  it("has sharper at original default", () => {
+    expect(crtGeomPreset.parameters?.u_sharper).toBe(1.0);
+  });
+
+  it("fragment shader declares uniform for scanline weight", () => {
+    const pass = crtGeomPreset.passes[0];
+    expect(pass.fragmentSource).toContain("uniform float u_scanlineWeight");
+  });
+
+  it("fragment shader declares uniform for mask strength", () => {
+    const pass = crtGeomPreset.passes[0];
+    expect(pass.fragmentSource).toContain("uniform float u_maskStrength");
+  });
+
+  it("fragment shader declares uniform for sharper", () => {
+    const pass = crtGeomPreset.passes[0];
+    expect(pass.fragmentSource).toContain("uniform float u_sharper");
+  });
+});

--- a/packages/ui/webgl/presets/crt-geom.ts
+++ b/packages/ui/webgl/presets/crt-geom.ts
@@ -5,6 +5,11 @@ export const crtGeomPreset: ShaderPresetDefinition = {
   id: "crt-geom",
   label: "CRT Geom",
   luts: [],
+  parameters: {
+    u_scanlineWeight: 0.35,
+    u_maskStrength: 0.25,
+    u_sharper: 1.0,
+  },
   passes: [
     {
       index: 0,

--- a/packages/ui/webgl/shaders.ts
+++ b/packages/ui/webgl/shaders.ts
@@ -294,6 +294,11 @@ uniform vec2 u_resolution;
 uniform vec2 u_textureSize;
 uniform int u_frameCount;
 
+// Tunable parameters (set from preset)
+uniform float u_scanlineWeight;
+uniform float u_maskStrength;
+uniform float u_sharper;
+
 in vec2 v_texCoord;
 out vec4 fragColor;
 
@@ -305,9 +310,6 @@ const float cornersize = 0.03;
 const float cornersmooth = 1000.0;
 const float overscan_x = 100.0;
 const float overscan_y = 100.0;
-const float DOTMASK = 0.3;
-const float SHARPER = 1.0;
-const float scanline_weight = 0.3;
 const float lum = 0.0;
 const float SATURATION = 1.0;
 
@@ -327,7 +329,7 @@ float corner(vec2 coord) {
 
 vec4 scanlineWeights(float distance, vec4 color) {
   vec4 wid = 2.0 + 2.0 * pow(color, vec4(4.0));
-  vec4 weights = vec4(distance / scanline_weight);
+  vec4 weights = vec4(distance / u_scanlineWeight);
   return (lum + 1.4) * exp(-pow(weights * inversesqrt(0.5 * wid), wid)) / (0.6 + 0.2 * wid);
 }
 
@@ -346,19 +348,22 @@ void main() {
 
   float cval = corner(xy);
 
-  // Interlace factor (detect interlaced content > 200 lines)
-  vec2 ilfac = vec2(1.0, clamp(floor(u_textureSize.y / 200.0), 1.0, 2.0));
+  // Interlace detection disabled: libretro cores deliver deinterlaced progressive
+  // frames, so the shader should not skip scanlines for >200-line content.
+  // The original crt-geom interlace logic halved vertical resolution for 480i,
+  // which destroyed text on the PS1 boot screen (640x480 output).
+  vec2 ilfac = vec2(1.0, 1.0);
 
   // Texel size accounting for sharpness
-  vec2 one = ilfac / vec2(SHARPER * u_textureSize.x, u_textureSize.y);
+  vec2 one = ilfac / vec2(u_sharper * u_textureSize.x, u_textureSize.y);
 
   // Sub-texel position within the current scanline pair
-  vec2 ratio_scale = (xy * u_textureSize - vec2(0.5)) / ilfac;
+  vec2 ratio_scale = xy * u_textureSize - vec2(0.5);
   float filter_ = u_textureSize.y / u_resolution.y;
   vec2 uv_ratio = fract(ratio_scale);
 
   // Snap to texel center
-  xy = (floor(ratio_scale) * ilfac + vec2(0.5)) / u_textureSize;
+  xy = (floor(ratio_scale) + vec2(0.5)) / u_textureSize;
 
   // Lanczos2 horizontal coefficients
   vec4 coeffs = PI * vec4(1.0 + uv_ratio.x, uv_ratio.x, 1.0 - uv_ratio.x, 2.0 - uv_ratio.x);
@@ -398,14 +403,14 @@ void main() {
   // Dot mask: alternate green-tinted and magenta-tinted columns
   float mod_factor = v_texCoord.x * u_textureSize.x * u_resolution.x / u_textureSize.x;
   vec3 dotMaskWeights = mix(
-    vec3(1.0, 1.0 - DOTMASK, 1.0),
-    vec3(1.0 - DOTMASK, 1.0, 1.0 - DOTMASK),
+    vec3(1.0, 1.0 - u_maskStrength, 1.0),
+    vec3(1.0 - u_maskStrength, 1.0, 1.0 - u_maskStrength),
     vec3(floor(mod(mod_factor, 2.0)))
   );
   mul_res *= dotMaskWeights;
 
   // Gamma correction — compensate for scanline + mask embedded gamma
-  vec3 pwr = vec3(1.0 / ((-0.7 * (1.0 - scanline_weight) + 1.0) * (-0.5 * DOTMASK + 1.0)) - 1.25);
+  vec3 pwr = vec3(1.0 / ((-0.7 * (1.0 - u_scanlineWeight) + 1.0) * (-0.5 * u_maskStrength + 1.0)) - 1.25);
   vec3 cir = mul_res - 1.0;
   cir *= cir;
   mul_res = mix(sqrt(mul_res), sqrt(1.0 - cir), pwr);

--- a/packages/ui/webgl/types.ts
+++ b/packages/ui/webgl/types.ts
@@ -47,5 +47,10 @@ export interface ShaderPresetDefinition {
   id: string;
   label: string;
   luts: Array<LutDefinition>;
+  /**
+   * Shader uniform overrides set once per frame for every pass.
+   * Keys are GLSL uniform names (e.g. `u_scanlineWeight`), values are floats.
+   */
+  parameters?: Record<string, number>;
   passes: Array<ShaderPassDefinition>;
 }


### PR DESCRIPTION
## Summary

- **Fixed garbled text on PS1 boot screen** — both CRT Geom shaders had interlace detection that halved vertical resolution for 480-line content (PS1 boot outputs 640×480i), permanently skipping every other scanline and destroying character shapes ("E" → "Γ", "L" → bracket)
- **Disabled interlace detection** — libretro cores deliver deinterlaced progressive frames, so the shader should never skip scanlines based on source height
- **Exposed tunable shader parameters** — converted baked `const` values (scanline weight, mask/aperture strength, sharpness) to uniforms via a new `parameters` field on `ShaderPresetDefinition`, enabling per-preset tuning and future user-facing settings
- **Tuned defaults for text legibility** — slightly wider scanline beams (0.3 → 0.35) and softer masks (0.3/0.4 → 0.25/0.35) improve text readability while preserving CRT aesthetic

## Test plan

- [x] Lint, typecheck, format pass
- [x] 43/43 shader preset tests pass (11 new for CRT Geom, 6 new for CRT Geom Deluxe)
- [x] Manual test: PS1 boot screen text fully legible with CRT Geom
- [x] Manual test: PS1 boot screen text fully legible with CRT Geom Deluxe
- [ ] Verify CRT aesthetic still looks good during gameplay (scanlines, mask visible)
- [ ] Follow-up: fine-tune halation/bloom on text (slightly soft currently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)