### PR TITLE
feat: integrate gamehacking.org as PSX cheat database

### DIFF
--- a/apps/desktop/src/main/services/CheatDatabaseService.test.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.test.ts
@@ -6,6 +6,8 @@ import {
   parseDuckStationChtFile,
   formatSerial,
   isBeetleCompatible,
+  parseGgBinary,
+  ggToGameShark,
 } from "./CheatDatabaseService";
 
 describe("parseChtFile", () => {
@@ -407,5 +409,215 @@ describe("isBeetleCompatible", () => {
     // 2F/FFFF patterns from extended DuckStation format
     expect(isBeetleCompatible("2F004010 00000000")).toBe(false);
     expect(isBeetleCompatible("FFFFFFFF FFFFFFFF")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MiSTer .gg binary parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper to build a .gg binary buffer from structured entries.
+ * Each entry is 16 bytes: compareFlag(u32LE), address(u32LE),
+ * compareValue(u32LE), replaceValue(u32LE).
+ */
+function buildGgBuffer(
+  entries: Array<{
+    compareFlag: number;
+    address: number;
+    compareValue: number;
+    replaceValue: number;
+  }>,
+): Buffer {
+  const buf = Buffer.alloc(entries.length * 16);
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!;
+    buf.writeUInt32LE(entry.compareFlag, i * 16);
+    buf.writeUInt32LE(entry.address, i * 16 + 4);
+    buf.writeUInt32LE(entry.compareValue, i * 16 + 8);
+    buf.writeUInt32LE(entry.replaceValue, i * 16 + 12);
+  }
+  return buf;
+}
+
+describe("parseGgBinary", () => {
+  it("returns empty array for empty buffer", () => {
+    expect(parseGgBinary(Buffer.alloc(0))).toEqual([]);
+  });
+
+  it("parses a single 16-byte entry without compare", () => {
+    const buf = buildGgBuffer([
+      { compareFlag: 0, address: 0x0c_51_ac, compareValue: 0, replaceValue: 0x00_8c },
+    ]);
+    const codes = parseGgBinary(buf);
+
+    expect(codes).toHaveLength(1);
+    expect(codes[0]).toEqual({
+      compareFlag: 0,
+      address: 0x0c_51_ac,
+      compareValue: 0,
+      replaceValue: 0x00_8c,
+    });
+  });
+
+  it("parses a single entry with compare flag set", () => {
+    const buf = buildGgBuffer([
+      { compareFlag: 1, address: 0xff_1c_a0, compareValue: 0xb5, replaceValue: 0xff },
+    ]);
+    const codes = parseGgBinary(buf);
+
+    expect(codes).toHaveLength(1);
+    expect(codes[0]).toEqual({
+      compareFlag: 1,
+      address: 0xff_1c_a0,
+      compareValue: 0xb5,
+      replaceValue: 0xff,
+    });
+  });
+
+  it("parses multiple entries (32 bytes = 2 codes)", () => {
+    const buf = buildGgBuffer([
+      { compareFlag: 0, address: 0x0c_51_ac, compareValue: 0, replaceValue: 0x00_8c },
+      { compareFlag: 1, address: 0x0c_f8_44, compareValue: 0x00_10, replaceValue: 0x00_c8 },
+    ]);
+    const codes = parseGgBinary(buf);
+
+    expect(codes).toHaveLength(2);
+    expect(codes[0]!.compareFlag).toBe(0);
+    expect(codes[1]!.compareFlag).toBe(1);
+  });
+
+  it("ignores trailing bytes that don't form a complete 16-byte entry", () => {
+    // 20 bytes = 1 full entry + 4 leftover bytes
+    const full = buildGgBuffer([
+      { compareFlag: 0, address: 0x0c_51_ac, compareValue: 0, replaceValue: 0x00_8c },
+    ]);
+    const buf = Buffer.concat([full, Buffer.from([0xde, 0xad, 0xbe, 0xef])]);
+
+    const codes = parseGgBinary(buf);
+    expect(codes).toHaveLength(1);
+  });
+
+  it("returns empty array for buffer smaller than 16 bytes", () => {
+    expect(parseGgBinary(Buffer.alloc(15))).toEqual([]);
+  });
+
+  it("handles addresses with PSX RAM base (0x80_00_00_00)", () => {
+    const buf = buildGgBuffer([
+      { compareFlag: 0, address: 0x80_0c_51_ac, compareValue: 0, replaceValue: 0x00_8c },
+    ]);
+    const codes = parseGgBinary(buf);
+
+    expect(codes).toHaveLength(1);
+    expect(codes[0]!.address).toBe(0x80_0c_51_ac);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .gg → GameShark conversion
+// ---------------------------------------------------------------------------
+
+describe("ggToGameShark", () => {
+  it("converts a 16-bit write (no compare, value > 0xFF)", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_51_ac,
+      compareValue: 0,
+      replaceValue: 0x00_8c,
+    });
+    // 16-bit write: 80 prefix + 24-bit address + 4-hex value
+    expect(result).toBe("800C51AC 008C");
+  });
+
+  it("uses 16-bit write even for small values (format is not recoverable from .gg)", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_87_14,
+      compareValue: 0,
+      replaceValue: 0x3f,
+    });
+    // Always 80 prefix — the .gg format doesn't encode 8-bit vs 16-bit
+    expect(result).toBe("800C8714 003F");
+  });
+
+  it("converts a conditional write (compare flag set)", () => {
+    const result = ggToGameShark({
+      compareFlag: 1,
+      address: 0x0c_f8_44,
+      compareValue: 0x00_10,
+      replaceValue: 0x00_c8,
+    });
+    // Conditional: D0 compare line + 80 write line
+    expect(result).toBe("D00CF844 0010+800CF844 00C8");
+  });
+
+  it("masks off PSX RAM base address (0x80_00_00_00)", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x80_0c_51_ac,
+      compareValue: 0,
+      replaceValue: 0x00_8c,
+    });
+    expect(result).toBe("800C51AC 008C");
+  });
+
+  it("handles address without PSX base correctly", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x00_12_34,
+      compareValue: 0,
+      replaceValue: 0xab,
+    });
+    expect(result).toBe("80001234 00AB");
+  });
+
+  it("produces output that passes isBeetleCompatible for simple writes", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_51_ac,
+      compareValue: 0,
+      replaceValue: 0x00_8c,
+    });
+    expect(isBeetleCompatible(result)).toBe(true);
+  });
+
+  it("produces output where each line passes isBeetleCompatible for conditional writes", () => {
+    const result = ggToGameShark({
+      compareFlag: 1,
+      address: 0x0c_f8_44,
+      compareValue: 0x00_10,
+      replaceValue: 0x00_c8,
+    });
+    expect(isBeetleCompatible(result)).toBe(true);
+  });
+
+  it("zero-pads small values in 16-bit write format", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_87_14,
+      compareValue: 0,
+      replaceValue: 0,
+    });
+    expect(result).toBe("800C8714 0000");
+  });
+
+  it("handles max single-byte value as 16-bit write", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_87_14,
+      compareValue: 0,
+      replaceValue: 0xff,
+    });
+    expect(result).toBe("800C8714 00FF");
+  });
+
+  it("handles multi-byte value as 16-bit write", () => {
+    const result = ggToGameShark({
+      compareFlag: 0,
+      address: 0x0c_87_14,
+      compareValue: 0,
+      replaceValue: 0x01_00,
+    });
+    expect(result).toBe("800C8714 0100");
   });
 });

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -346,6 +346,22 @@ const SYSTEM_CHT_FOLDERS: Record<string, Array<string>> = {
 };
 
 // ---------------------------------------------------------------------------
