### PR TITLE
fix: complete ESM main/preload migration so the app launches

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -90,7 +90,23 @@ export default defineConfig({
             "src/main/workers/json-stringify-worker.ts",
           ),
         },
-        external: [/\.node$/],
+        // `electron` must stay external — it's provided by the runtime. Bundling
+        // its npm shim breaks `getElectronPath()` (it reads `path.txt` relative
+        // to its own dir). electron-vite's externalize plugin doesn't reliably
+        // catch it under rolldown-vite, so list it explicitly.
+        external: ["electron", /^electron\/.+/, /\.node$/],
+        output: {
+          format: "es",
+          // electron-vite 5 + Vite 8 emit the main process as ESM (`.mjs`),
+          // where `__dirname`/`__filename` don't exist. The main source and
+          // bundled CJS deps (e.g. electron's index.js shim) rely on them, so
+          // recreate them per-file from `import.meta.url`.
+          banner:
+            "import { fileURLToPath as __gl_fileURLToPath } from 'node:url';\n" +
+            "import { dirname as __gl_dirname } from 'node:path';\n" +
+            "const __filename = __gl_fileURLToPath(import.meta.url);\n" +
+            "const __dirname = __gl_dirname(__filename);",
+        },
       },
     },
     define: {
@@ -108,6 +124,17 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve(__dirname, "src/preload.ts"),
+        },
+        // Keep `electron` external here too — bundling its shim makes the
+        // sandboxed preload throw on load, so `contextBridge` never runs and
+        // the renderer never receives `window.gamelord`.
+        external: ["electron", /^electron\/.+/, /\.node$/],
+        output: {
+          // Sandboxed preload scripts must be CommonJS — Electron does not
+          // support ESM preloads when `sandbox: true`. Force `.cjs` output so
+          // the preload loads and `contextBridge` exposes the renderer API.
+          format: "cjs",
+          entryFileNames: "[name].cjs",
         },
       },
     },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -68,7 +68,7 @@ const createWindow = () => {
           },
         }),
     webPreferences: {
-      preload: path.join(__dirname, "../preload/index.js"),
+      preload: path.join(__dirname, "../preload/index.cjs"),
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
@@ -189,7 +189,7 @@ app.on("ready", () => {
   });
 
   // Initialize IPC handlers before creating window
-  const preloadPath = path.join(__dirname, "../preload/index.js");
+  const preloadPath = path.join(__dirname, "../preload/index.cjs");
   ipcHandlers = new IPCHandlers(preloadPath);
   setupAppMenu();
   createWindow();

--- a/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
+++ b/apps/desktop/src/main/emulator/EmulationWorkerClient.ts
@@ -84,7 +84,7 @@ export class EmulationWorkerClient extends EventEmitter {
       await this.destroy();
     }
 
-    const workerPath = path.join(__dirname, "workers/core-worker.js");
+    const workerPath = path.join(__dirname, "workers/core-worker.mjs");
 
     this.workerProcess = utilityProcess.fork(workerPath, [], {
       serviceName: "LibretroCore",

--- a/apps/desktop/src/main/services/CheatDatabaseService.test.ts
+++ b/apps/desktop/src/main/services/CheatDatabaseService.test.ts
@@ -1,4 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+// CheatDatabaseService imports `app` from "electron" at module load. Mock it
+// so importing the module (even for its pure parsing helpers) doesn't trigger
+// electron's getElectronPath(), which throws when the binary isn't installed
+// (CI). A file-level mock is required — module mocks declared in setupFiles
+// don't reliably intercept `electron` for this suite.
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp/gamelord-test"),
+  },
+}));
+
 import {
   parseChtFile,
   matchChtFilename,

--- a/apps/desktop/src/main/services/LibraryService.ts
+++ b/apps/desktop/src/main/services/LibraryService.ts
@@ -264,7 +264,7 @@ export class LibraryService extends EventEmitter {
    */
   private stringifyInWorker(data: unknown): Promise<string> {
     return new Promise((resolve, reject) => {
-      const workerPath = path.join(__dirname, "workers/json-stringify-worker.js");
+      const workerPath = path.join(__dirname, "workers/json-stringify-worker.mjs");
       let worker: Worker;
       try {
         worker = new Worker(workerPath);

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -2,10 +2,12 @@
  * Global vitest setup — provides auto-mocks for modules that depend on the
  * Electron runtime so tests don't need to individually mock them.
  *
- * @sentry/electron/main and @sentry/electron/renderer import `electron`
- * internally, which doesn't exist in the vitest environment. Providing
- * no-op mocks here prevents transitive import failures (e.g. when a test
- * imports logger.ts → @sentry/electron/main → electron).
+ * @sentry/electron/main, @sentry/electron/renderer, and electron-log/main all
+ * import `electron` internally. In CI the Electron binary isn't downloaded, so
+ * `electron`'s `getElectronPath()` throws "Electron failed to install
+ * correctly" the moment one of these is loaded. Providing no-op mocks here
+ * prevents transitive import failures (e.g. when a test imports logger.ts →
+ * electron-log/main → electron).
  */
 import { vi } from "vitest";
 
@@ -15,6 +17,28 @@ vi.mock("@sentry/electron/main", () => ({
   captureException: vi.fn(),
   captureMessage: vi.fn(),
 }));
+
+vi.mock("electron-log/main", () => {
+  const scoped = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    verbose: vi.fn(),
+    debug: vi.fn(),
+    silly: vi.fn(),
+  };
+  const mockLog = {
+    ...scoped,
+    transports: {
+      file: { maxSize: 0, format: "" },
+      console: { format: "" },
+    },
+    hooks: [] as Array<unknown>,
+    // Scoped loggers delegate to the same no-op methods.
+    scope: vi.fn(() => scoped),
+  };
+  return { default: mockLog };
+});
 
 vi.mock("@sentry/electron/renderer", () => ({
   init: vi.fn(),


### PR DESCRIPTION
## Problem

The app failed to launch after the vite 8 / electron-vite 5 bump:

```
App threw an error during load
ReferenceError: __dirname is not defined in ES module scope
    at out/main/index.mjs:34:30
```

[#392](https://github.com/ryanmagoon/gamelord/pull/392) moved the `main` package.json entry to `.mjs` (ESM) but left several runtime bugs that the build doesn't catch — only launching the app surfaces them.

## Root causes (all from the incomplete ESM migration)

1. **`__dirname`/`__filename` undefined in ESM scope.** The main source and the bundled `electron` CJS shim both rely on them.
2. **`electron` npm package bundled instead of externalized** (main *and* preload). Its inlined shim calls `getElectronPath()`, which reads `path.txt` relative to the wrong dir → `Electron failed to install correctly`. In the **sandboxed preload** that throw aborts `contextBridge.exposeInMainWorld`, so the renderer never gets `window.gamelord` → `Cannot read properties of undefined (reading 'platform')` (ErrorBoundary). electron-vite's externalize plugin doesn't catch `electron` under rolldown-vite, so it's listed explicitly.
3. **Worker paths referenced `.js`** (`workers/core-worker.js`, `workers/json-stringify-worker.js`) but output is now `.mjs`.
4. **Preload referenced `../preload/index.js`** but output was `.mjs`; sandboxed preloads must be CommonJS, so it's forced to `.cjs` and the references updated.

## Fix

- Add a `__dirname`/`__filename` banner (from `import.meta.url`) to the main ESM build.
- Explicitly externalize `electron` in both the main and preload `rollupOptions`.
- Force preload output to CommonJS (`.cjs`); update preload path references in `main.ts`.
- Update worker path references to `.mjs`.

## Verification

App launches, `window.gamelord.platform === "darwin"`, no ErrorBoundary, library renders with full box art. `lint`, `typecheck`, `format` all pass.

![GameLord library rendering after fix](https://1o0zutvyhu7g3x5f.public.blob.vercel-storage.com/screenshots/20260621-175027-gamelord-final.png)

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: test fixes (CI)

CI surfaced a latent issue (present on `main` too, just not re-run since the Electron 41 bump): some test suites import modules that transitively load the real `electron` package, whose `getElectronPath()` throws `Electron failed to install correctly` when the binary isn't downloaded (CI runners).

- Mock `electron-log/main` globally in `test-setup.ts` (fixes EmulatorManager, ArtworkService, windowState).
- Add a file-level `vi.mock("electron")` to `CheatDatabaseService.test.ts` (it imports `app` directly; setupFiles mocks don't intercept it).

Verified by simulating the missing-binary condition locally (moving `electron/path.txt` + `dist` aside) — all four suites pass. Confirmed green in CI.
