### PR TITLE
feat: save state toast notifications + metadata persistence

### DIFF
--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -2,7 +2,12 @@ import { utilityProcess, UtilityProcess } from "electron";
 import { EventEmitter } from "node:events";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
-import type { WorkerCommand, WorkerEvent, AVInfo } from "../workers/core-worker-protocol";
+import type {
+  WorkerCommand,
+  WorkerEvent,
+  AVInfo,
+  SaveStateMetadata,
+} from "../workers/core-worker-protocol";
 import {
   RETRO_LOG_DEBUG,
   RETRO_LOG_INFO,
@@ -188,8 +193,15 @@ export class EmulationWorkerClient extends EventEmitter {
   }
 
   async screenshot(outputPath?: string): Promise<string> {
-    const result = await this.sendRequest({ action: "screenshot", outputPath });
-    return (result as { path: string }).path;
+    const result = await this.sendRequest<{ path: string }>({ action: "screenshot", outputPath });
+    return result.path;
+  }
+
+  async listSaveStates(): Promise<Array<SaveStateMetadata>> {
+    const result = await this.sendRequest<{ states: Array<SaveStateMetadata> }>({
+      action: "listSaveStates",
+    });
+    return result.states;
   }
 
   async cheatReset(): Promise<void> {
@@ -321,10 +333,10 @@ export class EmulationWorkerClient extends EventEmitter {
    * Send a command that expects a response, identified by `requestId`.
    * Returns a Promise that resolves/rejects when the worker responds.
    */
-  private sendRequest(
+  private sendRequest<T = void>(
     command: Record<string, unknown> & { action: string },
     timeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
-  ): Promise<unknown> {
+  ): Promise<T> {
     const requestId = crypto.randomUUID();
 
     return new Promise((resolve, reject) => {
@@ -340,7 +352,7 @@ export class EmulationWorkerClient extends EventEmitter {
         },
         resolve: (data?: unknown) => {
           clearTimeout(timeout);
-          resolve(data);
+          resolve(data as T);
         },
         timeout,
       });

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -4,6 +4,7 @@ import { EmulatorCore, EmulatorInfo, EmulatorLaunchOptions } from "./EmulatorCor
 import { RetroArchCore } from "./RetroArchCore";
 import { LibretroNativeCore } from "./LibretroNativeCore";
 import { EmulationWorkerClient } from "./EmulationWorkerClient";
+import type { SaveStateMetadata } from "../workers/core-worker-protocol";
 import { CoreDownloader, CoreInfo } from "./CoreDownloader";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -472,6 +473,16 @@ export class EmulatorManager extends EventEmitter {
       throw new Error("No emulator is currently running");
     }
     await this.currentEmulator.loadState(slot);
+  }
+
+  /**
+   * List save state metadata for the current game
+   */
+  async listSaveStates(): Promise<Array<SaveStateMetadata>> {
+    if (this.workerClient?.isRunning()) {
+      return await this.workerClient.listSaveStates();
+    }
+    throw new Error("No emulator is currently running");
   }
 
   /**

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -702,7 +702,22 @@ describe("IPCHandlers", () => {
       const handler = getHandler("savestate:load");
       const result = await handler(fakeEvent, 0);
 
-      expect(result).toEqual({ success: false, error: "Slot empty" });
+      expect(result).toEqual({ success: false, error: "Slot empty", errorCode: "load_failed" });
+    });
+
+    it("returns empty_slot errorCode for missing save state", async () => {
+      emulatorManagerInstance.loadState.mockRejectedValue(
+        new Error("No save state in slot 2"),
+      );
+
+      const handler = getHandler("savestate:load");
+      const result = await handler(fakeEvent, 2);
+
+      expect(result).toEqual({
+        success: false,
+        error: "No save state in slot 2",
+        errorCode: "empty_slot",
+      });
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -706,9 +706,7 @@ describe("IPCHandlers", () => {
     });
 
     it("returns empty_slot errorCode for missing save state", async () => {
-      emulatorManagerInstance.loadState.mockRejectedValue(
-        new Error("No save state in slot 2"),
-      );
+      emulatorManagerInstance.loadState.mockRejectedValue(new Error("No save state in slot 2"));
 
       const handler = getHandler("savestate:load");
       const result = await handler(fakeEvent, 2);

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -342,7 +342,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(50);
+      expect(handleCalls).toHaveLength(51);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -354,6 +354,16 @@ export class IPCHandlers {
       }
     });
 
+    ipcMain.handle("savestate:list", async () => {
+      try {
+        const states = await this.emulatorManager.listSaveStates();
+        return { success: true, states };
+      } catch (error) {
+        ipcLog.error("Failed to list save states:", error);
+        return { success: false, states: [], error: errorMessage(error) };
+      }
+    });
+
     // Screenshot
     ipcMain.handle("emulation:screenshot", async (event, outputPath?: string) => {
       try {

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -349,8 +349,16 @@ export class IPCHandlers {
         await this.emulatorManager.loadState(slot);
         return { success: true };
       } catch (error) {
-        ipcLog.error("Failed to load state:", error);
-        return { success: false, error: errorMessage(error) };
+        const msg = errorMessage(error);
+        const isEmptySlot = msg.includes("No save state in slot");
+        if (!isEmptySlot) {
+          ipcLog.error("Failed to load state:", error);
+        }
+        return {
+          success: false,
+          error: msg,
+          errorCode: isEmptySlot ? ("empty_slot" as const) : ("load_failed" as const),
+        };
       }
     });
 

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -72,6 +72,20 @@ export interface AVInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Save state metadata
+// ---------------------------------------------------------------------------
+
+export interface SaveStateMetadata {
+  slot: number;
+  createdAt: string;
+  coreName: string;
+  coreVersion: string;
+  playTimeSeconds: number | null;
+  romName: string;
+  stateSize: number;
+}
+
+// ---------------------------------------------------------------------------
 // Main → Worker commands
 // ---------------------------------------------------------------------------
 
@@ -116,7 +130,8 @@ export type WorkerCommand =
       code: string;
       requestId: string;
     }
-  | { action: "swapDisc"; index: number; requestId: string };
+  | { action: "swapDisc"; index: number; requestId: string }
+  | { action: "listSaveStates"; requestId: string };
 
 // ---------------------------------------------------------------------------
 // Libretro log levels (from libretro.h RETRO_LOG_*)

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -15,6 +15,7 @@ import type {
   WorkerCommand,
   WorkerEvent,
   AVInfo,
+  SaveStateMetadata,
 } from "./core-worker-protocol";
 import {
   CTRL_ACTIVE_BUFFER,
@@ -154,6 +155,19 @@ function saveState(slot: number): void {
   const statePath = getStatePath(slot);
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   fs.writeFileSync(statePath, Buffer.from(stateData.buffer));
+
+  const systemInfo = native.getSystemInfo();
+  const metadata: SaveStateMetadata = {
+    slot,
+    createdAt: new Date().toISOString(),
+    coreName: systemInfo?.libraryName ?? "Unknown",
+    coreVersion: systemInfo?.libraryVersion ?? "Unknown",
+    playTimeSeconds: null,
+    romName: getRomName(),
+    stateSize: stateData.byteLength,
+  };
+  const metaPath = statePath.replace(/\.sav$/, ".json");
+  fs.writeFileSync(metaPath, JSON.stringify(metadata, null, 2));
 }
 
 function loadState(slot: number): void {
@@ -172,6 +186,63 @@ function loadState(slot: number): void {
   if (!native.unserializeState(stateData)) {
     throw new Error("Failed to restore state");
   }
+}
+
+function listSaveStates(): Array<SaveStateMetadata> {
+  const romName = getRomName();
+  const dir = path.join(saveStatesDir, romName);
+
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir);
+  const states: Array<SaveStateMetadata> = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".sav")) {
+      continue;
+    }
+
+    const savPath = path.join(dir, entry);
+    const metaPath = savPath.replace(/\.sav$/, ".json");
+
+    // Derive slot number from filename
+    let slot: number;
+    if (entry === "autosave.sav") {
+      slot = 99;
+    } else {
+      const match = entry.match(/^state-(\d+)\.sav$/);
+      if (!match) {
+        continue;
+      }
+      slot = Number.parseInt(match[1], 10);
+    }
+
+    if (fs.existsSync(metaPath)) {
+      try {
+        const raw = fs.readFileSync(metaPath, "utf8");
+        states.push(JSON.parse(raw) as SaveStateMetadata);
+        continue;
+      } catch {
+        // Fall through to stat-based fallback
+      }
+    }
+
+    // Fallback for legacy saves without metadata sidecar
+    const stat = fs.statSync(savPath);
+    states.push({
+      slot,
+      createdAt: stat.mtime.toISOString(),
+      coreName: "Unknown",
+      coreVersion: "Unknown",
+      playTimeSeconds: null,
+      romName,
+      stateSize: stat.size,
+    });
+  }
+
+  return states.sort((a, b) => a.slot - b.slot);
 }
 
 // ---------------------------------------------------------------------------
@@ -748,6 +819,19 @@ function handleMessage(command: WorkerCommand): void {
           index: command.index,
           total: native.getDiscCount(),
         });
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
+    case "listSaveStates":
+      try {
+        const states = listSaveStates();
+        sendResponse(command.requestId, true, undefined, { states });
       } catch (error) {
         sendResponse(
           command.requestId,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -57,6 +57,7 @@ contextBridge.exposeInMainWorld("gamelord", {
   saveState: {
     save: (slot: number) => ipcRenderer.invoke("savestate:save", slot),
     load: (slot: number) => ipcRenderer.invoke("savestate:load", slot),
+    list: () => ipcRenderer.invoke("savestate:list"),
   },
 
   // Cheats

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -509,9 +509,6 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners("emulator:discChanged");
     api.removeAllListeners("game:disc-info");
     api.removeAllListeners("game:emulation-error");
-    api.removeAllListeners("emulator:stateSaved");
-    api.removeAllListeners("emulator:stateLoaded");
-
     // Register for SharedArrayBuffer delivery via MessagePort bridge.
     // The main process sends SABs through a MessagePort because contextBridge
     // cannot transfer SharedArrayBuffer directly.
@@ -593,16 +590,6 @@ export const GameWindow: React.FC = () => {
     api.on("game:emulation-error", (raw: unknown) => {
       const data = raw as { message: string };
       setEmulationError(data.message || "An unknown error occurred");
-    });
-
-    api.on("emulator:stateSaved", (raw: unknown) => {
-      const data = raw as { slot: number };
-      toast.success(`Saved to slot ${data.slot + 1}`);
-    });
-
-    api.on("emulator:stateLoaded", (raw: unknown) => {
-      const data = raw as { slot: number };
-      toast.success(`Loaded slot ${data.slot + 1}`);
     });
 
     api.on("game:prepare-close", () => {

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -509,6 +509,8 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners("emulator:discChanged");
     api.removeAllListeners("game:disc-info");
     api.removeAllListeners("game:emulation-error");
+    api.removeAllListeners("emulator:stateSaved");
+    api.removeAllListeners("emulator:stateLoaded");
 
     // Register for SharedArrayBuffer delivery via MessagePort bridge.
     // The main process sends SABs through a MessagePort because contextBridge
@@ -591,6 +593,16 @@ export const GameWindow: React.FC = () => {
     api.on("game:emulation-error", (raw: unknown) => {
       const data = raw as { message: string };
       setEmulationError(data.message || "An unknown error occurred");
+    });
+
+    api.on("emulator:stateSaved", (raw: unknown) => {
+      const data = raw as { slot: number };
+      toast.success(`Saved to slot ${data.slot + 1}`);
+    });
+
+    api.on("emulator:stateLoaded", (raw: unknown) => {
+      const data = raw as { slot: number };
+      toast.success(`Loaded slot ${data.slot + 1}`);
     });
 
     api.on("game:prepare-close", () => {
@@ -911,7 +923,15 @@ export const GameWindow: React.FC = () => {
       playSfx("loadState");
       toast.success(`Loaded slot ${selectedSlot}`);
     } else {
-      toast.error(result.error ?? "No save in this slot");
+      const msg = result.error?.toLowerCase() ?? "";
+      const isEmpty =
+        !result.error ||
+        msg.includes("no state") ||
+        msg.includes("not found") ||
+        msg.includes("does not exist");
+      toast(isEmpty ? `No save in slot ${selectedSlot}` : `Failed: ${result.error}`, {
+        icon: isEmpty ? undefined : "⚠️",
+      });
     }
   };
 

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -14,8 +14,8 @@ import {
   SHADER_LABELS,
   isHdrCapable,
   Toaster,
+  toast,
 } from "@gamelord/ui";
-import { toast } from "sonner";
 import {
   Play,
   Pause,

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -13,7 +13,9 @@ import {
   SHADER_PRESETS,
   SHADER_LABELS,
   isHdrCapable,
+  Toaster,
 } from "@gamelord/ui";
+import { toast } from "sonner";
 import {
   Play,
   Pause,
@@ -895,12 +897,22 @@ export const GameWindow: React.FC = () => {
 
   const handleSaveState = async () => {
     playSfx("saveState");
-    await api.saveState.save(selectedSlot);
+    const result = await api.saveState.save(selectedSlot);
+    if (result.success) {
+      toast.success(`Saved to slot ${selectedSlot}`);
+    } else {
+      toast.error(result.error ?? "Failed to save state");
+    }
   };
 
   const handleLoadState = async () => {
-    playSfx("loadState");
-    await api.saveState.load(selectedSlot);
+    const result = await api.saveState.load(selectedSlot);
+    if (result.success) {
+      playSfx("loadState");
+      toast.success(`Loaded slot ${selectedSlot}`);
+    } else {
+      toast.error(result.error ?? "No save in this slot");
+    }
   };
 
   const handleScreenshot = async () => {
@@ -1732,6 +1744,22 @@ export const GameWindow: React.FC = () => {
         onClose={() => {
           setEmulationError(null);
           api.gameWindow.readyToClose();
+        }}
+      />
+
+      <Toaster
+        position="bottom-center"
+        theme="dark"
+        duration={2000}
+        offset={80}
+        toastOptions={{
+          style: {
+            background: "rgba(0, 0, 0, 0.8)",
+            border: "none",
+            color: "white",
+            fontSize: "13px",
+            backdropFilter: "none",
+          },
         }}
       />
     </div>

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -909,16 +909,10 @@ export const GameWindow: React.FC = () => {
     if (result.success) {
       playSfx("loadState");
       toast.success(`Loaded slot ${selectedSlot}`);
+    } else if (result.errorCode === "empty_slot") {
+      toast(`No save in slot ${selectedSlot}`);
     } else {
-      const msg = result.error?.toLowerCase() ?? "";
-      const isEmpty =
-        !result.error ||
-        msg.includes("no state") ||
-        msg.includes("not found") ||
-        msg.includes("does not exist");
-      toast(isEmpty ? `No save in slot ${selectedSlot}` : `Failed: ${result.error}`, {
-        icon: isEmpty ? undefined : "⚠️",
-      });
+      toast.error(result.error ?? "Failed to load state");
     }
   };
 

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -55,7 +55,11 @@ export interface GamelordAPI {
   };
   saveState: {
     save: (slot: number) => Promise<{ success: boolean; error?: string }>;
-    load: (slot: number) => Promise<{ success: boolean; error?: string }>;
+    load: (slot: number) => Promise<{
+      success: boolean;
+      error?: string;
+      errorCode?: "empty_slot" | "load_failed";
+    }>;
     list: () => Promise<{
       success: boolean;
       states: Array<SaveStateMetadata>;

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -6,6 +6,16 @@ import type {
   GameCheatState,
 } from "../../types/library";
 
+export interface SaveStateMetadata {
+  slot: number;
+  createdAt: string;
+  coreName: string;
+  coreVersion: string;
+  playTimeSeconds: number | null;
+  romName: string;
+  stateSize: number;
+}
+
 export interface CoreInfo {
   name: string;
   displayName: string;
@@ -46,6 +56,11 @@ export interface GamelordAPI {
   saveState: {
     save: (slot: number) => Promise<{ success: boolean; error?: string }>;
     load: (slot: number) => Promise<{ success: boolean; error?: string }>;
+    list: () => Promise<{
+      success: boolean;
+      states: Array<SaveStateMetadata>;
+      error?: string;
+    }>;
   };
   cheats: {
     listForGame: (

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -44,8 +44,8 @@ export interface GamelordAPI {
     swapDisc: (index: number) => Promise<{ success: boolean; error?: string }>;
   };
   saveState: {
-    save: (slot: number) => Promise<{ success: boolean }>;
-    load: (slot: number) => Promise<{ success: boolean }>;
+    save: (slot: number) => Promise<{ success: boolean; error?: string }>;
+    load: (slot: number) => Promise<{ success: boolean; error?: string }>;
   };
   cheats: {
     listForGame: (

--- a/packages/ui/components/ui/sonner.tsx
+++ b/packages/ui/components/ui/sonner.tsx
@@ -1,7 +1,7 @@
-import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { Toaster as Sonner, toast, type ToasterProps } from "sonner";
 
 function Toaster(props: ToasterProps) {
   return <Sonner {...props} />;
 }
 
-export { Toaster };
+export { Toaster, toast };

--- a/packages/ui/components/ui/sonner.tsx
+++ b/packages/ui/components/ui/sonner.tsx
@@ -1,0 +1,7 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+
+function Toaster(props: ToasterProps) {
+  return <Sonner {...props} />;
+}
+
+export { Toaster };

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -8,6 +8,7 @@ export * from "./components/ui/input";
 export * from "./components/ui/select";
 export * from "./components/ui/dropdown-menu";
 export * from "./components/ui/switch";
+export * from "./components/ui/sonner";
 
 export * from "./components/ControllerConfig";
 export * from "./components/ControlsOverlay";

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "lucide-react": "^0.525.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -5095,6 +5098,12 @@ packages:
   socks@2.8.6:
     resolution: {integrity: sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10746,6 +10755,11 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  sonner@2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- **Toast notifications** — Save/load actions now show success/error feedback via sonner toasts. Previously the only indication was a sound effect, and errors were silently swallowed.
- **Empty-slot detection** — Loading from an empty slot shows a neutral "No save in slot X" message (not an error). Uses a typed `errorCode` field from the IPC handler instead of parsing error strings.
- **Metadata sidecar files** — Each save state now writes a `.json` sidecar alongside the `.sav` with timestamp, core name/version, ROM name, and state size. Legacy saves without sidecars fall back to file stat.
- **`savestate:list` IPC** — New API to query all save state slots for the current game, returning metadata for each. Foundation for slot occupied indicators (#318) and the save browser (#319).
- **Generic `sendRequest`** — Made `EmulationWorkerClient.sendRequest` generic to eliminate `as` casts when returning typed data from the worker.
- **sonner** — Installed via `@gamelord/ui` wrapper. Both `Toaster` and `toast` re-exported so consumers don't need a direct `sonner` dependency.

Closes #315
Closes #316

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 747/747 pass
- [ ] Manual: launch a game, F5 to save — toast appears "Saved to slot 0"
- [ ] Manual: F9 to load from occupied slot — toast "Loaded slot 0"
- [ ] Manual: F9 from empty slot — neutral toast "No save in slot 0" (not error-styled)
- [ ] Manual: check filesystem for `.json` sidecar alongside `.sav` after saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Sakshar Dhawan <sakshardhawanfzk@gmail.com>