### PR TITLE
fix(tsconfig): modernize moduleResolution to bundler

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "allowJs": true,
@@ -10,7 +10,7 @@
     "noImplicitAny": true,
     "sourceMap": true,
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "strict": true
   },

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Replace deprecated \`moduleResolution: "node"\` (alias for \`node10\`) with \`bundler\` in both tsconfigs
- Update \`apps/desktop\` from \`module: commonjs\` to \`module: ESNext\` to satisfy the bundler-resolution constraint (typecheck-only — runtime build is unchanged since electron-vite controls actual module output)

Unblocks #356 (the \`@typescript/native-preview\` bump), which fails on the deprecated value.

Closes #402

## Test plan

- [x] \`pnpm typecheck\` passes locally
- [x] \`pnpm lint\` passes locally
- [ ] CI passes
- [ ] After merge, rebase #356 and confirm it now typechecks against the new \`@typescript/native-preview\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)