### PR TITLE
docs: add last commit and platform badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   <a href="https://github.com/ryanmagoon/gamelord/actions/workflows/ci.yml"><img src="https://github.com/ryanmagoon/gamelord/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/ryanmagoon/gamelord/releases?q=nightly&expanded=true"><img src="https://img.shields.io/badge/download-nightly-blue" alt="Nightly Build" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License" /></a>
+  <a href="https://github.com/ryanmagoon/gamelord/commits/main"><img src="https://img.shields.io/github/last-commit/ryanmagoon/gamelord/main" alt="Last Commit" /></a>
+  <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows-lightgrey?logo=electron" alt="Platform" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Adds a **last commit** badge (shields.io, tracks `main`)
- Adds a **platform** badge showing macOS | Windows with the Electron logo

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)