### PR TITLE
feat: runtime disc count query and file picker fallback for missing discs

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -21,7 +21,7 @@ If the changes are visible in Storybook or a dev server preview, **capture the s
 
 Only ask the user for media when the state can't be reproduced in a preview server (e.g., requires real hardware, real network conditions, or the full Electron runtime with IPC).
 
-After capturing screenshots, upload them to Vercel Blob using `scripts/upload-screenshot.sh` and embed the returned URL in the PR body. See `screenshot-hosting.md` for the full workflow.
+After capturing screenshots, upload them to Vercel Blob using `scripts/upload-screenshot.sh` and embed the returned URL in the PR body. The script requires `BLOB_READ_WRITE_TOKEN` — source it from `apps/desktop/.env` before calling. See `screenshot-hosting.md` for the full workflow (includes both Storybook and app capture methods).
 
 If the user provides media, embed it in the PR body using GitHub markdown (`![description](url)` or a `<video>` tag). If screenshots can't be captured or provided, note in the PR body that a visual is pending.
 

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -9,9 +9,19 @@ Before creating a PR, evaluate whether the changes would benefit from a screensh
 - **When helpful** for bug fixes with a visual symptom: before/after screenshots make the fix obvious.
 - **Skip** for purely internal changes: refactors, dependency bumps, test-only changes, CI config, docs-only changes.
 
+## Storybook vs app screenshots
+
+Choose the capture method based on what the change actually needs to prove:
+
+- **Storybook is sufficient** when the component's visual states are fully representable as stories. This covers new component states, styling changes, loading/error/empty states, and prop-driven variations. If the reviewer can evaluate the visual change from isolated stories alone, Storybook screenshots are enough.
+- **App screenshots are needed** when the surrounding context matters: layout within the game window, interaction with adjacent UI, integration behavior that depends on IPC or real data, or when the change affects how the component looks in situ (positioning, z-index stacking, backdrop effects over the game canvas).
+- **Both** when the change adds new component states (show them isolated in Storybook) *and* changes how the component fits into the app (show it in context).
+
+When in doubt, Storybook screenshots are the baseline — they're fast to capture, reproducible, and cover the visual diff. Add app screenshots when they'd tell the reviewer something Storybook can't.
+
 ## Capture screenshots yourself
 
-If the changes are visible in Storybook or a dev server preview, **capture the screenshots yourself using preview tools before creating the PR.** Don't ask the user for screenshots when you can take them.
+**Capture screenshots using preview tools before creating the PR.** Don't ask the user for screenshots when you can take them.
 
 1. Start the relevant preview server (Storybook for component stories, desktop dev for full app)
 2. Navigate to the relevant story/page

