### PR TITLE
fix: load shared theme styles in Storybook

### DIFF
--- a/packages/ui/.storybook/preview.js
+++ b/packages/ui/.storybook/preview.js
@@ -3,7 +3,8 @@ import isChromatic from "chromatic/isChromatic";
 import { Agentation } from "agentation";
 import { tvStaticManager } from "../components/TVStaticManager";
 import "../index.css";
-// index.css imports tailwindcss and theme for Storybook
+import "../theme.css";
+// Load Tailwind/component styles first, then the shared app theme.
 
 // In Chromatic's capture environment, make canvas noise deterministic (seeded
 // PRNG, single frame) so screenshots are pixel-identical across runs.


### PR DESCRIPTION
## Related Issue

Closes #439

Related workflow guidance: #437 and #441

Supersedes fork PR #440. This replacement uses an upstream-owned branch so repository CI credentials are available.

## Summary

- Load the shared app theme in Storybook after Tailwind/component styles, matching the Electron renderer order.
- Fix Command Palette stories that rendered with block rows, zero padding, and no selected-state background.
- Validate the UI evidence workflow from #441 with externally hosted `agent-browser` screenshots and video, not generated files in the Git diff.

## Screenshots / Video

### Before

![Command Palette before the shared Storybook theme loads](https://mnbkyifklllrgowx.public.blob.vercel-storage.com/gamelord/issue-439/command-palette-before.png)

Rows render as unstyled blocks with `0px` padding and a transparent selected state.

### After

![Command Palette after the shared Storybook theme loads](https://mnbkyifklllrgowx.public.blob.vercel-storage.com/gamelord/issue-439/command-palette-after.png)

Rows render as padded flex containers and the selected result has the shared theme highlight.

### Interaction walkthrough

<video controls src="https://mnbkyifklllrgowx.public.blob.vercel-storage.com/gamelord/issue-439/command-palette-workflow.webm"></video>

[Watch the 5.5-second WebM directly](https://mnbkyifklllrgowx.public.blob.vercel-storage.com/gamelord/issue-439/command-palette-workflow.webm)

The recording opens the Command Palette, filters for `mario`, confirms the selected result, and closes it.

## Test Plan

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (37 UI files / 418 tests and 32 desktop files / 750 tests; package builds included)
- `agent-browser` before/after visual inspection and interaction recording in the existing Command Palette Storybook stories
- Computed-style proof: `display: block`, `padding: 0px`, transparent selection before; `display: flex`, `padding: 8px`, `rgb(241, 245, 249)` selection after
- Public artifact check: all three media URLs return HTTP 200 with the expected PNG/WebM content types
