### PR TITLE
feat: disc swap menu item and title bar indicator

### DIFF
--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -33,6 +33,7 @@ import {
   ChevronDown,
   Keyboard,
   Code,
+  Disc3,
   Minus,
   Square,
   X,
@@ -1266,6 +1267,11 @@ export const GameWindow: React.FC = () => {
           <div className="flex items-center gap-3">
             <h1 className="text-white font-semibold">{game.title}</h1>
             <span className="text-gray-400 text-sm">{game.system}</span>
+            {discTotal > 1 && (
+              <span className="text-xs text-white/50 bg-white/10 rounded px-1.5 py-0.5">
+                Disc {currentDiscIndex + 1}
+              </span>
+            )}
             <div style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
               <DevBranchBadge variant="overlay" />
             </div>
@@ -1561,6 +1567,33 @@ export const GameWindow: React.FC = () => {
                     <Code className="h-3.5 w-3.5" />
                     <span>Cheats</span>
                   </button>
+                  {discTotal > 1 && (
+                    <button
+                      onClick={() => {
+                        playSfx("click");
+                        setShowSettingsMenu(false);
+                        setShowDiscSwapOverlay((prev) => {
+                          const willOpen = !prev;
+                          if (willOpen && !isPaused) {
+                            pausedByOverlayRef.current = true;
+                            api.emulation.pause().catch(console.error);
+                          } else if (!willOpen && pausedByOverlayRef.current) {
+                            pausedByOverlayRef.current = false;
+                            api.emulation.resume().catch(console.error);
+                          }
+                          return willOpen;
+                        });
+                      }}
+                      className="w-full flex items-center gap-2 px-4 py-2 text-sm text-white/80 hover:bg-white/10 transition-colors"
+                    >
+                      <Disc3 className="h-3.5 w-3.5" />
+                      <span>Swap Disc</span>
+                      <span className="ml-auto text-xs text-white/30">
+                        Disc {currentDiscIndex + 1}
+                      </span>
+                      <span className="text-xs text-white/30">F6</span>
+                    </button>
+                  )}
                   <div className="border-t border-white/10 my-1" />
                   <button
                     onClick={() => {

--- a/scripts/upload-screenshot.sh
+++ b/scripts/upload-screenshot.sh
@@ -47,8 +47,15 @@ fi
 FILENAME="$(basename "$IMAGE_PATH")"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 
+EXT="${FILENAME##*.}"
+
 if [ $# -ge 2 ]; then
-  PATHNAME="$2"
+  # Preserve the source file's extension if the custom pathname doesn't have one
+  CUSTOM="$2"
+  if [[ "$CUSTOM" != *.* ]]; then
+    CUSTOM="${CUSTOM}.${EXT}"
+  fi
+  PATHNAME="$CUSTOM"
 else
   PATHNAME="screenshots/${TIMESTAMP}-${FILENAME}"
 fi


### PR DESCRIPTION
## Summary

- Add a **"Swap Disc"** entry to the in-game settings menu for multi-disc games, showing a disc icon, current disc label, and F6 hotkey hint
- Display a **disc badge** in the title bar (e.g. "Disc 1") so users always know which disc is loaded
- Both elements only render when `discTotal > 1`, so single-disc games are unaffected

Related: #272 (multi-disc support tracking issue)
Follow-up: #310 (partial disc collection support)

## Screenshots

**Title bar with disc badge:**

![Title bar showing Disc 1 badge](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260414-235508-titlebar-disc3.png)

**Settings menu with Swap Disc entry:**

![Settings menu showing Swap Disc item](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260414-235514-settings-menu-disc.png)

## Test plan

- [x] Load a multi-disc PS1 game via `.m3u` (e.g. Resident Evil 2)
- [x] Verify title bar shows "Disc 1" badge next to system name
- [x] Open settings menu and verify "Swap Disc" item appears with current disc and F6 hint
- [x] Click "Swap Disc" — overlay opens and emulation pauses
- [x] Swap to a different disc — title bar badge and menu label update
- [x] Load a single-disc game — verify neither badge nor menu item appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)