### PR TITLE
fix: point Electron main entry to .mjs after vite/electron-vite bump

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "GameLord desktop application",
-  "main": "./out/main/index.js",
+  "main": "./out/main/index.mjs",
   "scripts": {
     "build:native": "cd native && node-gyp rebuild",
     "clean": "node -e \"const fs=require('fs');['out','dist'].forEach(d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}})\"",


### PR DESCRIPTION
Fixes #391.

## Summary

- Nightly workflow has been broken since 2026-04-20 (23 consecutive failures). Both macOS and Windows package jobs fail in `electron-builder` with `Application entry file "out/main/index.js" … is corrupted: "out/main/index.js" was not found in this archive`.
- Root cause: electron-vite 5 + Vite 8 (landed in the 2026-04-20 dependency train) emit the main process bundle as `out/main/index.mjs`, but `apps/desktop/package.json` still pointed `"main"` at the old `.js` path.
- Update `"main"` to `./out/main/index.mjs`. Electron 41 supports ESM main entries natively.

## Test plan

- [x] Reproduced the failure locally with `pnpm install && cd apps/desktop && npx electron-vite build && npx electron-builder --linux` — got the exact same `out/main/index.js was not found in this archive` error.
- [x] After the fix, `electron-builder --linux` and `--win` both proceed past the asar `checkFileInArchive` step (the macOS step can't be exercised on Linux; will be validated by the nightly workflow itself).
- [x] Trigger the nightly via `workflow_dispatch` with `skip_no_changes_check=true` against this branch to confirm the full pipeline (mac sign+notarize, win nsis) goes green before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBMXQ7nRNdntDVB1j9o5X9)_