--- a/.claude/rules/screenshot-hosting.md
+++ b/.claude/rules/screenshot-hosting.md
@@ -51,6 +51,36 @@ Uploads an image to Vercel Blob and prints the public URL.
    ```
 4. In worktrees, run `./scripts/setup-worktree.sh` to symlink the `.env` file
 
+## Storybook screenshots (component-level)
+
+For UI component changes visible in Storybook, capture directly with Playwright:
+
+```bash
+# Storybook must be running (pnpm --filter @gamelord/ui exec storybook dev -p 6009 --ci)
+node -e "
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 400, height: 500 } });
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await page.goto('http://localhost:6009/iframe.html?id=<story-id>&viewMode=story');
+  await page.waitForTimeout(1000);
+  await page.screenshot({ path: '/tmp/component.jpg', type: 'jpeg', quality: 80 });
+  await browser.close();
+})();
+"
+
+# Upload
+export \$(grep BLOB_READ_WRITE_TOKEN apps/desktop/.env)
+URL=\$(./scripts/upload-screenshot.sh /tmp/component.jpg)
+```
+
+Use the iframe URL (`/iframe.html?id=...&viewMode=story`) for clean captures without Storybook chrome. Find story IDs in the Storybook sidebar or derive from the story file (e.g., `components-discswapoverlay--missing-disc-with-browse`).
+
+## App screenshots (full Electron runtime)
+
+For changes requiring the running app (IPC, game window, full integration), use the CDP-based capture script — see "Full workflow" above.
+
 ## When to use
 
 Follow the guidance in `pull-requests.md` for when screenshots are needed. Use this workflow whenever you need to include screenshots in a PR.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,12 @@ Closes #
 
 -
 
+## Screenshots / Video
+
+<!-- Required for UI changes, new features, and visual bug fixes. -->
+<!-- Skip for purely internal changes (refactors, deps, CI, docs). -->
+<!-- Capture from Storybook or the running app — see .claude/rules/pull-requests.md -->
+
 ## Test Plan
 
 <!-- How was this tested? Automated tests, manual verification, or both? -->

--- a/apps/desktop/native/src/libretro_core.cc
+++ b/apps/desktop/native/src/libretro_core.cc
@@ -163,6 +163,8 @@ Napi::Object LibretroCore::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("getCurrentDiscIndex", &LibretroCore::GetCurrentDiscIndex),
     InstanceMethod("getDiscCount", &LibretroCore::GetDiscCount),
     InstanceMethod("getDiscLabel", &LibretroCore::GetDiscLabel),
+    InstanceMethod("replaceDiscImage", &LibretroCore::ReplaceDiscImage),
+    InstanceMethod("addDiscImage", &LibretroCore::AddDiscImage),
   });
 
   Napi::FunctionReference *constructor = new Napi::FunctionReference();
@@ -837,6 +839,89 @@ Napi::Value LibretroCore::GetDiscLabel(const Napi::CallbackInfo &info) {
   }
 
   return Napi::String::New(env, label);
+}
+
+Napi::Value LibretroCore::ReplaceDiscImage(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (!s_instance) return Napi::Boolean::New(env, false);
+
+  if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsString()) {
+    Napi::TypeError::New(env, "Expected (index: number, path: string)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  unsigned index = info[0].As<Napi::Number>().Uint32Value();
+  std::string filePath = info[1].As<Napi::String>().Utf8Value();
+
+  if (index >= s_instance->disc_paths_.size()) {
+    return Napi::Boolean::New(env, false);
+  }
+
+  // Update the internal path
+  s_instance->disc_paths_[index] = filePath;
+
+  // Notify the core via the replace_image_index callback
+  if (s_instance->has_disc_control_ext_ && s_instance->disc_control_ext_cb_.replace_image_index) {
+    retro_game_info game_info = {};
+    game_info.path = filePath.c_str();
+    game_info.data = nullptr;
+    game_info.size = 0;
+    game_info.meta = nullptr;
+    s_instance->disc_control_ext_cb_.replace_image_index(index, &game_info);
+  } else if (s_instance->has_disc_control_ && s_instance->disc_control_cb_.replace_image_index) {
+    retro_game_info game_info = {};
+    game_info.path = filePath.c_str();
+    game_info.data = nullptr;
+    game_info.size = 0;
+    game_info.meta = nullptr;
+    s_instance->disc_control_cb_.replace_image_index(index, &game_info);
+  }
+
+  return Napi::Boolean::New(env, true);
+}
+
+Napi::Value LibretroCore::AddDiscImage(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+  if (!s_instance) return Napi::Number::New(env, -1);
+
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "Expected (path: string)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  std::string filePath = info[0].As<Napi::String>().Utf8Value();
+
+  // Add a new slot via the core callback
+  if (s_instance->has_disc_control_ext_ && s_instance->disc_control_ext_cb_.add_image_index) {
+    s_instance->disc_control_ext_cb_.add_image_index();
+  } else if (s_instance->has_disc_control_ && s_instance->disc_control_cb_.add_image_index) {
+    s_instance->disc_control_cb_.add_image_index();
+  }
+
+  unsigned newIndex = static_cast<unsigned>(s_instance->disc_paths_.size() - 1);
+
+  // The add_image_index callback already pushed an empty string to disc_paths_
+  // via our static DiskAddImageIndex. Now replace it with the actual path.
+  s_instance->disc_paths_[newIndex] = filePath;
+
+  // Notify the core of the actual file path
+  if (s_instance->has_disc_control_ext_ && s_instance->disc_control_ext_cb_.replace_image_index) {
+    retro_game_info game_info = {};
+    game_info.path = filePath.c_str();
+    game_info.data = nullptr;
+    game_info.size = 0;
+    game_info.meta = nullptr;
+    s_instance->disc_control_ext_cb_.replace_image_index(newIndex, &game_info);
+  } else if (s_instance->has_disc_control_ && s_instance->disc_control_cb_.replace_image_index) {
+    retro_game_info game_info = {};
+    game_info.path = filePath.c_str();
+    game_info.data = nullptr;
+    game_info.size = 0;
+    game_info.meta = nullptr;
+    s_instance->disc_control_cb_.replace_image_index(newIndex, &game_info);
+  }
+
+  return Napi::Number::New(env, static_cast<int32_t>(newIndex));
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/native/src/libretro_core.h
+++ b/apps/desktop/native/src/libretro_core.h
@@ -63,6 +63,8 @@ private:
   Napi::Value GetCurrentDiscIndex(const Napi::CallbackInfo &info);
   Napi::Value GetDiscCount(const Napi::CallbackInfo &info);
   Napi::Value GetDiscLabel(const Napi::CallbackInfo &info);
+  Napi::Value ReplaceDiscImage(const Napi::CallbackInfo &info);
+  Napi::Value AddDiscImage(const Napi::CallbackInfo &info);
 
   // Internal
   void CloseCore();

--- a/apps/desktop/src/main/GameWindowManager.ts
+++ b/apps/desktop/src/main/GameWindowManager.ts
@@ -53,7 +53,7 @@ export class GameWindowManager extends EventEmitter {
     avInfo: AVInfo,
     shouldResume = false,
     cardScreenBounds?: { x: number; y: number; width: number; height: number },
-    discInfo?: { paths: Array<string>; initialIndex: number },
+    discInfo?: { paths: Array<string>; initialIndex: number; missingIndices?: Array<number> },
     saveStatesSupported = true,
   ): BrowserWindow {
     const existingWindow = this.gameWindows.get(game.id);
@@ -163,6 +163,7 @@ export class GameWindowManager extends EventEmitter {
         gameWindow.webContents.send("game:disc-info", {
           total: discInfo.paths.length,
           currentIndex: discInfo.initialIndex,
+          missingIndices: discInfo.missingIndices ?? [],
         });
       }
 

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -228,6 +228,29 @@ export class EmulationWorkerClient extends EventEmitter {
     await this.sendRequest({ action: "swapDisc", index });
   }
 
+  async getDiscInfo(): Promise<{
+    total: number;
+    currentIndex: number;
+    labels: Array<string | null>;
+  }> {
+    return this.sendRequest<{
+      total: number;
+      currentIndex: number;
+      labels: Array<string | null>;
+    }>({ action: "getDiscInfo" });
+  }
+
+  async replaceDiscImage(index: number, path: string): Promise<void> {
+    await this.sendRequest({ action: "replaceDiscImage", index, path });
+  }
+
+  async addDiscImage(path: string): Promise<{ index: number }> {
+    return this.sendRequest<{ index: number }>({
+      action: "addDiscImage",
+      path,
+    });
+  }
+
   /**
    * Mark the worker as shutting down so that a process exit during the
    * async shutdown sequence doesn't emit an unexpected-exit error.

--- a/apps/desktop/src/main/emulator/EmulatorManager.ts
+++ b/apps/desktop/src/main/emulator/EmulatorManager.ts
@@ -558,6 +558,40 @@ export class EmulatorManager extends EventEmitter {
   }
 
   /**
+   * Query runtime disc info from the running core.
+   */
+  async getDiscInfo(): Promise<{
+    total: number;
+    currentIndex: number;
+    labels: Array<string | null>;
+  }> {
+    if (!this.workerClient?.isRunning()) {
+      throw new Error("No emulator is currently running");
+    }
+    return this.workerClient.getDiscInfo();
+  }
+
+  /**
+   * Replace a disc image path at the given index (for adding missing discs).
+   */
+  async replaceDiscImage(index: number, path: string): Promise<void> {
+    if (!this.workerClient?.isRunning()) {
+      throw new Error("No emulator is currently running");
+    }
+    await this.workerClient.replaceDiscImage(index, path);
+  }
+
+  /**
+   * Add a new disc image to the end of the disc list.
+   */
+  async addDiscImage(path: string): Promise<{ index: number }> {
+    if (!this.workerClient?.isRunning()) {
+      throw new Error("No emulator is currently running");
+    }
+    return this.workerClient.addDiscImage(path);
+  }
+
+  /**
    * Set emulation speed multiplier (1 = normal, 2 = 2x, etc.)
    */
   setSpeed(multiplier: number): void {

--- a/apps/desktop/src/main/ipc/handlers.test.ts
+++ b/apps/desktop/src/main/ipc/handlers.test.ts
@@ -342,7 +342,7 @@ describe("IPCHandlers", () => {
 
     it("registers exactly the expected number of handle channels", () => {
       const handleCalls = vi.mocked(ipcMain.handle).mock.calls;
-      expect(handleCalls).toHaveLength(51);
+      expect(handleCalls).toHaveLength(53);
     });
   });
 

--- a/apps/desktop/src/main/ipc/handlers.ts
+++ b/apps/desktop/src/main/ipc/handlers.ts
@@ -14,6 +14,7 @@ import type { AutoUpdaterService } from "../services/AutoUpdaterService";
 import { Game, GameSystem } from "../../types/library";
 import type { AmbiguousRomFile } from "../services/LibraryService";
 import { ipcLog } from "../logger";
+import fs from "node:fs";
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -190,18 +191,59 @@ export class IPCHandlers {
             const workerClient = new EmulationWorkerClient();
             const addonPath = resolveAddonPath();
 
-            // Build disc paths for multi-disc games
+            // Build disc paths for multi-disc games.
+            // Strategy: use .m3u paths (includes missing files) or library entries.
             let discPaths: string[] | undefined;
             let initialDiscIndex: number | undefined;
-            if (game.discGroup) {
+            let missingDiscIndices: Array<number> | undefined;
+            if (game.m3uPath) {
+              // .m3u knows about all discs, even ones not in the library
+              const m3uPaths = await this.libraryService.parseM3uPlaylist(game.m3uPath);
+              if (m3uPaths.length > 1) {
+                discPaths = m3uPaths;
+                // Find which disc the user launched
+                const launchedIdx = m3uPaths.indexOf(game.romPath);
+                initialDiscIndex = launchedIdx >= 0 ? launchedIdx : 0;
+                // Check which disc files are missing from disk
+                const missing: Array<number> = [];
+                for (let i = 0; i < m3uPaths.length; i++) {
+                  if (!fs.existsSync(m3uPaths[i])) {
+                    missing.push(i);
+                  }
+                }
+                if (missing.length > 0) {
+                  missingDiscIndices = missing;
+                }
+              }
+            } else if (game.discGroup) {
               const allGames = this.libraryService.getGames(systemId);
               const groupGames = allGames
                 .filter((g) => g.discGroup === game.discGroup)
                 .sort((a, b) => (a.discNumber ?? 0) - (b.discNumber ?? 0));
-              if (groupGames.length > 1) {
-                discPaths = groupGames.map((g) => g.romPath);
-                const launchedIndex = groupGames.findIndex((g) => g.id === game.id);
-                initialDiscIndex = launchedIndex >= 0 ? launchedIndex : 0;
+
+              // If we have a discTotal but fewer library entries, create
+              // placeholder slots for missing discs so the UI can show browse
+              const knownTotal = game.discTotal ?? groupGames.length;
+              if (knownTotal > 1) {
+                discPaths = new Array<string>(knownTotal).fill("");
+                const missing: Array<number> = [];
+                for (const g of groupGames) {
+                  const idx = (g.discNumber ?? 1) - 1;
+                  if (idx >= 0 && idx < knownTotal) {
+                    discPaths[idx] = g.romPath;
+                  }
+                }
+                for (let i = 0; i < knownTotal; i++) {
+                  if (!discPaths[i]) {
+                    missing.push(i);
+                  }
+                }
+                if (missing.length > 0) {
+                  missingDiscIndices = missing;
+                }
+                const launchedIdx = groupGames.findIndex((g) => g.id === game.id);
+                initialDiscIndex =
+                  launchedIdx >= 0 ? (groupGames[launchedIdx].discNumber ?? 1) - 1 : 0;
               }
             }
 
@@ -232,7 +274,13 @@ export class IPCHandlers {
               avInfo,
               shouldResume,
               cardScreenBounds,
-              discPaths ? { paths: discPaths, initialIndex: initialDiscIndex ?? 0 } : undefined,
+              discPaths
+                ? {
+                    paths: discPaths,
+                    initialIndex: initialDiscIndex ?? 0,
+                    missingIndices: missingDiscIndices,
+                  }
+                : undefined,
               saveStatesSupported,
             );
           } else {
@@ -331,6 +379,42 @@ export class IPCHandlers {
         return { success: true };
       } catch (error) {
         ipcLog.error("Failed to swap disc:", error);
+        return { success: false, error: errorMessage(error) };
+      }
+    });
+
+    ipcMain.handle("emulation:getDiscInfo", async () => {
+      try {
+        const info = await this.emulatorManager.getDiscInfo();
+        return { success: true, ...info };
+      } catch (error) {
+        ipcLog.error("Failed to get disc info:", error);
+        return { success: false, error: errorMessage(error) };
+      }
+    });
+
+    ipcMain.handle("emulation:browseForDisc", async (_event, index: number) => {
+      try {
+        const result = await dialog.showOpenDialog({
+          title: `Select Disc ${index + 1}`,
+          filters: [
+            {
+              name: "Disc Images",
+              extensions: ["bin", "cue", "iso", "img", "chd", "pbp", "mdf", "ccd"],
+            },
+          ],
+          properties: ["openFile"],
+        });
+
+        if (result.canceled || result.filePaths.length === 0) {
+          return { success: false, canceled: true };
+        }
+
+        const filePath = result.filePaths[0];
+        await this.emulatorManager.replaceDiscImage(index, filePath);
+        return { success: true, path: filePath };
+      } catch (error) {
+        ipcLog.error("Failed to browse for disc:", error);
         return { success: false, error: errorMessage(error) };
       }
     });

--- a/apps/desktop/src/main/workers/core-worker-protocol.ts
+++ b/apps/desktop/src/main/workers/core-worker-protocol.ts
@@ -49,6 +49,8 @@ export interface NativeLibretroCore {
   getCurrentDiscIndex(): number;
   getDiscCount(): number;
   getDiscLabel(index?: number): string | null;
+  replaceDiscImage(index: number, path: string): boolean;
+  addDiscImage(path: string): number;
 }
 
 export interface NativeAddon {
@@ -136,6 +138,9 @@ export type WorkerCommand =
       requestId: string;
     }
   | { action: "swapDisc"; index: number; requestId: string }
+  | { action: "getDiscInfo"; requestId: string }
+  | { action: "replaceDiscImage"; index: number; path: string; requestId: string }
+  | { action: "addDiscImage"; path: string; requestId: string }
   | { action: "listSaveStates"; requestId: string };
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/workers/core-worker.ts
+++ b/apps/desktop/src/main/workers/core-worker.ts
@@ -834,6 +834,79 @@ function handleMessage(command: WorkerCommand): void {
       }
       break;
 
+    case "getDiscInfo":
+      try {
+        if (!native) {
+          throw new Error("No core loaded");
+        }
+        const discCount = native.getDiscCount();
+        const discIndex = native.getCurrentDiscIndex();
+        const labels: Array<string | null> = [];
+        for (let i = 0; i < discCount; i++) {
+          labels.push(native.getDiscLabel(i));
+        }
+        sendResponse(command.requestId, true, undefined, {
+          total: discCount,
+          currentIndex: discIndex,
+          labels,
+        });
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
+    case "replaceDiscImage":
+      try {
+        if (!native) {
+          throw new Error("No core loaded");
+        }
+        const replaceOk = native.replaceDiscImage(command.index, command.path);
+        if (!replaceOk) {
+          throw new Error(`Failed to replace disc image at index ${command.index}`);
+        }
+        sendResponse(command.requestId, true);
+        send({
+          type: "discChanged",
+          index: native.getCurrentDiscIndex(),
+          total: native.getDiscCount(),
+        });
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
+    case "addDiscImage":
+      try {
+        if (!native) {
+          throw new Error("No core loaded");
+        }
+        const newIndex = native.addDiscImage(command.path);
+        if (newIndex < 0) {
+          throw new Error("Failed to add disc image");
+        }
+        sendResponse(command.requestId, true, undefined, { index: newIndex });
+        send({
+          type: "discChanged",
+          index: native.getCurrentDiscIndex(),
+          total: native.getDiscCount(),
+        });
+      } catch (error) {
+        sendResponse(
+          command.requestId,
+          false,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      break;
+
     case "listSaveStates":
       try {
         const states = listSaveStates();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -51,6 +51,21 @@ contextBridge.exposeInMainWorld("gamelord", {
     setFastForwardAudio: (enabled: boolean) =>
       ipcRenderer.invoke("emulation:setFastForwardAudio", enabled),
     swapDisc: (index: number) => ipcRenderer.invoke("emulation:swapDisc", index),
+    getDiscInfo: () =>
+      ipcRenderer.invoke("emulation:getDiscInfo") as Promise<{
+        success: boolean;
+        total?: number;
+        currentIndex?: number;
+        labels?: Array<string | null>;
+        error?: string;
+      }>,
+    browseForDisc: (index: number) =>
+      ipcRenderer.invoke("emulation:browseForDisc", index) as Promise<{
+        success: boolean;
+        canceled?: boolean;
+        path?: string;
+        error?: string;
+      }>,
   },
 
   // Save states

--- a/apps/desktop/src/renderer/components/GameWindow.tsx
+++ b/apps/desktop/src/renderer/components/GameWindow.tsx
@@ -160,8 +160,10 @@ export const GameWindow: React.FC = () => {
   // Multi-disc state
   const [discTotal, setDiscTotal] = useState(0);
   const [currentDiscIndex, setCurrentDiscIndex] = useState(0);
+  const [missingDiscIndices, setMissingDiscIndices] = useState<Set<number>>(new Set());
   const [showDiscSwapOverlay, setShowDiscSwapOverlay] = useState(false);
   const [swappingDiscIndex, setSwappingDiscIndex] = useState<number | undefined>(undefined);
+  const [browsingDiscIndex, setBrowsingDiscIndex] = useState<number | undefined>(undefined);
 
   // Animate out the controls hint, then remove it from the DOM
   const dismissControlsHint = useCallback(() => {
@@ -589,9 +591,16 @@ export const GameWindow: React.FC = () => {
     });
 
     api.on("game:disc-info", (raw: unknown) => {
-      const data = raw as { total: number; currentIndex: number };
+      const data = raw as {
+        total: number;
+        currentIndex: number;
+        missingIndices?: Array<number>;
+      };
       setDiscTotal(data.total);
       setCurrentDiscIndex(data.currentIndex);
+      if (data.missingIndices && data.missingIndices.length > 0) {
+        setMissingDiscIndices(new Set(data.missingIndices));
+      }
     });
 
     api.on("game:emulation-error", (raw: unknown) => {
@@ -1708,15 +1717,42 @@ export const GameWindow: React.FC = () => {
               setSwappingDiscIndex(undefined);
             });
           }}
+          onBrowse={(index) => {
+            setBrowsingDiscIndex(index);
+            api.emulation
+              .browseForDisc(index)
+              .then((result) => {
+                if (result.success) {
+                  // Disc file was found and replaced — mark it as available
+                  setMissingDiscIndices((prev) => {
+                    const next = new Set(prev);
+                    next.delete(index);
+                    return next;
+                  });
+                }
+              })
+              .catch((error) => {
+                console.error("Browse for disc failed:", error);
+              })
+              .finally(() => {
+                setBrowsingDiscIndex(undefined);
+              });
+          }}
           discs={Array.from(
             { length: discTotal },
             (_, i): DiscInfo => ({
               index: i,
               label: `Disc ${i + 1}`,
-              status: i === currentDiscIndex ? "current" : "available",
+              status:
+                i === currentDiscIndex
+                  ? "current"
+                  : missingDiscIndices.has(i)
+                    ? "missing"
+                    : "available",
             }),
           )}
           swappingIndex={swappingDiscIndex}
+          browsingIndex={browsingDiscIndex}
         />
       )}
 

--- a/apps/desktop/src/renderer/types/global.d.ts
+++ b/apps/desktop/src/renderer/types/global.d.ts
@@ -52,6 +52,19 @@ export interface GamelordAPI {
     setSpeed: (multiplier: number) => Promise<{ success: boolean; error?: string }>;
     setFastForwardAudio: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
     swapDisc: (index: number) => Promise<{ success: boolean; error?: string }>;
+    getDiscInfo: () => Promise<{
+      success: boolean;
+      total?: number;
+      currentIndex?: number;
+      labels?: Array<string | null>;
+      error?: string;
+    }>;
+    browseForDisc: (index: number) => Promise<{
+      success: boolean;
+      canceled?: boolean;
+      path?: string;
+      error?: string;
+    }>;
   };
   saveState: {
     save: (slot: number) => Promise<{ success: boolean; error?: string }>;

--- a/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.stories.tsx
+++ b/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.stories.tsx
@@ -50,10 +50,27 @@ type Story = StoryObj<typeof DiscSwapOverlay>;
 /** 3-disc game, currently on Disc 1. */
 export const ThreeDiscGame: Story = {};
 
-/** Incomplete set — Disc 2 is missing from the library. */
-export const MissingDisc: Story = {
+/** Incomplete set — Disc 2 is missing, no browse handler (legacy). */
+export const MissingDiscNoBrowse: Story = {
   args: {
     discs: INCOMPLETE_SET,
+  },
+};
+
+/** Incomplete set — Disc 2 is missing, browse available. */
+export const MissingDiscWithBrowse: Story = {
+  args: {
+    discs: INCOMPLETE_SET,
+    onBrowse: fn(),
+  },
+};
+
+/** Browse in progress — loading indicator on the missing disc. */
+export const BrowseInProgress: Story = {
+  args: {
+    discs: INCOMPLETE_SET,
+    onBrowse: fn(),
+    browsingIndex: 1,
   },
 };
 

--- a/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.tsx
+++ b/packages/ui/components/DiscSwapOverlay/DiscSwapOverlay.tsx
@@ -14,9 +14,13 @@ export interface DiscSwapOverlayProps {
   open: boolean;
   onClose: () => void;
   onSwap: (index: number) => void;
+  /** Called when the user clicks "Browse..." on a missing disc. */
+  onBrowse?: (index: number) => void;
   discs: ReadonlyArray<DiscInfo>;
   /** Index of the disc currently being swapped to (shows loading state). */
   swappingIndex?: number;
+  /** Index of a disc currently being browsed for (shows loading state). */
+  browsingIndex?: number;
 }
 
 /**
@@ -30,8 +34,10 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
   open,
   onClose,
   onSwap,
+  onBrowse,
   discs,
   swappingIndex,
+  browsingIndex,
 }) => {
   // Delayed unmount: keep the DOM alive while exit animations play.
   const [mounted, setMounted] = useState(open);
@@ -81,7 +87,7 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
   }
 
   const closing = !open && mounted;
-  const isSwapping = swappingIndex !== undefined;
+  const isBusy = swappingIndex !== undefined || browsingIndex !== undefined;
 
   return (
     <div
@@ -93,7 +99,7 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
       <div
         className="absolute inset-0 bg-black/60"
         data-testid="disc-swap-overlay-backdrop"
-        onClick={closing || isSwapping ? undefined : onClose}
+        onClick={closing || isBusy ? undefined : onClose}
       />
 
       {/* Panel */}
@@ -113,20 +119,28 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
             const isCurrent = disc.status === "current";
             const isMissing = disc.status === "missing";
             const isThisSwapping = swappingIndex === disc.index;
-            const canClick = !isCurrent && !isMissing && !isSwapping;
+            const isThisBrowsing = browsingIndex === disc.index;
+            const canSwap = !isCurrent && !isMissing && !isBusy;
+            const canBrowse = isMissing && !isBusy && onBrowse !== undefined;
 
             return (
               <button
                 key={disc.index}
-                disabled={!canClick}
-                onClick={() => canClick && onSwap(disc.index)}
+                disabled={!canSwap && !canBrowse}
+                onClick={() => {
+                  if (canSwap) {
+                    onSwap(disc.index);
+                  } else if (canBrowse) {
+                    onBrowse(disc.index);
+                  }
+                }}
                 className={`
                   relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-left
                   transition-all duration-150
                   ${isCurrent ? "bg-white/10 border border-white/20" : "border border-transparent"}