+// gamehacking.org system mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps GameLord system IDs to the system code used in gamehacking.org's
+ * MiSTer cheat pack filenames (`mister_{code}_YYYYMMDD.zip`).
+ *
+ * PSX-only for now — expand to other systems as needed.
+ */
+const GAMEHACKING_SYSTEM_CODES: Record<string, string> = {
+  psx: "psx",
+};
+
+const GAMEHACKING_BASE_URL = "https://gamehacking.org/mister";
+
+// ---------------------------------------------------------------------------
 // Download progress
 // ---------------------------------------------------------------------------
 
@@ -363,6 +379,8 @@ interface CheatDatabaseMetadata {
   lastDownloaded: number; // ms since epoch
   /** Timestamp of last chtdb download (undefined = never downloaded). */
   chtdbLastDownloaded?: number;
+  /** Timestamp of last gamehacking.org download (undefined = never downloaded). */
+  gamehackingLastDownloaded?: number;
 }
 
 const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -392,7 +410,7 @@ export class CheatDatabaseService extends EventEmitter {
     this.metadataPath = path.join(this.cheatsDir, "metadata.json");
   }
 
-  /** Ensure both cheat databases exist. Downloads if missing or stale. Non-blocking. */
+  /** Ensure all cheat databases exist. Downloads if missing or stale. Non-blocking. */
   async ensureDatabase(): Promise<void> {
     if (this.downloading) {
       return;
@@ -400,19 +418,23 @@ export class CheatDatabaseService extends EventEmitter {
 
     const libreFresh = this.isDatabaseFresh("libretro");
     const chtdbFresh = this.isDatabaseFresh("chtdb");
+    const ghFresh = this.isDatabaseFresh("gamehacking");
 
-    if (libreFresh && chtdbFresh) {
+    if (libreFresh && chtdbFresh && ghFresh) {
       return;
     }
 
     try {
-      // Download both databases in parallel when both are stale
+      // Download all stale databases in parallel
       const downloads: Array<Promise<void>> = [];
       if (!libreFresh) {
         downloads.push(this.downloadLibretroDatabase());
       }
       if (!chtdbFresh) {
         downloads.push(this.downloadChtdb());
+      }
+      if (!ghFresh) {
+        downloads.push(this.downloadGamehacking());
       }
       this.downloading = true;
       await Promise.all(downloads);
@@ -426,11 +448,9 @@ export class CheatDatabaseService extends EventEmitter {
   }
 
   /**
-   * Get cheats for a specific game, merging both databases.
+   * Get cheats for a specific game, merging all databases.
    *
-   * When a serial is provided and the active core supports DuckStation's
-   * extended cheat format, chtdb results are included with priority.
-   * Otherwise only libretro-database cheats are returned.
+   * Merge priority: chtdb > gamehacking > libretro.
    *
    * @param coreId - The libretro core identifier (e.g. "mednafen_psx_hw",
    *   "swanstation"). When set to "swanstation", chtdb cheats are included
@@ -449,12 +469,15 @@ export class CheatDatabaseService extends EventEmitter {
     const useChtdb = serial && coreId === "swanstation";
     const chtdbCheats = useChtdb ? this.getCheatsFromChtdb(serial) : [];
 
+    // gamehacking.org cheats — matched by serial or title, standard GameShark format
+    const ghCheats = this.getCheatsFromGamehacking(systemId, romFilename, serial);
+
     // Filename-matched libretro cheats (works with all cores)
     const libreCheats = this.getCheatsFromLibretro(systemId, romFilename);
 
-    // Merge: chtdb first (serial-matched = higher confidence), then
-    // libretro cheats that aren't duplicates.
-    return this.mergeCheats(chtdbCheats, libreCheats);
+    // Merge: chtdb first (serial-matched DuckStation format), then
+    // gamehacking (serial/title-matched GameShark), then libretro.
+    return this.mergeCheats(this.mergeCheats(chtdbCheats, ghCheats), libreCheats);
   }
 
   /** Look up cheats from the libretro-database by filename matching. */
@@ -527,8 +550,115 @@ export class CheatDatabaseService extends EventEmitter {
   }
 
   /**
-   * Merge chtdb and libretro cheats, deduplicating by normalised code string.
-   * Chtdb cheats take priority (they appear first and block libretro duplicates).
+   * Look up cheats from gamehacking.org's MiSTer cheat packs.
+   *
+   * Matching strategy (in priority order):
+   * 1. Serial match — directory name matches the formatted serial (e.g. "SLUS-00551")
+   * 2. Title match — base title of directory name matches base title of ROM filename
+   */
+  private getCheatsFromGamehacking(
+    systemId: string,
+    romFilename: string,
+    serial?: string,
+  ): Array<CheatEntry> {
+    const systemCode = GAMEHACKING_SYSTEM_CODES[systemId];
+    if (!systemCode) {
+      return [];
+    }
+
+    const systemDir = path.join(this.cheatsDir, "gamehacking", systemCode);
+    if (!fs.existsSync(systemDir)) {
+      return [];
+    }
+
+    let entries: Array<string>;
+    try {
+      entries = fs.readdirSync(systemDir);
+    } catch {
+      return [];
+    }
+
+    const romNameNoExt = path.basename(romFilename, path.extname(romFilename));
+    const formattedSerial = serial ? formatSerial(serial) : undefined;
+    const romBase = baseTitle(romNameNoExt);
+
+    // Find the matching game directory
+    let matchDir: string | undefined;
+
+    for (const entry of entries) {
+      const entryPath = path.join(systemDir, entry);
+      try {
+        if (!fs.statSync(entryPath).isDirectory()) {
+          continue;
+        }
+      } catch {
+        continue;
+      }
+
+      // Serial match (highest priority)
+      if (formattedSerial && entry.toUpperCase() === formattedSerial) {
+        matchDir = entryPath;
+        break;
+      }
+
+      // Title match
+      if (baseTitle(entry) === romBase) {
+        matchDir = entryPath;
+        // Don't break — a serial match could still come
+      }
+    }
+
+    if (!matchDir) {
+      return [];
+    }
+
+    return this.readGgDirectory(matchDir);
+  }
+
+  /**
+   * Read all .gg files from a directory and convert them to CheatEntry items.
+   * Each .gg file becomes one CheatEntry with the filename stem as description
+   * and all codes joined with `+`.
+   */
+  private readGgDirectory(dirPath: string): Array<CheatEntry> {
+    let files: Array<string>;
+    try {
+      files = fs.readdirSync(dirPath).filter((f) => f.toLowerCase().endsWith(".gg"));
+    } catch {
+      return [];
+    }
+
+    const cheats: Array<CheatEntry> = [];
+
+    for (const file of files) {
+      try {
+        const buffer = fs.readFileSync(path.join(dirPath, file));
+        const rawCodes = parseGgBinary(buffer);
+        if (rawCodes.length === 0) {
+          continue;
+        }
+
+        const gsLines = rawCodes.map(ggToGameShark);
+        const description = path.basename(file, ".gg");
+
+        cheats.push({
+          index: cheats.length,
+          description,
+          code: gsLines.join("+"),
+          enabled: false,
+          source: "gamehacking" as CheatSource,
+        });
+      } catch {
+        // Skip unreadable files
+      }
+    }
+
+    return cheats;
+  }
+
+  /**
+   * Merge cheats from two sources, deduplicating by normalised code string.
+   * Primary cheats take priority (they appear first and block secondary duplicates).
    */
   private mergeCheats(primary: Array<CheatEntry>, secondary: Array<CheatEntry>): Array<CheatEntry> {
     if (primary.length === 0) {
@@ -572,7 +702,7 @@ export class CheatDatabaseService extends EventEmitter {
   }
 
   /** Whether a specific database source has been downloaded and is not stale. */
-  private isDatabaseFresh(source: "libretro" | "chtdb"): boolean {
+  private isDatabaseFresh(source: "libretro" | "chtdb" | "gamehacking"): boolean {
     if (!fs.existsSync(this.metadataPath)) {
       return false;
     }
@@ -580,8 +710,12 @@ export class CheatDatabaseService extends EventEmitter {
     try {
       const raw = fs.readFileSync(this.metadataPath, "utf8");
       const metadata: CheatDatabaseMetadata = JSON.parse(raw);
-      const timestamp =
-        source === "libretro" ? metadata.lastDownloaded : metadata.chtdbLastDownloaded;
+      const timestampMap: Record<string, number | undefined> = {
+        libretro: metadata.lastDownloaded,
+        chtdb: metadata.chtdbLastDownloaded,
+        gamehacking: metadata.gamehackingLastDownloaded,
+      };
+      const timestamp = timestampMap[source];
       if (!timestamp) {
         return false;
       }
@@ -676,6 +810,109 @@ export class CheatDatabaseService extends EventEmitter {
     } finally {
       try {
         fs.unlinkSync(tarballPath);
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
+  /**
+   * Download gamehacking.org MiSTer cheat packs for all configured systems.
+   *
+   * Flow:
+   * 1. Fetch the file listing from the MiSTer endpoint
+   * 2. Find the matching ZIP filename for each system (timestamped: mister_psx_YYYYMMDD.zip)
+   * 3. Download and extract each ZIP
+   * 4. Each outer ZIP contains per-game .zip files — extract those into per-game directories
+   */
+  private async downloadGamehacking(): Promise<void> {
+    const ghDir = path.join(this.cheatsDir, "gamehacking");
+    fs.mkdirSync(ghDir, { recursive: true });
+
+    // Fetch the list of available ZIP files
+    const listUrl = `${GAMEHACKING_BASE_URL}/?script=fetchcheats`;
+    const listPath = path.join(ghDir, "index.html");
+
+    try {
+      await this.downloadFile(listUrl, listPath, () => {
+        // Small request, no progress needed
+      });
+
+      const listing = fs.readFileSync(listPath, "utf8");
+
+      for (const [systemId, systemCode] of Object.entries(GAMEHACKING_SYSTEM_CODES)) {
+        // Find the matching ZIP filename (e.g. "mister_psx_20260321.zip")
+        const pattern = new RegExp(`mister_${systemCode}_\\d{8}\\.zip`);
+        const match = listing.match(pattern);
+        if (!match) {
+          continue;
+        }
+
+        const zipFilename = match[0];
+        const zipUrl = `${GAMEHACKING_BASE_URL}/${zipFilename}?script=fetchcheats`;
+        const zipPath = path.join(ghDir, zipFilename);
+        const systemDir = path.join(ghDir, systemId);
+
+        try {
+          await this.downloadFile(zipUrl, zipPath, () => {
+            // Progress is reported by the libretro download
+          });
+
+          // Clear previous data for this system and re-extract
+          fs.rmSync(systemDir, { recursive: true, force: true });
+          fs.mkdirSync(systemDir, { recursive: true });
+
+          // Extract the outer ZIP
+          await execFileAsync("unzip", ["-o", "-q", zipPath, "-d", systemDir]);
+
+          // The outer ZIP contains per-game .zip files. Extract each into
+          // a directory named after the game, then remove the per-game ZIP.
+          await this.extractPerGameZips(systemDir);
+        } finally {
+          try {
+            fs.unlinkSync(zipPath);
+          } catch {
+            // Ignore
+          }
+        }
+      }
+
+      const metadata = this.readMetadata();
+      metadata.gamehackingLastDownloaded = Date.now();
+      this.writeMetadata(metadata);
+    } finally {
+      try {
+        fs.unlinkSync(listPath);
+      } catch {
+        // Ignore
+      }
+    }
+  }
+
+  /**
+   * Extract per-game .zip files in a directory into subdirectories.
+   *
+   * Each `GameName.zip` is extracted into `GameName/` and the .zip is deleted.
+   * This pre-extraction avoids runtime unzip calls in getCheatsFromGamehacking.
+   */
+  private async extractPerGameZips(systemDir: string): Promise<void> {
+    const entries = fs.readdirSync(systemDir);
+    const zipFiles = entries.filter((e) => e.toLowerCase().endsWith(".zip"));
+
+    for (const zipFile of zipFiles) {
+      const zipPath = path.join(systemDir, zipFile);
+      const gameName = zipFile.slice(0, -4); // Strip .zip
+      const gameDir = path.join(systemDir, gameName);
+
+      try {
+        fs.mkdirSync(gameDir, { recursive: true });
+        await execFileAsync("unzip", ["-o", "-q", zipPath, "-d", gameDir]);
+      } catch {
+        // Skip games whose zip fails to extract
+      }
+
+      try {
+        fs.unlinkSync(zipPath);
       } catch {
         // Ignore
       }

--- a/apps/desktop/src/main/services/CheatDatabaseService.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.ts
@@ -152,6 +152,87 @@ export function parseDuckStationChtFile(content: string): Array<CheatEntry> {
 }
 
 // ---------------------------------------------------------------------------
+// MiSTer .gg binary parser (pure function, no side effects — easy to test)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single raw code entry from a MiSTer .gg binary cheat file.
+ * Each entry is 16 bytes: four little-endian uint32 values.
+ */
+export interface GgRawCode {
+  /** 0 = no compare (unconditional write), 1 = compare before write */
+  compareFlag: number;
+  /** Memory address to patch */
+  address: number;
+  /** Value to compare against (only used when compareFlag is 1) */
+  compareValue: number;
+  /** Value to write at the address */
+  replaceValue: number;
+}
+
+/**
+ * Parse a MiSTer .gg binary cheat file into structured code entries.
+ *
+ * Format: each code is exactly 16 bytes (all uint32 little-endian):
+ * ```
+ * [0-3]   compareFlag   — 0x00000000 = no compare, 0x00000001 = compare
+ * [4-7]   address       — memory address
+ * [8-11]  compareValue  — value to compare against
+ * [12-15] replaceValue  — value to write
+ * ```
+ *
+ * Trailing bytes that don't form a complete 16-byte entry are ignored.
+ */
+export function parseGgBinary(buffer: Buffer): Array<GgRawCode> {
+  const ENTRY_SIZE = 16;
+  const entryCount = Math.floor(buffer.length / ENTRY_SIZE);
+  const codes: Array<GgRawCode> = [];
+
+  for (let i = 0; i < entryCount; i++) {
+    const offset = i * ENTRY_SIZE;
+    codes.push({
+      compareFlag: buffer.readUInt32LE(offset),
+      address: buffer.readUInt32LE(offset + 4),
+      compareValue: buffer.readUInt32LE(offset + 8),
+      replaceValue: buffer.readUInt32LE(offset + 12),
+    });
+  }
+
+  return codes;
+}
+
+/**
+ * Convert a MiSTer .gg raw code to PSX GameShark format.
+ *
+ * GameShark format: `PPAAAAAA VVVV`
+ * - PP: prefix (30 = 8-bit write, 80 = 16-bit write, D0 = 16-bit conditional)
+ * - AAAAAA: 24-bit address (PSX RAM base 0x80000000 is masked off)
+ * - VVVV: 4-hex value
+ *
+ * When the compare flag is set, produces a two-line conditional code:
+ * `D0AAAAAA CCCC+80AAAAAA VVVV`
+ */
+export function ggToGameShark(code: GgRawCode): string {
+  // Mask off PSX RAM base address (0x80000000) to get the 24-bit offset
+  const addr = code.address & 0x00_ff_ff_ff;
+  const addrHex = addr.toString(16).toUpperCase().padStart(6, "0");
+  const replaceHex = (code.replaceValue & 0xff_ff).toString(16).toUpperCase().padStart(4, "0");
+
+  if (code.compareFlag !== 0) {
+    // Conditional: compare + write
+    const compareHex = (code.compareValue & 0xff_ff).toString(16).toUpperCase().padStart(4, "0");
+    return `D0${addrHex} ${compareHex}+80${addrHex} ${replaceHex}`;
+  }
+
+  // Unconditional 16-bit write. The .gg binary format doesn't encode whether
+  // the original code was an 8-bit or 16-bit write, so we always emit 80
+  // (16-bit). This is safe because a 16-bit write of 0x00XX is equivalent to
+  // writing XX to the target byte + 0x00 to the adjacent byte, which is the
+  // correct behaviour for the vast majority of PSX GameShark codes.
+  return `80${addrHex} ${replaceHex}`;
+}
+
+// ---------------------------------------------------------------------------
 // Code compatibility filtering
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/src/types/library.ts
+++ b/apps/desktop/src/types/library.ts
@@ -1,5 +1,5 @@
 /** Where a cheat entry was sourced from. */
-export type CheatSource = "libretro" | "chtdb";
+export type CheatSource = "libretro" | "chtdb" | "gamehacking";
 
 /** A single cheat code parsed from a cheat database file. */
 export interface CheatEntry {


### PR DESCRIPTION
## Summary

- Add gamehacking.org as a third cheat source (alongside libretro-database and DuckStation chtdb), significantly expanding PSX cheat coverage
- Parse MiSTer's binary `.gg` cheat format (16 bytes per code: compareFlag, address, compareValue, replaceValue) and convert to standard GameShark codes
- Download bulk MiSTer cheat packs from `gamehacking.org/mister/`, extract per-game ZIP archives, and pre-extract `.gg` files at download time for fast synchronous lookup
- Match games by CD-ROM serial (e.g. `SLUS-00551`) with title-based fuzzy fallback via existing `baseTitle()` matcher
- Merge cheats with priority: chtdb > gamehacking > libretro, deduplicating by normalized code string

## Why

The DuckStation chtdb repo has limited PSX cheat coverage — e.g. Resident Evil Director's Cut (SLUS-00551) only has 3 cheats, while gamehacking.org has a comprehensive library including Infinite Health, Infinite Ammo, etc. MiSTer FPGA uses gamehacking.org as its cheat source, which is why MiSTer has significantly more cheats available.

## Scope

PSX only for now. The `GAMEHACKING_SYSTEM_CODES` map is designed for easy expansion to other systems (NES, SNES, Genesis, etc.) in future PRs.

## Test plan

- [x] `parseGgBinary` tests: empty buffer, single entry, multiple entries, truncated trailing bytes, compare flag variants, PSX RAM base addresses
- [x] `ggToGameShark` tests: 16-bit write, small values, conditional writes, address masking, `isBeetleCompatible()` validation
- [x] All 63 cheat tests pass
- [x] Lint, typecheck, format clean
- [ ] Manual test with real `mister_psx_*.zip` data (requires running the app and triggering cheat download)

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)