### PR TITLE
feat: restore inline search filtering in game library

### DIFF
--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -727,6 +727,37 @@ export const LibraryView: React.FC<{
     return result;
   }, [filteredGames]);
 
+  // All games as UiGame for the command palette (unfiltered by system tab).
+  // Reuses the same cache so games already mapped by `uiGames` aren't recreated.
+  const allUiGames = useMemo<Array<UiGame>>(() => {
+    if (!selectedSystem) {
+      return uiGames; // no filter active, same list
+    }
+    const cache = uiGameCacheRef.current;
+    return games.map((game) => {
+      const cached = cache.get(game);
+      if (cached) {
+        return cached;
+      }
+      return {
+        id: game.id,
+        title: game.title,
+        platform: game.system,
+        systemId: game.systemId,
+        genre: game.metadata?.genre,
+        coverArt: game.coverArt,
+        coverArtAspectRatio: game.coverArtAspectRatio,
+        romPath: game.romPath,
+        lastPlayed: game.lastPlayed,
+        playTime: game.playTime,
+        favorite: game.favorite,
+        discGroup: game.discGroup,
+        discNumber: game.discNumber,
+        discTotal: game.discTotal,
+      };
+    });
+  }, [games, selectedSystem, uiGames]);
+
   // Build command palette actions: library-level actions + parent-provided actions
   const allPaletteActions = useMemo<Array<CommandAction>>(() => {
     const libraryActions: Array<CommandAction> = [
@@ -980,7 +1011,7 @@ export const LibraryView: React.FC<{
       <CommandPalette
         open={commandPaletteOpen}
         onOpenChange={handleCommandPaletteOpenChange}
-        games={uiGames}
+        games={allUiGames}
         onSelectGame={(game) => {
           playSfx("confirm");
           void handlePlayUiGame(game);

--- a/apps/desktop/src/renderer/components/LibraryView.tsx
+++ b/apps/desktop/src/renderer/components/LibraryView.tsx
@@ -912,7 +912,6 @@ export const LibraryView: React.FC<{
             scrollContainerRef={scrollContainerRef}
             onReady={handleGridReady}
             isRevealing={isRevealing}
-            onSearchClick={() => handleCommandPaletteOpenChange(true)}
           />
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-center">

--- a/packages/ui/components/GameLibrary.tsx
+++ b/packages/ui/components/GameLibrary.tsx
@@ -80,11 +80,6 @@ export interface GameLibraryProps {
    * the #root opacity fade. Set to false after the fade completes.
    */
   isRevealing?: boolean;
-  /**
-   * When provided, replaces the inline search input with a clickable
-   * Cmd+K trigger button that calls this callback on click.
-   */
-  onSearchClick?: () => void;
 }
 
 type ViewMode = "grid" | "list";
@@ -123,7 +118,6 @@ export const GameLibrary: React.FC<GameLibraryProps> = ({
   scrollContainerRef,
   onReady,
   isRevealing,
-  onSearchClick,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedPlatform, setSelectedPlatform] = useState<string>("all");
@@ -408,30 +402,19 @@ export const GameLibrary: React.FC<GameLibraryProps> = ({
          z-indices so they don't escape above the header/system tabs. */}
       <div className="sticky -top-4 z-20 bg-background -mx-4 px-4 pt-4 pb-4 space-y-4">
         <div className="flex flex-col sm:flex-row gap-4">
-          {/* Search — either inline input or Cmd+K trigger */}
-          {onSearchClick ? (
-            <button
-              type="button"
-              onClick={onSearchClick}
-              className="relative flex-1 flex items-center gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors cursor-pointer"
-            >
-              <Search className="h-4 w-4 shrink-0" />
-              <span>Search games...</span>
-              <kbd className="ml-auto hidden shrink-0 select-none rounded border bg-muted px-1.5 py-0.5 text-[10px] font-medium sm:inline-block">
-                {modifierKey()}K
-              </kbd>
-            </button>
-          ) : (
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                className="pl-10"
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search games..."
-                value={searchQuery}
-              />
-            </div>
-          )}
+          {/* Search — inline input with Cmd+K hint for command palette */}
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              className="pl-10 pr-16"
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search games..."
+              value={searchQuery}
+            />
+            <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden shrink-0 select-none rounded border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline-block pointer-events-none">
+              {modifierKey()}K
+            </kbd>
+          </div>
 
           {/* Filters */}
           <div className="flex gap-2">


### PR DESCRIPTION
## Summary

- Always show the inline search input in the library header instead of replacing it with a Cmd+K trigger button
- Users can now type to filter the game grid directly while Cmd+K remains available as a keyboard shortcut for the command palette
- The search input includes a `⌘K` badge so users still discover the command palette

## Before/After

**Before:** Clicking the search area or pressing Cmd+K both opened the command palette modal. No way to filter the library grid by text.

**After:** Typing in the search input filters the library grid inline. Cmd+K still opens the command palette for quick-launch.

## Test plan

- [ ] Type in search input — library grid filters by game title
- [ ] Press Cmd+K — command palette opens as before
- [ ] Cmd+K badge visible inside the search input
- [ ] Storybook `GameLibrary` stories render correctly (they never used `onSearchClick`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)