-                  ${canClick ? "hover:bg-white/8 hover:border-white/15 cursor-pointer" : ""}
-                  ${isMissing ? "opacity-40 cursor-not-allowed" : ""}
-                  ${isThisSwapping ? "bg-white/5 border-white/15" : ""}
+                  ${canSwap || canBrowse ? "hover:bg-white/8 hover:border-white/15 cursor-pointer" : ""}
+                  ${isMissing && !canBrowse ? "opacity-40 cursor-not-allowed" : ""}
+                  ${isThisSwapping || isThisBrowsing ? "bg-white/5 border-white/15" : ""}
                 `}
                 data-testid={`disc-${disc.index}`}
               >
@@ -136,13 +150,17 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
                     flex items-center justify-center size-8 rounded-full text-xs font-bold
                     transition-colors duration-150
                     ${isCurrent ? "bg-white/20 text-white" : "bg-white/5 text-white/50"}
-                    ${isThisSwapping ? "bg-white/15 text-white/80" : ""}
+                    ${isThisSwapping || isThisBrowsing ? "bg-white/15 text-white/80" : ""}
                   `}
                 >
-                  {isThisSwapping ? <LoadingSpinner className="size-4" /> : disc.index + 1}
+                  {isThisSwapping || isThisBrowsing ? (
+                    <LoadingSpinner className="size-4" />
+                  ) : (
+                    disc.index + 1
+                  )}
                 </div>
 
