### PR TITLE
chore: remove redundant Vercel Storybook project, add Chromatic PR links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -135,7 +135,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run Chromatic
-        id: chromatic
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -143,43 +142,6 @@ jobs:
           exitZeroOnChanges: true
           autoAcceptChanges: main
 
-      - name: Comment Storybook link on PR
-        if: github.event_name == 'pull_request' && steps.chromatic.outputs.storybookUrl
-        uses: actions/github-script@v7
-        env:
-          STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
-          BUILD_URL: ${{ steps.chromatic.outputs.buildUrl }}
-        with:
-          script: |
-            const marker = '<!-- chromatic-storybook-link -->';
-            const body = [
-              marker,
-              `📖 **Storybook Preview:** ${process.env.STORYBOOK_URL}`,
-              `🔍 **Visual Review:** ${process.env.BUILD_URL}`,
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   chromatic-skip:
     name: Visual Regression (Chromatic)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -135,12 +135,51 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/ui
           exitZeroOnChanges: true
           autoAcceptChanges: main
+
+      - name: Comment Storybook link on PR
+        if: github.event_name == 'pull_request' && steps.chromatic.outputs.storybookUrl
+        uses: actions/github-script@v7
+        env:
+          STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
+          BUILD_URL: ${{ steps.chromatic.outputs.buildUrl }}
+        with:
+          script: |
+            const marker = '<!-- chromatic-storybook-link -->';
+            const body = [
+              marker,
+              `📖 **Storybook Preview:** ${process.env.STORYBOOK_URL}`,
+              `🔍 **Visual Review:** ${process.env.BUILD_URL}`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   chromatic-skip:
     name: Visual Regression (Chromatic)

--- a/packages/ui/vercel.json
+++ b/packages/ui/vercel.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "cd ../.. && pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm build-storybook",
-  "outputDirectory": "storybook-static"
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "mkdir -p dist && echo '<html><body><h1>Coming Soon</h1><p>GameLord is a desktop app — no web version yet.</p></body></html>' > dist/index.html && echo 'No web app yet.'"
+  "buildCommand": "mkdir -p dist && echo '<html><body><h1>Coming Soon</h1><p>GameLord is a desktop app — no web version yet.</p></body></html>' > dist/index.html && echo 'No web app yet.'",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- vercel.json docs/ website/"
 }


### PR DESCRIPTION
## Summary
- Remove `packages/ui/vercel.json` — Chromatic already builds, hosts, and tests Storybook. The Vercel `gamelord-ui` project was a duplicate build.
- Add `ignoreCommand` to root `vercel.json` so `gamelord-desktop` skips rebuilds unless landing page files change.
- Post Chromatic Storybook preview + visual review URLs as a PR comment on UI changes.

**Manual step required:** Delete the `gamelord-ui` project in the [Vercel dashboard](https://vercel.com/ryan-magoons-projects/gamelord-ui/settings) after merging.

Closes #365

## Test plan
- [ ] Verify `gamelord-desktop` Vercel build is skipped for this PR (no landing page files changed)
- [ ] Verify Chromatic PR comment appears with Storybook + visual review links (requires UI change in a follow-up PR)
- [ ] After merge, delete `gamelord-ui` from Vercel dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)