### PR TITLE
feat: save/load state toast notifications (#315)

### DIFF
--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -13,6 +13,8 @@ import {
   SHADER_PRESETS,
   SHADER_LABELS,
   isHdrCapable,
+  SaveStateToast,
+  type SaveStateToastStatus,
 } from "@gamelord/ui";
 import {
   Play,
@@ -158,6 +160,11 @@ export const GameWindow: React.FC = () => {
   const [currentDiscIndex, setCurrentDiscIndex] = useState(0);
   const [showDiscSwapOverlay, setShowDiscSwapOverlay] = useState(false);
   const [swappingDiscIndex, setSwappingDiscIndex] = useState<number | undefined>(undefined);
+
+  // Save/load state toast
+  const [toastStatus, setToastStatus] = useState<SaveStateToastStatus>("idle");
+  const [toastSlot, setToastSlot] = useState<number | undefined>(undefined);
+  const [toastError, setToastError] = useState<string | undefined>(undefined);
 
   // Animate out the controls hint, then remove it from the DOM
   const dismissControlsHint = useCallback(() => {
@@ -507,6 +514,8 @@ export const GameWindow: React.FC = () => {
     api.removeAllListeners("emulator:discChanged");
     api.removeAllListeners("game:disc-info");
     api.removeAllListeners("game:emulation-error");
+    api.removeAllListeners("emulator:stateSaved");
+    api.removeAllListeners("emulator:stateLoaded");
 
     // Register for SharedArrayBuffer delivery via MessagePort bridge.
     // The main process sends SABs through a MessagePort because contextBridge
@@ -589,6 +598,23 @@ export const GameWindow: React.FC = () => {
     api.on("game:emulation-error", (raw: unknown) => {
       const data = raw as { message: string };
       setEmulationError(data.message || "An unknown error occurred");
+    });
+
+    // Surface save/load state results as toast notifications.
+    // The IPC handler already returns { success, error } from savestate:save/load;
+    // these events are forwarded from the emulator for the success path.
+    api.on("emulator:stateSaved", (raw: unknown) => {
+      const data = raw as { slot: number };
+      setToastSlot(data.slot + 1);
+      setToastError(undefined);
+      setToastStatus("save-success");
+    });
+
+    api.on("emulator:stateLoaded", (raw: unknown) => {
+      const data = raw as { slot: number };
+      setToastSlot(data.slot + 1);
+      setToastError(undefined);
+      setToastStatus("load-success");
     });
 
     api.on("game:prepare-close", () => {
@@ -895,12 +921,33 @@ export const GameWindow: React.FC = () => {
 
   const handleSaveState = async () => {
     playSfx("saveState");
-    await api.saveState.save(selectedSlot);
+    const result = await api.saveState.save(selectedSlot) as { success: boolean; error?: string };
+    setToastSlot(selectedSlot + 1);
+    if (result.success) {
+      setToastError(undefined);
+      setToastStatus("save-success");
+    } else {
+      setToastError(result.error);
+      setToastStatus("error");
+    }
   };
 
   const handleLoadState = async () => {
     playSfx("loadState");
-    await api.saveState.load(selectedSlot);
+    const result = await api.saveState.load(selectedSlot) as { success: boolean; error?: string };
+    setToastSlot(selectedSlot + 1);
+    if (result.success) {
+      setToastError(undefined);
+      setToastStatus("load-success");
+    } else {
+      const isEmpty =
+        !result.error ||
+        result.error.toLowerCase().includes("no state") ||
+        result.error.toLowerCase().includes("not found") ||
+        result.error.toLowerCase().includes("does not exist");
+      setToastError(isEmpty ? undefined : result.error);
+      setToastStatus(isEmpty ? "empty-slot" : "error");
+    }
   };
 
   const handleScreenshot = async () => {
@@ -1724,6 +1771,14 @@ export const GameWindow: React.FC = () => {
           </button>
         </div>
       )}
+
+      {/* Save/load state toast — bottom-center, auto-dismisses after 2s */}
+      <SaveStateToast
+        status={toastStatus}
+        slot={toastSlot}
+        errorMessage={toastError}
+        onDismiss={() => setToastStatus("idle")}
+      />
 
       {/* Fatal emulation error dialog */}
       <EmulationErrorDialog

--- a/packages/ui/components/SaveStateToast/SaveStateToast.stories.tsx
+++ b/packages/ui/components/SaveStateToast/SaveStateToast.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, within } from "storybook/test";
+import { SaveStateToast } from "./SaveStateToast";
+
+const meta = {
+  title: "Components/SaveStateToast",
+  component: SaveStateToast,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+  decorators: [(Story) => (
+    <div className="relative w-96 h-48 bg-black/90 rounded-lg overflow-hidden">
+      <Story />
+    </div>
+  )],
+} satisfies Meta<typeof SaveStateToast>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SaveSuccess: Story = { args: { status: "save-success", slot: 2, onDismiss: fn(), dismissAfterMs: 99999 } };
+export const LoadSuccess: Story = { args: { status: "load-success", slot: 2, onDismiss: fn(), dismissAfterMs: 99999 } };
+export const SaveError: Story = { args: { status: "error", slot: 1, errorMessage: "No core loaded", onDismiss: fn(), dismissAfterMs: 99999 } };
+export const SerializationError: Story = { args: { status: "error", slot: 3, errorMessage: "Serialization failure", onDismiss: fn(), dismissAfterMs: 99999 } };
+export const EmptySlot: Story = { args: { status: "empty-slot", slot: 4, onDismiss: fn(), dismissAfterMs: 99999 } };
+export const Idle: Story = { args: { status: "idle", onDismiss: fn() } };
+
+export const AccessibilityTest: Story = {
+  args: { status: "save-success", slot: 2, onDismiss: fn(), dismissAfterMs: 99999 },
+  play: async ({ canvasElement }) => {
+    const toast = within(canvasElement).getByRole("status");
+    await expect(toast).toBeInTheDocument();
+    await expect(toast).toHaveAttribute("aria-live", "polite");
+    await expect(toast).toHaveTextContent("State saved");
+  },
+};

--- a/packages/ui/components/SaveStateToast/SaveStateToast.tsx
+++ b/packages/ui/components/SaveStateToast/SaveStateToast.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from "react";
+import { CheckCircle2, AlertCircle, HardDrive } from "lucide-react";
+import { cn } from "../../utils";
+
+export type SaveStateToastStatus =
+  | "idle"
+  | "save-success"
+  | "load-success"
+  | "error"
+  | "empty-slot";
+
+export interface SaveStateToastProps {
+  status: SaveStateToastStatus;
+  slot?: number;
+  errorMessage?: string;
+  dismissAfterMs?: number;
+  onDismiss: () => void;
+}
+
+export const SaveStateToast: React.FC<SaveStateToastProps> = ({
+  status,
+  slot,
+  errorMessage,
+  dismissAfterMs = 2000,
+  onDismiss,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  useEffect(() => {
+    if (status === "idle") {
+      setVisible(false);
+      return;
+    }
+    if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    const enterTimer = setTimeout(() => setVisible(true), 16);
+    dismissTimerRef.current = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => onDismissRef.current(), 300);
+    }, dismissAfterMs);
+    return () => {
+      clearTimeout(enterTimer);
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    };
+  }, [status, dismissAfterMs]);
+
+  if (status === "idle") return null;
+
+  const slotLabel = slot !== undefined ? ` · Slot ${slot}` : "";
+  const message = {
+    "save-success": `State saved${slotLabel}`,
+    "load-success": `State loaded${slotLabel}`,
+    "empty-slot": `No save in slot ${slot ?? ""}`,
+    error: errorMessage ? `Failed: ${errorMessage}` : "Save state failed",
+  }[status];
+
+  const isSuccess = status === "save-success" || status === "load-success";
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className={cn(
+        "absolute bottom-10 left-1/2 -translate-x-1/2 z-50",
+        "flex items-center gap-2 px-4 py-2 rounded-lg",
+        "text-sm font-medium select-none pointer-events-none",
+        "shadow-lg backdrop-blur-sm",
+        "transition-all duration-300 ease-out",
+        visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2",
+        isSuccess && "bg-emerald-900/80 text-emerald-100 border border-emerald-500/30",
+        !isSuccess && "bg-zinc-900/85 text-zinc-200 border border-zinc-600/40",
+      )}
+    >
+      {isSuccess && <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />}
+      {status === "empty-slot" && <HardDrive className="h-4 w-4 text-zinc-400 shrink-0" />}
+      {status === "error" && <AlertCircle className="h-4 w-4 text-red-400 shrink-0" />}
+      <span>{message}</span>
+    </div>
+  );
+};

--- a/packages/ui/components/SaveStateToast/index.ts
+++ b/packages/ui/components/SaveStateToast/index.ts
@@ -1,0 +1,2 @@
+export { SaveStateToast } from "./SaveStateToast";
+export type { SaveStateToastProps, SaveStateToastStatus } from "./SaveStateToast";

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -15,6 +15,7 @@ export * from "./components/CheatPanel";
 export * from "./components/DiscSwapOverlay";
 export * from "./components/CoreDownloadBanner";
 export * from "./components/UpdateNotification";
+export * from "./components/SaveStateToast";
 export * from "./components/GameCard";
 export * from "./components/CommandPalette";
 export * from "./components/GameLibrary";


### PR DESCRIPTION
Closes #315

## What changed
- New `SaveStateToast` component in `packages/ui/` with Storybook stories for all 5 states (save-success, load-success, error, empty-slot, idle)
- `handleSaveState` / `handleLoadState` in `GameWindow.tsx` now check the `{ success, error }` return value from IPC instead of silently ignoring it
- `emulator:stateSaved` and `emulator:stateLoaded` IPC events are now wired to UI
- Toast renders bottom-center of the game window, auto-dismisses after 2s, never steals focus

## Toast states
| State | Colour | Message |
|---|---|---|
| save-success | green | "State saved · Slot N" |
| load-success | green | "State loaded · Slot N" |
| empty-slot | grey | "No save in slot N" |
| error | grey | "Failed: [reason]" |