### PR TITLE
fix: make CDP debugging port configurable via CDP_PORT env var

### DIFF
--- a/.claude/rules/agent-browser.md
+++ b/.claude/rules/agent-browser.md
@@ -1,6 +1,6 @@
 # agent-browser — Visual Verification
 
-The dev server exposes Chrome DevTools Protocol on port 9222. Use `agent-browser` to inspect and interact with the running Electron app.
+The dev server exposes Chrome DevTools Protocol on port 9222 by default (configurable via `CDP_PORT` env var). Use `agent-browser` to inspect and interact with the running Electron app.
 
 ## When to Use
 
@@ -22,4 +22,11 @@ Always re-snapshot after interactions — element refs change when the DOM updat
 
 ## Port Conflict
 
-If port 9222 is in use (e.g. Chrome debugging), the app will fail to bind. Kill the conflicting process or change the port in `apps/desktop/package.json`.
+If port 9222 is in use (e.g. another app instance or Chrome debugging), set `CDP_PORT` to use a different port:
+
+```bash
+CDP_PORT=9223 pnpm dev
+agent-browser connect 9223
+```
+
+Each worktree can use its own port to avoid collisions.

--- a/.claude/rules/screenshot-hosting.md
+++ b/.claude/rules/screenshot-hosting.md
@@ -5,8 +5,8 @@ PR screenshots are hosted on Vercel Blob. Two scripts handle the full pipeline â
 ## Full workflow
 
 ```bash
-# 1. Start the Electron app with CDP enabled
-cd apps/desktop && pnpm exec electron-vite dev -- --remote-debugging-port=9222
+# 1. Start the Electron app with CDP enabled (default port 9222, configurable via CDP_PORT)
+cd apps/desktop && pnpm dev
 
 # 2. Capture a screenshot of the running app
 ./scripts/capture-screenshot.sh /tmp/library.png
@@ -28,8 +28,7 @@ gh pr edit <number> --body "${BODY}
 Connects to the running Electron app via CDP (playwright) and saves a PNG screenshot.
 
 - Default output: `/tmp/gamelord-screenshot.png`
-- Default CDP port: `9222`
-- Requires the app to be running with `--remote-debugging-port=9222`
+- Default CDP port: `9222` (reads `CDP_PORT` env var, then `--cdp-port` flag)
 - Outputs JPEG by default (quality 80) to stay under GitHub's ~5MB camo proxy limit
 - Uses `playwright` (project dev dependency)
 

--- a/.claude/skills/electron-inspect/SKILL.md
+++ b/.claude/skills/electron-inspect/SKILL.md
@@ -5,7 +5,7 @@ description: Inspect and interact with the running GameLord Electron app using a
 
 # Electron App Inspection with agent-browser
 
-GameLord's dev server exposes Chrome DevTools Protocol on port 9222 (`--remote-debugging-port=9222` in the dev script). Use `agent-browser` to connect, take screenshots, inspect the DOM, interact with UI elements, and record videos — all without leaving the terminal.
+GameLord's dev server exposes Chrome DevTools Protocol on port 9222 by default (configurable via `CDP_PORT` env var). Use `agent-browser` to connect, take screenshots, inspect the DOM, interact with UI elements, and record videos — all without leaving the terminal.
 
 ## Prerequisites
 
@@ -131,5 +131,5 @@ agent-browser network requests
 - **Re-snapshot after interactions** — refs change when the DOM updates.
 - **Use `agent-browser tab list`** when the app has multiple windows open — the game window is a separate target.
 - **Screenshots go to `/tmp/`** to keep the repo clean. Use descriptive filenames.
-- **The port 9222 is always available** in dev mode — no special flags needed.
+- **CDP port defaults to 9222** — override with `CDP_PORT=9223 pnpm dev` when running multiple instances.
 - **For PR screenshots**, capture specific component states and include them in the PR body.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
     "build:native": "cd native && node-gyp rebuild",
     "clean": "node -e \"const fs=require('fs');['out','dist'].forEach(d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}})\"",
     "build": "npm run clean && npm run build:native && electron-vite build",
-    "dev": "electron-vite dev --remote-debugging-port=9222",
+    "dev": "electron-vite dev --remote-debugging-port=${CDP_PORT:-9222}",
     "start": "electron-vite preview",
     "package": "npm run build && electron-builder --dir",
     "make": "npm run build && electron-builder",

--- a/scripts/capture-screenshot.sh
+++ b/scripts/capture-screenshot.sh
@@ -3,11 +3,11 @@
 #
 # Usage: ./scripts/capture-screenshot.sh [output-path] [--cdp-port PORT]
 #   output-path  Where to save the screenshot (default: /tmp/gamelord-screenshot.jpg)
-#   --cdp-port   CDP debugging port (default: 9222)
+#   --cdp-port   CDP debugging port (default: CDP_PORT env var, or 9222)
 #
 # Prerequisites:
-#   - The Electron app must be running with --remote-debugging-port=9222:
-#       cd apps/desktop && pnpm exec electron-vite dev -- --remote-debugging-port=9222
+#   - The Electron app must be running with CDP enabled:
+#       cd apps/desktop && pnpm dev
 #   - playwright must be installed (it's a dev dependency of this project)
 #
 # Output: saves a JPEG screenshot (quality 80) and prints the path to stdout.
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 OUTPUT_PATH="/tmp/gamelord-screenshot.jpg"
-CDP_PORT=9222
+CDP_PORT="${CDP_PORT:-9222}"
 
 while [ $# -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
## Summary

- Makes the CDP debugging port configurable via `CDP_PORT` env var (defaults to `9222`) so multiple app instances (e.g., main repo + worktree) can run simultaneously without port conflicts
- Updates `capture-screenshot.sh` to also read `CDP_PORT` as a fallback before the `--cdp-port` flag
- Updates docs (`agent-browser.md`, `screenshot-hosting.md`, `electron-inspect` skill) to document the env var

Closes #371

## Test plan

- [ ] Run `pnpm dev` — should bind CDP on port 9222 (default)
- [ ] Run `CDP_PORT=9223 pnpm dev` — should bind CDP on port 9223
- [ ] Run `CDP_PORT=9223 ./scripts/capture-screenshot.sh /tmp/test.jpg` — should connect to 9223
- [ ] Run two instances on different ports simultaneously — no conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)