### PR TITLE
chore: configure Matt Pocock engineering skills for this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,22 @@ Never give advice about what to work on next, or start new work, from a stale br
 - `ARCHITECTURE.md` — How the app works, key files, supported cores.
 - **GitHub Issues** — Source of truth for project state. Use parent issues with sub-issues for multi-part work. Close issues via PRs (`Closes #123`). Create new issues when discovering work.
 
+## Agent skills
+
+This repo uses the engineering skills from [mattpocock/skills](https://github.com/mattpocock/skills) (installed under `.claude/skills/`). The skills read the docs below to know how this repo operates.
+
+### Issue tracker
+
+GitHub Issues at [ryanmagoon/gamelord](https://github.com/ryanmagoon/gamelord). See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Canonical 5-state vocabulary, names match the defaults. See [docs/agents/triage-labels.md](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context. `CONTEXT.md` + `docs/adr/` live at the repo root if/when they're created (lazily by `/grill-with-docs`). See [docs/agents/domain.md](docs/agents/domain.md).
+
 ## Package Manager
 
 This project uses **pnpm**. Always use `pnpm` for installing dependencies, running scripts, etc. — never `npm` or `yarn`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+- **`ARCHITECTURE.md`** at the repo root — system architecture overview (acts as a stand-in for `CONTEXT.md` until a dedicated glossary file is created by `/grill-with-docs`).
+
+If `CONTEXT.md` or `docs/adr/` don't exist yet, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md            ← created lazily by /grill-with-docs
+├── ARCHITECTURE.md       ← existing system overview
+├── docs/adr/             ← created lazily; ADR-NNNN-slug.md
+└── apps/, packages/, scripts/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues at [ryanmagoon/gamelord](https://github.com/ryanmagoon/gamelord). Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Repo-specific rules (see CLAUDE.md for the source of truth)
+
+- **Every PR references an issue** — PR body must include `Closes #<n>` or `Fixes #<n>`. If no issue exists for non-trivial work, create one first. See `## Pull Requests` in CLAUDE.md.
+- **Branch naming**: `<type>/<short-descriptive-name>` where type is one of `feat | fix | refactor | docs | test | chore`. See `## Git Conventions` in CLAUDE.md.
+- **Never push to `main`** — branch protection enforces this. Always open a PR.
+- **Sub-issues for multi-part work**: parent tracking issue + linked sub-issues via the GraphQL `addSubIssue` mutation. See `.claude/rules/github-issues.md`.
+- **Good-first-issue labeling**: check new issues against `.claude/rules/good-first-issues.md` and apply the label at creation time when it qualifies.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+The 2 category labels (`bug`, `enhancement`) match GitHub's defaults and need no remapping.


### PR DESCRIPTION
## Summary

Follow-up to #401, which installed the engineering skills. This wires them up to this repo by adding:

- **`## Agent skills` block in `CLAUDE.md`** — declares this repo's issue tracker, triage label vocabulary, and domain doc layout. Inserted between `## Key Documentation` and `## Package Manager` to keep doc/process sections grouped.
- **`docs/agents/issue-tracker.md`** — GitHub conventions for the skills, plus a cross-reference section so skills inherit this repo's existing rules (every PR needs an issue, branch naming, no push to main, sub-issue GraphQL mutation, good-first-issue labeling).
- **`docs/agents/triage-labels.md`** — Canonical 5-role label table. Defaults across the board — no remapping needed.
- **`docs/agents/domain.md`** — Single-context layout. Notes that `ARCHITECTURE.md` acts as a stand-in for `CONTEXT.md` until `/grill-with-docs` creates one.

Also created 4 new triage labels on the repo via `gh label create` (live now):
- `needs-triage` (yellow)
- `needs-info` (lavender)
- `ready-for-agent` (green)
- `ready-for-human` (blue)

`wontfix`, `bug`, `enhancement` already existed and match the canonical names — no changes there.

## Decisions made

| Section | Choice | Reasoning |
|---|---|---|
| Issue tracker | GitHub | Already in use; remote points here; we just opened #400/#401/#404 |
| Triage labels | Defaults | No existing competing scheme; descriptive; 4 new labels created |
| Domain layout | Single-context | Monorepo is structural (`apps/desktop` + `packages/ui` + `scripts/`) but shares one domain vocabulary. Multi-context would be premature. |

## Out of scope (created lazily, not now)

- `CONTEXT.md` and `docs/adr/` are referenced in the new docs but **not created here** — per the skill author's intent, those appear lazily when `/grill-with-docs` resolves terms or decisions. Creating them upfront would defeat that pattern.

Closes #404

## Test plan

- [x] CLAUDE.md renders correctly (new block fits between Key Documentation and Package Manager)
- [x] All 4 new labels exist on the GitHub repo (verified via `gh label list`)
- [x] `docs/agents/` files reference real existing things (CLAUDE.md sections, `.claude/rules/` files, `ARCHITECTURE.md`)
- [ ] After merge: invoke `/triage` or `/to-issues` on a fresh issue and confirm the skill picks up the config without re-asking for setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)