### PR TITLE
docs: clarify UI evidence workflow

### DIFF
--- a/.claude/rules/agent-browser.md
+++ b/.claude/rules/agent-browser.md
@@ -20,6 +20,16 @@ agent-browser screenshot /tmp/x.png # capture state
 
 Always re-snapshot after interactions — element refs change when the DOM updates.
 
+For motion or interaction that a still image cannot show clearly, record a short walkthrough:
+
+```bash
+agent-browser record start /tmp/feature-walkthrough.webm
+# Perform the changed interaction
+agent-browser record stop
+```
+
+Generated screenshots and recordings are verification evidence, not repository source files. Keep them outside the worktree (for example, under `/tmp`), upload them externally, and embed their URLs in the PR's `Screenshots / Video` section. Never commit generated media to the branch.
+
 ## Port Conflict
 
 If port 9222 is in use (e.g. another app instance or Chrome debugging), set `CDP_PORT` to use a different port:

--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -31,7 +31,11 @@ When in doubt, Storybook screenshots are the baseline — they're fast to captur
 
 Only ask the user for media when the state can't be reproduced in a preview server (e.g., requires real hardware, real network conditions, or the full Electron runtime with IPC).
 
+For Electron UI changes, use `agent-browser` against the running app as documented in `agent-browser.md`. Capture screenshots for meaningful visual states. Record a short video when motion, animation, or interaction cannot be shown clearly with still images.
+
 After capturing screenshots, upload them to Vercel Blob using `scripts/upload-screenshot.sh` and embed the returned URL in the PR body. The script requires `BLOB_READ_WRITE_TOKEN` — source it from `apps/desktop/.env` before calling. See `screenshot-hosting.md` for the full workflow (includes both Storybook and app capture methods).
+
+Generated screenshots and videos belong in the PR body, not the Git diff. Save them outside the repository (for example, under `/tmp`), upload them externally, and embed the resulting URLs under `Screenshots / Video`. Never commit generated verification media to the branch.
 
 If the user provides media, embed it in the PR body using GitHub markdown (`![description](url)` or a `<video>` tag). If screenshots can't be captured or provided, note in the PR body that a visual is pending.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Closes #
 <!-- Required for UI changes, new features, and visual bug fixes. -->
 <!-- Skip for purely internal changes (refactors, deps, CI, docs). -->
 <!-- Capture from Storybook or the running app — see .claude/rules/pull-requests.md -->
+<!-- Upload generated media externally and embed it here. Do not commit screenshots or videos to the repository. -->
 
 ## Test Plan
 


### PR DESCRIPTION
## Related Issue

Closes #437

Related to #362

Supersedes fork PR #438. This replacement uses an upstream-owned branch so repository CI credentials are available.

## Summary

- document an exact `agent-browser` WebM recording workflow for interaction evidence
- require generated screenshots and videos to stay outside the worktree and be embedded in the PR body
- reinforce the same rule in the pull request template

## Screenshots / Video

Not applicable. This is a documentation-only change with no UI-visible behavior change.

## Test Plan

- `git diff --check`
- `agent-browser record --help`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (37 UI files / 418 tests and 32 desktop files / 750 tests)

Validation used Node 24.19.0 and the repository-pinned pnpm 10.15.0, matching the CI Node major and package-manager version.
