### PR TITLE
docs: README badges, contributing links, and issue-first workflow

### DIFF
--- a/.claude/rules/issue-first.md
+++ b/.claude/rules/issue-first.md
@@ -1,0 +1,9 @@
+# Issue-First Workflow
+
+**Every PR must have a corresponding GitHub issue.** No work should begin without an issue to track it.
+
+## Rules
+
+- **Before starting work, ensure an issue exists.** If the user's request doesn't map to an existing issue, create one first. Trivial fixes (typos, one-line changes) still need an issue — it takes 10 seconds and keeps the history traceable.
+- **Every PR must reference its issue.** Use `Closes #123` or `Fixes #123` in the PR description. The PR template enforces this.
+- **Don't bundle unrelated work.** If you discover adjacent work while implementing an issue, create a separate issue for it rather than folding it into the current PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,7 @@
 ## Related Issue
 
-<!-- If this PR implements a feature or fixes a bug with an existing issue, link it below. -->
+<!-- Every PR must reference a GitHub issue. Create one first if it doesn't exist. -->
 <!-- Use "Closes #123" for features or "Fixes #123" for bugs — this auto-closes the issue on merge. -->
-<!-- If no issue exists and the work is non-trivial, create one first. -->
 
 Closes #
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 <p align="center">A vibesmaxxed emulation frontend built with Electron, React, and TypeScript.</p>
 
 <p align="center">
+  <img src="https://img.shields.io/badge/stage-alpha-orange" alt="Alpha" />
+  <a href="https://github.com/ryanmagoon/gamelord/actions/workflows/ci.yml"><img src="https://github.com/ryanmagoon/gamelord/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/ryanmagoon/gamelord/releases?q=nightly&expanded=true"><img src="https://img.shields.io/badge/download-nightly-blue" alt="Nightly Build" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License" /></a>
+</p>
+
+<p align="center">
   <img src=".github/assets/screenshot-library.jpg" alt="GameLord library view" width="800" />
 </p>
 
@@ -73,6 +80,10 @@ pnpm lint          # Lint
 pnpm typecheck     # Type check
 pnpm storybook     # Component browser
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and development workflow. For a deep dive into how the app is structured, check out [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## Sponsors
 


### PR DESCRIPTION
## Related Issue

Closes #334

## Summary

- Add CI status, MIT license, alpha stage, and nightly download badges to README
- Add Contributing section linking to CONTRIBUTING.md and ARCHITECTURE.md
- Strengthen PR template to require a linked GitHub issue on every PR
- Add `.claude/rules/issue-first.md` enforcing issue-first workflow

## Test Plan

- Visual: badges render correctly on GitHub
- No code changes — docs and rules only

🤖 Generated with [Claude Code](https://claude.com/claude-code)