-                {/* Label */}
+                {/* Label + status */}
                 <div className="flex-1 min-w-0">
                   <span
                     className={`text-sm ${isCurrent ? "text-white font-medium" : "text-white/70"}`}
@@ -154,9 +172,9 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
                       Current
                     </span>
                   )}
-                  {isMissing && (
+                  {isMissing && !isThisBrowsing && (
                     <span className="ml-2 text-[10px] uppercase tracking-wider text-red-400/60 font-medium">
-                      Missing
+                      {canBrowse ? "Browse\u2026" : "Missing"}
                     </span>
                   )}
                   {isThisSwapping && (
@@ -164,7 +182,17 @@ export const DiscSwapOverlay: React.FC<DiscSwapOverlayProps> = ({
                       Swapping...
                     </span>
                   )}
+                  {isThisBrowsing && (
+                    <span className="ml-2 text-[10px] uppercase tracking-wider text-white/40 font-medium">
+                      Locating...
+                    </span>
+                  )}
                 </div>
+
+                {/* Browse icon for missing discs */}
+                {isMissing && canBrowse && !isThisBrowsing && (
+                  <FolderIcon className="size-4 text-white/30" />
+                )}
               </button>
             );
           })}
@@ -195,6 +223,23 @@ function DiscIcon({ className }: { className?: string }) {
     >
       <circle cx="12" cy="12" r="10" />
       <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+/** Minimal folder icon for the browse action. */
+function FolderIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
     </svg>
   );
 }


### PR DESCRIPTION
## Related Issue

Closes #310

## Summary

- Adds runtime disc count querying from the native addon so the UI accurately reflects all discs in a multi-disc game, even when only some are present in the library
- Missing discs now show a "Browse..." action in the disc swap overlay, opening a native file picker to locate the disc file on disk
- Full-stack implementation: native addon → worker protocol → IPC → renderer

## Screenshots

| All discs present | Missing disc (browse) | Browse in progress |
|---|---|---|
| ![Normal](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260415-005108-disc-swap-normal.jpg) | ![Browse](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260415-005057-disc-swap-browse.jpg) | ![Locating](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260415-005105-disc-swap-locating.jpg) |

## Changes

**Native addon** (`libretro_core.cc/.h`):
- `replaceDiscImage(index, path)` — update a disc slot's file path and notify the core
- `addDiscImage(path)` — add a new disc slot via the core's `add_image_index` callback

**Worker protocol** (`core-worker-protocol.ts`):
- New commands: `getDiscInfo`, `replaceDiscImage`, `addDiscImage`

**Main process** (`handlers.ts`, `EmulatorManager.ts`, `EmulationWorkerClient.ts`):
- `emulation:getDiscInfo` IPC — query runtime disc count, labels, current index
- `emulation:browseForDisc` IPC — opens native file picker, replaces disc image on selection
- Launch handler builds disc paths from `.m3u` (all entries, including missing files) or `discTotal` metadata

**Renderer** (`GameWindow.tsx`, `DiscSwapOverlay.tsx`):
- Tracks `missingDiscIndices` from `game:disc-info` event
- Missing discs show "Browse..." with a folder icon; clicking opens the file picker
- After a successful browse, the disc becomes available for swapping
- New `onBrowse` / `browsingIndex` props on `DiscSwapOverlay`

**Storybook**:
- `MissingDiscWithBrowse` and `BrowseInProgress` stories

## Test Plan

- [x] All 747 existing tests pass
- [x] Lint, typecheck, format clean
- [ ] Manual test: launch a single disc from a 4-disc `.m3u` — verify swap overlay shows all 4 discs with 3 marked "Browse..."
- [ ] Manual test: click "Browse..." on a missing disc — verify file picker opens, selecting a disc file makes it available
- [ ] Manual test: swap to a previously-missing disc after browsing — verify emulation continues on the new disc

🤖 Generated with [Claude Code](https://claude.com/claude-code)